### PR TITLE
Do not capture block content of a component if component render is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Do not capture the block of a component if `render?` is false
+
+    *Vincent Rolea*
+
 ## 2.23.2
 
 * Fix bug where rendering a component `with_collection` from a controller raised an error.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1198,7 +1198,7 @@ ViewComponent is built by:
 |@johannesengl|@czj|@mrrooijen|@bradparker|@mattbrictson|
 |Berlin, Germany|Paris, France|The Netherlands|Brisbane, Australia|San Francisco|
 
-|<img src="https://avatars.githubusercontent.com/mixergtz?s=256" alt="mixergtz" width="128" />|<img src="https://avatars.githubusercontent.com/jules2689?s=256" alt="jules2689" width="128" />|<img src="https://avatars.githubusercontent.com/g13ydson?s=256" alt="g13ydson" width="128" />|<img src="https://avatars.githubusercontent.com/swanson?s=256" alt="swanson" width="128" />|
-|:---:|:---:|:---:|:---:|
-|@mixergtz|@jules2689|@g13ydson|@swanson|
-|Medellin, Colombia|Toronto, Canada|João Pessoa, Brazil|Indianapolis, IN|
+|<img src="https://avatars.githubusercontent.com/mixergtz?s=256" alt="mixergtz" width="128" />|<img src="https://avatars.githubusercontent.com/jules2689?s=256" alt="jules2689" width="128" />|<img src="https://avatars.githubusercontent.com/g13ydson?s=256" alt="g13ydson" width="128" />|<img src="https://avatars.githubusercontent.com/swanson?s=256" alt="swanson" width="128" />|<img src="https://avatars.githubusercontent.com/virolea?s=256" alt="virolea" width="128" />|
+|:---:|:---:|:---:|:---:|:---:|
+|@mixergtz|@jules2689|@g13ydson|@swanson|@virolea
+|Medellin, Colombia|Toronto, Canada|João Pessoa, Brazil|Indianapolis, IN|Nantes, France|

