### PR TITLE
Contextual components

### DIFF
--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -213,6 +213,11 @@ module ViewComponent
       # `view_context.capture` twice, which is slower
       slot._content_block = block if block_given?
 
+      # Store args and kwargs for late re-instantiation
+      slot._args = args
+      slot._kwargs = kwargs
+      slot._renderable_function = slot_definition[:renderable_function]
+
       # If class
       if slot_definition[:renderable]
         slot._component_instance = slot_definition[:renderable].new(*args, **kwargs)

--- a/test/app/components/contextual_paginator_component.html.erb
+++ b/test/app/components/contextual_paginator_component.html.erb
@@ -1,0 +1,11 @@
+<ul role="pagination">
+  <% 1.upto(@max).each do |page_number| %>
+    <li data-page="<%= page_number %>">
+      <% if page_number == @current %>
+        <%= current_page.with(number: page_number) %>
+      <% else %>
+        <%= page.with(number: page_number) %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/test/app/components/contextual_paginator_component.rb
+++ b/test/app/components/contextual_paginator_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ContextualPaginatorComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+
+  renders_one :page, "PageComponent"
+  renders_one :current_page, "PageComponent"
+
+  def initialize(max:, current:)
+    @max = max
+    @current = current
+  end
+
+  class PageComponent < ViewComponent::Base
+    attr_reader :number
+
+    def initialize(number: nil)
+      @number = number
+    end
+
+    def call
+      content
+    end
+  end
+end

--- a/test/app/components/contextual_table_component.html.erb
+++ b/test/app/components/contextual_table_component.html.erb
@@ -1,0 +1,22 @@
+<table>
+  <thead>
+    <tr>
+      <% columns.each do |column| %>
+        <th data-field="<%= column.path.join(' ') %>">
+          <%= column.label %>
+        </th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% data.each do |item| %>
+      <tr data-id="<%= item[:id] %>">
+        <% columns.each do |column| %>
+          <td data-field="<%= column.path.join(' ') %>">
+            <%= column.with(item: item) %>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/test/app/components/contextual_table_component.rb
+++ b/test/app/components/contextual_table_component.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class ContextualTableComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+
+  renders_many :columns, ->(*path, **kwargs) { ColumnComponent.new(path: path, **kwargs) }
+
+  attr_reader :data
+
+  def initialize(data:)
+    @data = data
+  end
+
+  class ColumnComponent < ViewComponent::Base
+    attr_reader :label, :path, :item
+
+    def initialize(label: nil, path: nil, item: nil)
+      @label = label
+      @path = [*path]
+      @item = item
+    end
+
+    def value
+      item.dig(*path) if item && !path.empty?
+    end
+
+    def call
+      content || value
+    end
+  end
+end

--- a/test/view_component/contextual_test.rb
+++ b/test/view_component/contextual_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ContextualTest < ViewComponent::TestCase
+  def test_table_like_component
+    data = [
+      {id: 1, foo: "foo-1", bar: "bar-1"},
+      {id: 2, foo: "foo-2", bar: "bar-2"}
+    ]
+
+    render_inline(ContextualTableComponent.new(data: data)) do |component|
+      component.column :foo, label: "Foo"
+      component.column label: "Bar" do |col|
+        "item #{ col.item[:bar] }"
+      end
+      component.column :bar, label: "Bar directly" do |col|
+        "value #{ col.value }"
+      end
+    end
+
+    assert_selector 'thead th[data-field="foo"]', text: "Foo"
+
+    assert_selector 'tbody tr[data-id="1"] td[data-field="foo"]', text: "foo-1"
+    assert_selector 'tbody tr[data-id="1"] td[data-field=""]', text: "item bar-1"
+    assert_selector 'tbody tr[data-id="1"] td[data-field="bar"]', text: "value bar-1"
+    assert_selector 'tbody tr[data-id="2"] td[data-field="bar"]', text: "value bar-2"
+  end
+
+  def test_paginator_like_component
+    render_inline(ContextualPaginatorComponent.new(max: 10, current: 5)) do |component|
+      component.current_page do |page|
+        "current #{ page.number }"
+      end
+
+      component.page do |page|
+        "page #{ page.number }"
+      end
+    end
+
+    assert_selector %(ul li[data-page="1"]), text: "page 1"
+    assert_selector %(ul li[data-page="2"]), text: "page 2"
+    assert_selector %(ul li[data-page="5"]), text: "current 5"
+  end
+end


### PR DESCRIPTION
### Summary

Provide a way to inject slot arguments from the parent component. It is useful for components that accept a slot that acts as a "template" which should be applied to different data (paginators, tables, ...).

A method `with` is added to `SlotV2`, that returns a new slot instance with the arguments to `with` are merged with the original slot arguments.

### Example

```rb
class PaginationComponent < ViewComponent::Base
  include ViewComponent::SlotableV2

  renders_one :page, "PageComponent"
  renders_one :current_page, "PageComponent"

  def initialize(current:, max:)
    @current, @max = current, max
  end

  class PageComponent < ViewComponent::Base
    attr_reader :number

    def initalize(number: nil)
      @number = number
    end

    def call
      tag.li content, data: {page: number}
    end
  end
end
```

```erb
<!-- pagination_component.html.erb -->
<ul role="pagination">
  <% 1.upto(@max).each do |n| %>
    <li>
      <% if n == @current %>
        <%= current_page.with(number: n) %>
      <% else %>
        <%= page.with(number: n) %>
      <% end %>
    </li>
  <% end %>
</ul>
```

```erb
<!-- usage -->
<%= render PaginationComponent.new(current: 2, max: 3) do |c| %>
  <% c.current_page do |p| %><a href>#{p.number}</a><% end %>
  <% c.page do |p| %><span>#{p.number}</span><% end %>
<% end %>
```

```html
<!-- rendered -->
<ul>
  <li><span>1</span></li>
  <li><a href>2</a></li>
  <li><span>3</span></li>
</ul>
```
