### PR TITLE
Add basic attributes API (experimental)

### DIFF
--- a/lib/view_component/attributes.rb
+++ b/lib/view_component/attributes.rb
@@ -13,25 +13,33 @@ require "active_support/concern"
 #     accepts :author, default: NullUser.new
 #   end
 #
-#   <%= render PostComponent.new(title: "foo", posted_at: Date.yesterday %>
+#   <%= render PostComponent.new(title: "foo", posted_at: Date.yesterday) %>
 module ViewComponent
   module Attributes
     extend ActiveSupport::Concern
 
     included do
-      cattr_accessor :_optional_attributes, default: {}
-      cattr_accessor :_required_attributes, default: Set.new
+      class_attribute :_optional_attributes, default: {}
+      class_attribute :_required_attributes, default: Set.new
     end
 
     class_methods do
       def requires(parameter)
         _required_attributes << parameter
+
+        attr_reader parameter
       end
 
       def accepts(parameter, default: nil)
         _optional_attributes[parameter] = default
 
         attr_accessor parameter
+      end
+
+      def inherited(subclass)
+        subclass._optional_attributes = _optional_attributes.dup
+        subclass._required_attributes = _required_attributes.dup
+        super
       end
     end
 

--- a/lib/view_component/attributes.rb
+++ b/lib/view_component/attributes.rb
@@ -36,12 +36,12 @@ module ViewComponent
     end
 
     def initialize(**args)
-      construct_params(args)
+      _construct_attributes(args)
     end
 
     private
 
-    def construct_params(args)
+    def _construct_attributes(args)
       _required_attributes.each do |attr, _default|
         if !args.has_key?(attr)
           raise ArgumentError.new("Missing keyword: #{attr}") # Simulate required kwargs

--- a/lib/view_component/attributes.rb
+++ b/lib/view_component/attributes.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+# An attributes API for declaratively defining properties a component accepts.
+# @example
+#   class PostComponent
+#     include ViewComponent::Attributes
+#
+#     accepts :title, required: true
+#     accepts :posted_at, required: true
+#
+#     accepts :author, default: NullUser.new
+#   end
+#
+#   <%= render PostComponent.new(title: "foo", posted_at: Date.yesterday %>
+module ViewComponent
+  module Attributes
+    extend ActiveSupport::Concern
+
+    included do
+      cattr_accessor :_optional_attributes, default: {}
+      cattr_accessor :_required_attributes, default: {}
+    end
+
+    class_methods do
+      def accepts(parameter, required: false, default: nil)
+        if required
+          _required_attributes[parameter] = default
+        else
+          _optional_attributes[parameter] = default
+        end
+
+        attr_accessor parameter
+      end
+    end
+
+    def initialize(**args)
+      construct_params(args)
+    end
+
+    private
+
+    def construct_params(args)
+      _required_attributes.each do |attr, _default|
+        if !args.has_key?(attr)
+          raise ArgumentError.new("Missing keyword: #{attr}") # Simulate required kwargs
+        end
+
+        instance_variable_set("@#{attr}", args[attr])
+      end
+
+      _optional_attributes.each do |attr, default|
+        if args.has_key?(attr)
+          value = args[attr]
+          instance_variable_set("@#{attr}", value)
+        else
+          value = args[attr]
+          instance_variable_set("@#{attr}", default)
+        end
+      end
+    end
+  end
+end

--- a/lib/view_component/attributes.rb
+++ b/lib/view_component/attributes.rb
@@ -7,8 +7,8 @@ require "active_support/concern"
 #   class PostComponent
 #     include ViewComponent::Attributes
 #
-#     accepts :title, required: true
-#     accepts :posted_at, required: true
+#     requires :title
+#     requires :posted_at
 #
 #     accepts :author, default: NullUser.new
 #   end
@@ -20,20 +20,16 @@ module ViewComponent
 
     included do
       cattr_accessor :_optional_attributes, default: {}
-      cattr_accessor :_required_attributes, default: {}
+      cattr_accessor :_required_attributes, default: Set.new
     end
 
     class_methods do
-      def accepts(parameter, required: false, default: nil)
-        if required
-          if !default.nil?
-            raise ArgumentError.new("Required arguments can't have defaults: :#{parameter}")
-          end
+      def requires(parameter)
+        _required_attributes << parameter
+      end
 
-          _required_attributes[parameter] = default
-        else
-          _optional_attributes[parameter] = default
-        end
+      def accepts(parameter, default: nil)
+        _optional_attributes[parameter] = default
 
         attr_accessor parameter
       end
@@ -46,7 +42,7 @@ module ViewComponent
     private
 
     def _construct_attributes(args)
