### PR TITLE
use render component: syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Components are now rendered with `render component: MyComponent, locals: { foo: :bar }`
+
+    *Joel Hawksley*
+
 *   Components now inherit from ActionView::Component::base
 
     *Joel Hawksley*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    actionview-component (1.0.1)
+    actionview-component (2.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ end
 We can render it in a view as:
 
 ```erb
-<%= render(TestComponent.new(title: "my title")) do %>
+<%= render(component: TestComponent, locals: { title: "my title" }) do %>
   Hello, World!
 <% end %>
 ```
@@ -140,7 +140,7 @@ Which returns:
 If the component is rendered with a blank title:
 
 ```erb
-<%= render(TestComponent.new(title: "")) do %>
+<%= render(component: TestComponent, locals: { title: "" }) do %>
   Hello, World!
 <% end %>
 ```
@@ -162,7 +162,7 @@ class MyComponentTest < Minitest::Test
   def test_render_component
     assert_equal(
       %(<span title="my title">Hello, World!</span>),
-      render_component(TestComponent.new(title: "my title")) { "Hello, World!" }.css("span").to_html
+      render_component(component: TestComponent, locals: { title: "my title" }) { "Hello, World!" }.css("span").to_html
     )
   end
 end

--- a/actionview-component.gemspec
+++ b/actionview-component.gemspec
@@ -6,7 +6,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "actionview-component"
-  spec.version       = "1.1.0"
+  spec.version       = "2.0.0"
   spec.authors       = ["GitHub Open Source"]
   spec.email         = ["opensource+actionview-component@github.com"]
 

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -2,18 +2,18 @@
 
 # Monkey patch ActionView::Base#render to support ActionView::Component
 #
-# Upstreamed in https://github.com/rails/rails/pull/36388
-# Necessary for Rails versions < 6.1.0.alpha
+# A previous version of this monkey patch was merged in https://github.com/rails/rails/pull/36388,
+# but we'll need to make further upstream changes to support the component: syntax
 class ActionView::Base
   module RenderMonkeyPatch
-    def render(component, _ = nil, &block)
-      return super unless component.respond_to?(:render_in)
+    def render(options = {}, &block)
+      return super unless options.has_key?(:component)
 
-      component.render_in(self, &block)
+      options[:component].new(options[:locals]).render_in(self, &block)
     end
   end
 
-  prepend RenderMonkeyPatch unless Rails::VERSION::MINOR > 0 && Rails::VERSION::MAJOR == 6
+  prepend RenderMonkeyPatch
 end
 
 module ActionView
@@ -42,7 +42,7 @@ module ActionView
       # <span title="<%= @title %>">Hello, <%= content %>!</span>
       #
       # In use:
-      # <%= render MyComponent.new(title: "greeting") do %>world<% end %>
+      # <%= render MyComponent, locals: { title: "greeting" } do %>world<% end %>
       # returns:
       # <span title="greeting">Hello, world!</span>
       #

--- a/lib/action_view/component/test_helpers.rb
+++ b/lib/action_view/component/test_helpers.rb
@@ -3,8 +3,8 @@
 module ActionView
   module Component
     module TestHelpers
-      def render_component(component, &block)
-        Nokogiri::HTML(component.render_in(ApplicationController.new.view_context, &block))
+      def render_component(options = {}, &block)
+        Nokogiri::HTML(options[:component].new(options[:locals]).render_in(ApplicationController.new.view_context, &block))
       end
     end
   end

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -6,14 +6,14 @@ class ActionView::ComponentTest < Minitest::Test
   include ActionView::Component::TestHelpers
 
   def test_render_component
-    result = render_component(MyComponent.new)
+    result = render_component(component: MyComponent)
 
     assert_equal trim_result(result.css("div").first.to_html), "<div>hello,world!</div>"
   end
 
   def test_raises_error_when_sidecar_template_is_missing
     exception = assert_raises NotImplementedError do
-      render_component(MissingTemplateComponent.new)
+      render_component(component: MissingTemplateComponent)
     end
 
     assert_includes exception.message, "Could not find a template file for MissingTemplateComponent"
@@ -21,7 +21,7 @@ class ActionView::ComponentTest < Minitest::Test
 
   def test_raises_error_when_more_then_one_sidecar_template_is_present
     error = assert_raises StandardError do
-      render_component(TooManySidecarFilesComponent.new)
+      render_component(component: TooManySidecarFilesComponent)
     end
 
     assert_includes error.message, "More than one template found for TooManySidecarFilesComponent."
@@ -29,7 +29,7 @@ class ActionView::ComponentTest < Minitest::Test
 
   def test_raises_error_when_initializer_is_not_defined
     exception = assert_raises NotImplementedError do
-      render_component(MissingInitializerComponent.new)
+      render_component(component: MissingInitializerComponent)
     end
 
     assert_includes exception.message, "must implement #initialize"
@@ -37,14 +37,14 @@ class ActionView::ComponentTest < Minitest::Test
 
   def test_checks_validations
     exception = assert_raises ActiveModel::ValidationError do
-      render_component(WrapperComponent.new)
+      render_component(component: WrapperComponent)
     end
 
     assert_includes exception.message, "Content can't be blank"
   end
 
   def test_renders_content_from_block
-    result = render_component(WrapperComponent.new) do
+    result = render_component(component: WrapperComponent) do
       "content"
     end
 
@@ -52,28 +52,28 @@ class ActionView::ComponentTest < Minitest::Test
   end
 
   def test_renders_slim_template
-    result = render_component(SlimComponent.new(message: "bar")) { "foo" }
+    result = render_component(component: SlimComponent, locals: { message: "bar" }) { "foo" }
 
     assert_includes result.text, "foo"
     assert_includes result.text, "bar"
   end
 
   def test_renders_haml_template
-    result = render_component(HamlComponent.new(message: "bar")) { "foo" }
+    result = render_component(component: HamlComponent, locals: { message: "bar" }) { "foo" }
 
     assert_includes result.text, "foo"
     assert_includes result.text, "bar"
   end
 
   def test_renders_erb_template
-    result = render_component(ErbComponent.new(message: "bar")) { "foo" }
+    result = render_component(component: ErbComponent, locals: { message: "bar" }) { "foo" }
 
     assert_includes result.text, "foo"
     assert_includes result.text, "bar"
   end
 
   def test_renders_route_helper
-    result = render_component(RouteComponent.new)
+    result = render_component(component: RouteComponent)
 
     assert_includes result.text, "/"
   end
@@ -81,25 +81,25 @@ class ActionView::ComponentTest < Minitest::Test
   def test_template_changes_are_not_reflected_in_production
     ActionView::Base.cache_template_loading = true
 
-    assert_equal "<div>hello,world!</div>", render_component(MyComponent.new).css("div").first.to_html
+    assert_equal "<div>hello,world!</div>", render_component(component: MyComponent).css("div").first.to_html
 
     modify_file "app/components/my_component.html.erb", "<div>Goodbye world!</div>" do
-      assert_equal  "<div>hello,world!</div>", render_component(MyComponent.new).css("div").first.to_html
+      assert_equal  "<div>hello,world!</div>", render_component(component: MyComponent).css("div").first.to_html
     end
 
-    assert_equal "<div>hello,world!</div>", render_component(MyComponent.new).css("div").first.to_html
+    assert_equal "<div>hello,world!</div>", render_component(component: MyComponent).css("div").first.to_html
   end
 
   def test_template_changes_are_reflected_outside_production
     ActionView::Base.cache_template_loading = false
 
-    assert_equal "<div>hello,world!</div>", render_component(MyComponent.new).css("div").first.to_html
+    assert_equal "<div>hello,world!</div>", render_component(component: MyComponent).css("div").first.to_html
 
     modify_file "app/components/my_component.html.erb", "<div>Goodbye world!</div>" do
-      assert_equal "<div>Goodbye world!</div>", render_component(MyComponent.new).css("div").first.to_html
+      assert_equal "<div>Goodbye world!</div>", render_component(component: MyComponent).css("div").first.to_html
     end
 
-    assert_equal "<div>hello,world!</div>", render_component(MyComponent.new).css("div").first.to_html
+    assert_equal "<div>hello,world!</div>", render_component(component: MyComponent).css("div").first.to_html
   end
 
   private

--- a/test/app/views/application/index.html.erb
+++ b/test/app/views/application/index.html.erb
@@ -1,1 +1,1 @@
-<span><%= render ErbComponent.new(message: "bar") do %>Foo<% end %></span>
+<span><%= render component: ErbComponent, locals: { message: "bar" } do %>Foo<% end %></span>


### PR DESCRIPTION
In https://github.com/github/actionview-component/issues/21,
@nogtini pointed out that our existing syntax of calling
`render(MyComponent.new)` was incompatible with the
`render(... collection: @products)` syntax Rails allows for partials.

In order to support this, and potentially other changes to align
with the existing Rails API, it is necessary to change our
syntax used to render components in views.

Now, components are rendered as:
`render(component: MyComponent, locals: { foo: :bar })`.

As this is a major breaking change, I feel this change should bump
us straight to v2.0.0.