### PR TITLE
Fix invalid slots with_content example

### DIFF
--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -201,6 +201,6 @@ Slot content can also be set using `#with_content`:
 
 ```erb
 <%= render BlogComponent.new do |c| %>
-  <% c.header.with_content("My blog") %>
+  <% c.header(classes: "title").with_content("My blog") %>
 <% end %>
 ```


### PR DESCRIPTION
The example in the documentation won't work because no arguments and no
block are being passed to the slot, so it is attempting to get the slot
instead of setting it. This example will raise when run.

This updates the example to pass an argument to the slot, setting it
instead of fetching it.