-      _required_attributes.each do |attr, _default|
+      _required_attributes.each do |attr|
         if !args.has_key?(attr)
           raise ArgumentError.new("Missing keyword: :#{attr}") # Simulate required kwargs
         end

--- a/lib/view_component/attributes.rb
+++ b/lib/view_component/attributes.rb
@@ -26,6 +26,10 @@ module ViewComponent
     class_methods do
       def accepts(parameter, required: false, default: nil)
         if required
+          if !default.nil?
+            raise ArgumentError.new("Required arguments can't have defaults: :#{parameter}")
+          end
+
           _required_attributes[parameter] = default
         else
           _optional_attributes[parameter] = default
@@ -44,7 +48,7 @@ module ViewComponent
     def _construct_attributes(args)
       _required_attributes.each do |attr, _default|
         if !args.has_key?(attr)
-          raise ArgumentError.new("Missing keyword: #{attr}") # Simulate required kwargs
+          raise ArgumentError.new("Missing keyword: :#{attr}") # Simulate required kwargs
         end
 
         instance_variable_set("@#{attr}", args[attr])

--- a/test/view_component/attributes_test.rb
+++ b/test/view_component/attributes_test.rb
@@ -22,8 +22,13 @@ class AttributesTest < ViewComponent::TestCase
     end
   end
 
+  class MyInheritedAttributeComponent < MyAttributeComponent
+  end
+
   def test_basic_attributes
     render_inline MyAttributeComponent.new(title: "foo")
+
+    assert_selector('h1', text: 'foo')
   end
 
   def test_required_attribute_raises_if_missing
@@ -47,5 +52,11 @@ class AttributesTest < ViewComponent::TestCase
   def test_explicit_nil_overrides_default_values
     component = MyAttributeComponent.new(title: "foo", posted_at: nil)
     assert_nil component.posted_at
+  end
+
+  def test_inheritance_works
+    render_inline MyInheritedAttributeComponent.new(title: "foo")
+
+    assert_selector('h1', text: 'foo')
   end
 end

--- a/test/view_component/attributes_test.rb
+++ b/test/view_component/attributes_test.rb
@@ -31,6 +31,30 @@ class AttributesTest < ViewComponent::TestCase
     assert_selector("h1", text: "foo")
   end
 
+  def test_exposes_attributes
+    component = MyAttributeComponent.new(title: "foo", body: "hello world!")
+
+    assert_equal "foo", component.title
+    assert_equal "hello world!", component.body
+  end
+
+  def test_inherits_attributes
+    new_component_class = Class.new(MyAttributeComponent) do
+    end
+
+    assert new_component_class.public_instance_methods.include?(:title)
+  end
+
+  def test_does_not_pollute_attribute_cache
+    Class.new(ViewComponent::Base) do
+      include ViewComponent::Attributes
+
+      requires :fake_field
+    end
+
+    refute MyAttributeComponent.public_instance_methods.include?(:fake_field)
+  end
+
   def test_all_attributes_provided
     posted_at = Date.yesterday
     render_inline MyAttributeComponent.new(title: "foo", body: "hello world!", posted_at: posted_at)

--- a/test/view_component/attributes_test.rb
+++ b/test/view_component/attributes_test.rb
@@ -71,4 +71,12 @@ class AttributesTest < ViewComponent::TestCase
     assert_selector("p", text: "hello world!")
     assert_selector("date", text: posted_at.to_s)
   end
+
+  def test_required_params_can_not_have_defaults
+    assert_raises ArgumentError do
+      MyAttributeComponent.instance_exec do
+        accepts :foo, required: true, default: "bar"
+      end
+    end
+  end
 end

--- a/test/view_component/attributes_test.rb
+++ b/test/view_component/attributes_test.rb
@@ -7,7 +7,7 @@ class AttributesTest < ViewComponent::TestCase
   class MyAttributeComponent < ViewComponent::Base
     include ViewComponent::Attributes
 
-    accepts :title, required: true
+    requires :title
     accepts :body
     accepts :posted_at, default: Date.today
 
@@ -70,13 +70,5 @@ class AttributesTest < ViewComponent::TestCase
     assert_selector("h1", text: "foo")
     assert_selector("p", text: "hello world!")
     assert_selector("date", text: posted_at.to_s)
-  end
-
-  def test_required_params_can_not_have_defaults
-    assert_raises ArgumentError do
-      MyAttributeComponent.instance_exec do
-        accepts :foo, required: true, default: "bar"
-      end
-    end
   end
 end

--- a/test/view_component/attributes_test.rb
+++ b/test/view_component/attributes_test.rb
@@ -28,16 +28,16 @@ class AttributesTest < ViewComponent::TestCase
   def test_basic_attributes
     render_inline MyAttributeComponent.new(title: "foo")
 
