### PR TITLE
Allow compiler buffer instance to be customized

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -224,6 +224,11 @@ module ViewComponent
         @_template_compiler ||= Compiler.new(self)
       end
 
+      # Returns a new instance of the string buffer used by the template compiler
+      def template_buffer_instance
+        ActionView::OutputBuffer.new
+      end
+
       # we'll eventually want to update this to support other types
       def type
         "text/html"

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -56,7 +56,7 @@ module ViewComponent
 
         component_class.class_eval <<-RUBY, template[:path], -1
           def #{method_name}
-            @output_buffer = ActionView::OutputBuffer.new
+            @output_buffer = self.class.template_buffer_instance
             #{compiled_template(template[:path])}
           end
         RUBY
@@ -160,7 +160,7 @@ module ViewComponent
 
       sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
 
-      (sidecar_files - [source_location] + sidecar_directory_files)
+      (sidecar_files - [source_location] + sidecar_directory_files).uniq
     end
 
     def inline_calls


### PR DESCRIPTION
I've been working on implementing support for ViewComponent outside of a full-blown Rails app, as well adding a template language similar to ERB but slightly different (a larger story for another time), and I ran into just a couple of slight issues related to each. This PR contains the following fixes:

* I wanted to be able to control the output buffer object and not have it hardcoded to `ActionView::OutputBuffer`. Now there's a component class method which will return a buffer instance.

* Because my template language ends in `.serb`, the matching views array ended up with duplicate file paths because `erb` matches `serb` and `serb` itself also matches `serb`. By calling `uniq` on the array when its returned, we ensure there's no possibility of duplicate file paths.

I don't think there needs to be a new test for the first change as if any existing tests pass at all, we know it works. :) I'd be happy to write a test for the second change but I'm not sure the best way to go about that.

Overall though, I'm quite impressed that ViewComponent is working well thus far only pulling in ActionView and not all of Rails. There might be a certain feature here or there I haven't tried out yet that is "broken", but if I do run into anything that seems like it could be mitigated fairly easily, I'll file another PR.