### PR TITLE
Modify SlotV2 to inherit from BasicObject

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Change SlotV2 to inherit from BasicObject to reduce method name collisions
+
+    *Will Cosgrove*
+
 ## 2.45.0
 
 * Remove internal APIs from API documentation, fix link to license.

--- a/test/sandbox/app/components/basic_object_slot_v2_component.rb
+++ b/test/sandbox/app/components/basic_object_slot_v2_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BasicObjectSlotV2Component < ViewComponent::Base
+  renders_one :link, "Link"
+
+  class Link < ViewComponent::Base
+    attr_reader :method
+
+    def initialize(method:)
+      @method = method
+    end
+  end
+
+  def call
+    helpers.tag.a(data: { method: link.method })
+  end
+end

--- a/test/view_component/slotable_v2_test.rb
+++ b/test/view_component/slotable_v2_test.rb
@@ -472,4 +472,11 @@ class SlotsV2sTest < ViewComponent::TestCase
 
     assert_includes error.message, "invalid slot definition"
   end
+
+  def test_slot_v2_inherits_from_basic_object
+    component = BasicObjectSlotV2Component.new
+    render_inline(component) do |component|
+      component.link method: :patch
+    end
+  end
 end


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

>`SlotV2` can act like a delegator when used with a component instance.
Inheriting from `BasicObject` reduces the likelihood that a method defined
on itself clashes with a method on the delegated component instance.

I had a component for a button used as a slot that had a `method` attribute for defining which HTTP method should be used for the request. The component works fine by itself, but I was surprised when using it as a slot of a different component, it stopped working. The reason was that when I called `method` on my component instance, I was actually calling it on a `SlotV2` instance which has its own `method` method which expects an argument.

Maybe the answer here should be to avoid "reserved" names for attributes on a component. If so, that's fine. I just thought I would share the result of my digging around to figure out what the problem was. Maybe it could be helpful to others.