-    assert_selector('h1', text: 'foo')
+    assert_selector("h1", text: "foo")
   end
 
   def test_all_attributes_provided
     posted_at = Date.yesterday
     render_inline MyAttributeComponent.new(title: "foo", body: "hello world!", posted_at: posted_at)
 
-    assert_selector('h1', text: 'foo')
-    assert_selector('p', text: 'hello world!')
-    assert_selector('date', text: posted_at.to_s)
+    assert_selector("h1", text: "foo")
+    assert_selector("p", text: "hello world!")
+    assert_selector("date", text: posted_at.to_s)
   end
 
   def test_required_attribute_raises_if_missing
@@ -67,8 +67,8 @@ class AttributesTest < ViewComponent::TestCase
     posted_at = Date.yesterday
     render_inline MyInheritedAttributeComponent.new(title: "foo", body: "hello world!", posted_at: posted_at)
 
-    assert_selector('h1', text: 'foo')
-    assert_selector('p', text: 'hello world!')
-    assert_selector('date', text: posted_at.to_s)
+    assert_selector("h1", text: "foo")
+    assert_selector("p", text: "hello world!")
+    assert_selector("date", text: posted_at.to_s)
   end
 end

--- a/test/view_component/attributes_test.rb
+++ b/test/view_component/attributes_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "view_component/attributes"
+
+class AttributesTest < ViewComponent::TestCase
+  class MyAttributeComponent < ViewComponent::Base
+    include ViewComponent::Attributes
+
+    accepts :title, required: true
+    accepts :body
+    accepts :posted_at, default: Date.today
+
+    def call
+      content_tag :div do
+        safe_join([
+          content_tag(:h1, @title),
+          content_tag(:p, @body),
+          content_tag(:date, @posted_at),
+        ])
+      end
+    end
+  end
+
+  def test_basic_attributes
+    render_inline MyAttributeComponent.new(title: "foo")
+  end
+
+  def test_required_attribute_raises_if_missing
+    assert_raises ArgumentError do
+      render_inline MyAttributeComponent.new
+    end
+  end
+
+  def test_optional_arguments_default_to_nil
+    component = MyAttributeComponent.new(title: "foo")
+    assert_nil component.body
+  end
+
+  def test_default_values_are_set_if_argument_is_missing
+    freeze_time do
+      component = MyAttributeComponent.new(title: "foo")
+      assert_equal Date.today, component.posted_at
+    end
+  end
+
+  def test_explicit_nil_overrides_default_values
+    component = MyAttributeComponent.new(title: "foo", posted_at: nil)
+    assert_nil component.posted_at
+  end
+end

--- a/test/view_component/attributes_test.rb
+++ b/test/view_component/attributes_test.rb
@@ -31,6 +31,15 @@ class AttributesTest < ViewComponent::TestCase
     assert_selector('h1', text: 'foo')
   end
 
+  def test_all_attributes_provided
+    posted_at = Date.yesterday
+    render_inline MyAttributeComponent.new(title: "foo", body: "hello world!", posted_at: posted_at)
+
+    assert_selector('h1', text: 'foo')
+    assert_selector('p', text: 'hello world!')
+    assert_selector('date', text: posted_at.to_s)
+  end
+
   def test_required_attribute_raises_if_missing
     assert_raises ArgumentError do
       render_inline MyAttributeComponent.new
@@ -55,8 +64,11 @@ class AttributesTest < ViewComponent::TestCase
   end
 
   def test_inheritance_works
-    render_inline MyInheritedAttributeComponent.new(title: "foo")
+    posted_at = Date.yesterday
+    render_inline MyInheritedAttributeComponent.new(title: "foo", body: "hello world!", posted_at: posted_at)
 
     assert_selector('h1', text: 'foo')
+    assert_selector('p', text: 'hello world!')
+    assert_selector('date', text: posted_at.to_s)
   end
 end


### PR DESCRIPTION
This adds a basic and experimental attributes API that is used to define the
properties that a component accepts when initialized.

The idea behind this API is to give the library more control over the
`initializer`, attempt to close API gaps like `helpers` sometimes not being
callable, and reduce boilerplate when assigning attributes.

As-is, the API introduces two new methods:

1. `requires :name` - defines a required attribute accessible via the `name` property.. If this value is not provided when initializing the component an `ArgumentError` is raised.
1. `accepts :name` - defines an optional attribute accessible via the `name` property. Optionally, a default value can be provided by passing a `default` kwarg. e.g. `accepts :name, default: "NullUser"`.

This API is not added to all components by default, but can be opted-into by
adding `include ViewComponent::Attributes` to a component.

Feedback/thoughts welcome!