--- a/docs/index.md
+++ b/docs/index.md
@@ -167,6 +167,30 @@ Returning:
 </div>
 ```
 
+In the case when you need the block passed to a `ViewComponent` to be evaluated only if the parent component is rendering, you can do as follows:
+
+```ruby
+class MyComponent < ViewComponent::Base
+  def initialize(should_render: true)
+    @should_render = should_render
+  end
+
+  def render?
+    @should_render
+  end
+end
+```
+
+```erb
+<%= render MyComponent(should_render: current_user.present?) do |component| %>
+  <%= component.content do %>
+    <%= current_user.name %>
+  <% end >
+<% end >
+```
+
+In the code above, `current_user.name` will be evaluated only if `current_user` is present on the parent component.
+
 #### Slots (experimental)
 
 _Slots are currently under development as the successor to Content Areas. The Slot APIs should be considered unfinished (it's already in its second iteration, [see the original API](/slots-v1).) and subject to breaking changes in non-major releases of ViewComponent._
@@ -1198,7 +1222,7 @@ ViewComponent is built by:
 |@johannesengl|@czj|@mrrooijen|@bradparker|@mattbrictson|
 |Berlin, Germany|Paris, France|The Netherlands|Brisbane, Australia|San Francisco|
 
-|<img src="https://avatars.githubusercontent.com/mixergtz?s=256" alt="mixergtz" width="128" />|<img src="https://avatars.githubusercontent.com/jules2689?s=256" alt="jules2689" width="128" />|<img src="https://avatars.githubusercontent.com/g13ydson?s=256" alt="g13ydson" width="128" />|<img src="https://avatars.githubusercontent.com/swanson?s=256" alt="swanson" width="128" />|<img src="https://avatars.githubusercontent.com/virolea?s=256" alt="virolea" width="128" />|
+|<img src="https://avatars.githubusercontent.com/mixergtz?s=256" alt="mixergtz" width="128" />|<img src="https://avatars.githubusercontent.com/jules2689?s=256" alt="jules2689" width="128" />|<img src="https://avatars.githubusercontent.com/g13ydson?s=256" alt="g13ydson" width="128" />|<img src="https://avatars.githubusercontent.com/swanson?s=256" alt="swanson" width="128" />|<img src="https://avatars.githubusercontent.com/virolea?s=256" alt="viroleaA" width="128" />|
 |:---:|:---:|:---:|:---:|:---:|
 |@mixergtz|@jules2689|@g13ydson|@swanson|@virolea
 |Medellin, Colombia|Toronto, Canada|João Pessoa, Brazil|Indianapolis, IN|Nantes, France|

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -68,12 +68,13 @@ module ViewComponent
       old_current_template = @current_template
       @current_template = self
 
-      # Assign captured content passed to component as a block to @content
-      @content = view_context.capture(self, &block) if block_given?
 
       before_render
 
       if render?
+        # Assign captured content passed to component as a block to @content
+        @content = view_context.capture(self, &block) if block_given?
+
         render_template_for(@variant)
       else
         ""

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -68,13 +68,14 @@ module ViewComponent
       old_current_template = @current_template
       @current_template = self
 
+      # Assign captured content passed to component as a block to @content
+      @content = view_context.capture(self, &block) if block_given?
 
       before_render
 
       if render?
-        # Assign captured content passed to component as a block to @content
-        @content = view_context.capture(self, &block) if block_given?
-
+        # Call the block from `render_content` and set it as @content if render? is true
+        @content = @block_from_render_content.call if @block_from_render
         render_template_for(@variant)
       else
         ""
@@ -93,6 +94,10 @@ module ViewComponent
 
     def render?
       true
+    end
+
+    def render_content(&block)
+      @block_from_render_content = block
     end
 
     def initialize(*); end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -69,13 +69,11 @@ module ViewComponent
       @current_template = self
 
       # Assign captured content passed to component as a block to @content
-      @content = view_context.capture(self, &block) if block_given?
+      @_content = view_context.capture(self, &block) if block_given?
 
       before_render
 
       if render?
-        # Call the block from `render_content` and set it as @content if render? is true
-        @content = @block_from_render_content.call if @block_from_render
         render_template_for(@variant)
       else
         ""
@@ -96,8 +94,14 @@ module ViewComponent
       true
     end
 
-    def render_content(&block)
-      @block_from_render_content = block
+    def content(&block)
+      if block_given?
+        @block_from_content = block
+      else
+        @_content ||= if defined?(@block_from_content)
+          @block_from_content.call
+        end
+      end
     end
 
     def initialize(*); end
@@ -173,7 +177,7 @@ module ViewComponent
       @request ||= controller.request
     end
 
-    attr_reader :content, :view_context
+    attr_reader :view_context
 
     # The controller used for testing components.
     # Defaults to ApplicationController. This should be set early

--- a/test/app/components/conditional_render_component.html.erb
+++ b/test/app/components/conditional_render_component.html.erb
@@ -1,1 +1,2 @@
 <div>component was rendered</div>
+<%= content %>

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -558,4 +558,10 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_predicate InheritedInlineComponent, :compiled?
     assert_selector("input[type='text'][name='name']")
   end
+
+  def test_does_not_capture_block_if_render_is_false
+    render_inline(ConditionalRenderComponent.new(should_render: false)) do
+      raise
+    end
+  end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -559,17 +559,17 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("input[type='text'][name='name']")
   end
 
-  def capture_block_in_render_content_only_if_component_is_rendering
+  def test_block_passed_to_content_evaluated_only_if_parent_component_is_rendering
     render_inline(ConditionalRenderComponent.new(should_render: true)) do |c|
-      c.render_content do
-        render ErbComponent.new(message: "Hello World")
+      c.content do
+        "Hello World"
       end
     end
 
-    assert_selector("div", text: "Hello World")
+    assert_text("Hello World")
 
     render_inline(ConditionalRenderComponent.new(should_render: false)) do |c|
-      c.render_content do
+      c.content do
         raise
       end
     end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -559,9 +559,19 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_selector("input[type='text'][name='name']")
   end
 
-  def test_does_not_capture_block_if_render_is_false
-    render_inline(ConditionalRenderComponent.new(should_render: false)) do
-      raise
+  def capture_block_in_render_content_only_if_component_is_rendering
+    render_inline(ConditionalRenderComponent.new(should_render: true)) do |c|
+      c.render_content do
+        render ErbComponent.new(message: "Hello World")
+      end
+    end
+
+    assert_selector("div", text: "Hello World")
+
+    render_inline(ConditionalRenderComponent.new(should_render: false)) do |c|
+      c.render_content do
+        raise
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

In #558 I detailed the motivations for a conditional block content capture when rendering a component. In the current implementation, we capture the block content passed to a component we are rendering, no matter what:

```ruby
# lib/view_component_base L71 

def render_in(view_context, &block)
  # ...

  # Assign captured content passed to component as a block to @content
  @content = view_context.capture(self, &block) if block_given?  # ⬅️ block captured no matter what

  # ...
end
```
The code in this PR conditions the capture of the block on the result of `render?`. 

== EDIT ==
After thinking about it, I don't see why we should not condition the call to `before_render` to `render?` as well !
