### PR TITLE
tests: check if within is supported.

### DIFF
--- a/test/view_component/slotable_test.rb
+++ b/test/view_component/slotable_test.rb
@@ -37,18 +37,20 @@ class SlotableTest < ViewComponent::TestCase
 
     assert_selector(".card.mt-4")
 
-    assert_selector(".title", text: "This is my title!")
+    within(".card.mt-4") do
+      assert_selector(".title", text: "This is my title!")
 
-    assert_selector(".subtitle", text: "This is my subtitle!")
+      assert_selector(".subtitle", text: "This is my subtitle!")
 
-    assert_selector(".tab", text: "Tab A")
-    assert_selector(".tab", text: "Tab B")
+      assert_selector(".tab", text: "Tab A")
+      assert_selector(".tab", text: "Tab B")
 
-    assert_selector(".item", count: 3)
-    assert_selector(".item.highlighted", count: 1)
-    assert_selector(".item.normal", count: 2)
+      assert_selector(".item", count: 3)
+      assert_selector(".item.highlighted", count: 1)
+      assert_selector(".item.normal", count: 2)
 
-    assert_selector(".footer.text-blue", text: "This is the footer")
+      assert_selector(".footer.text-blue", text: "This is the footer")
+    end
   end
 
   def test_inherited_component_renders_slots


### PR DESCRIPTION
### Summary

A quick test to see if `within` works with minitest.

### Other Information

Speaking with @joelhawksley it appears there some uncertainty around supporting `within`. it works with RSpec, but unsure with minitest.

EDIT: 

`within` is supported under RSpec since it gets aliased under ProxyMatchers. 

https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/RSpecMatcherProxies#within-instance_method

There is no equivalent for minitest, and the base `within` provided by Capybara relies on the session which as far as I can tell is only set in tests which use a controller and is scoped under `request`.

`request.session.within()`

Anyways, Capybara docs recommend just using chaining instead of `within`

https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Session#within-instance_method

It is worth noting that Capybara scopes `page` to the `within` so using an `expect(page).to have_text("blah")` has different effects when used within a `within` block as opposed to outside of a `within` block. All that to say, there are workarounds and I dont think this is a show stopper.