### PR TITLE
lock dev dep versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,11 +143,11 @@ PLATFORMS
 DEPENDENCIES
   actionview-component!
   bundler (>= 1.14)
-  haml-rails
+  haml-rails (~> 2.0)
   minitest (~> 5.0)
   rails (~> 5.2.2.1.ca21bd1ba2)
   rake (~> 10.0)
-  slim
+  slim (~> 4.0)
 
 BUNDLED WITH
    2.0.2

--- a/actionview-component.gemspec
+++ b/actionview-component.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "haml-rails"
-  spec.add_development_dependency "slim"
+  spec.add_development_dependency "haml-rails", "~> 2.0"
+  spec.add_development_dependency "slim", "~> 4.0"
 end


### PR DESCRIPTION
Attempting to install this gem in `github/github` warned me that we should have some form of version locking here. So here it goes!