### PR TITLE
Adds support to localized components files

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -96,9 +96,8 @@ module ViewComponent
 
       if render?
         if defined?(I18n) && !I18n.locale.eql?(I18n.default_locale)
-          attr = (I18n.locale || I18n.default_locale).to_s.downcase.tr("-", "_")
-
-          custom_variant = [@__vc_variant, attr].compact.reduce { |s, x| "#{s}_#{x}" }
+          attr = (I18n.locale || I18n.default_locale).to_s.underscore
+          custom_variant = [@__vc_variant, attr].compact.join('_')
         end
 
         render_template_for(custom_variant || @__vc_variant).to_s + _output_postamble

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -95,9 +95,10 @@ module ViewComponent
       before_render
 
       if render?
-        if defined?(I18n.locale) && I18n.locale != :en
-          custom_variant = [@__vc_variant, I18n.locale.to_s.downcase.tr("-", "_")]
-          custom_variant = custom_variant.compact.reduce { |s, x| s + "_" + x }.to_sym
+        if defined?(I18n) && !I18n.locale.eql?(I18n.default_locale)
+          attr = (I18n.locale || I18n.default_locale).to_s.downcase.tr("-", "_")
+
+          custom_variant = [@__vc_variant, attr].compact.reduce { |s, x| "#{s}_#{x}" }
         end
 
         render_template_for(custom_variant || @__vc_variant).to_s + _output_postamble

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -95,12 +95,12 @@ module ViewComponent
       before_render
 
       if render?
-        custom_variant = [@__vc_variant]
         if defined?(I18n.locale) && I18n.locale != :en
-          custom_variant << I18n.locale.to_s.downcase.tr("-", "_")
+          custom_variant = [@__vc_variant, I18n.locale.to_s.downcase.tr("-", "_")]
+          custom_variant = custom_variant.compact.reduce { |s, x| s + "_" + x }.to_sym
         end
 
-        render_template_for(custom_variant.join("_").to_sym).to_s + _output_postamble
+        render_template_for(custom_variant || @__vc_variant).to_s + _output_postamble
       else
         ""
       end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -95,7 +95,12 @@ module ViewComponent
       before_render
 
       if render?
-        render_template_for(@__vc_variant).to_s + _output_postamble
+        custom_variant = [@__vc_variant]
+        if defined?(I18n.locale) && I18n.locale != :en
+          custom_variant << I18n.locale.to_s.downcase.tr("-", "_")
+        end
+
+        render_template_for(custom_variant.join("_").to_sym).to_s + _output_postamble
       else
         ""
       end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -130,13 +130,17 @@ module ViewComponent
 
         component_class._sidecar_files(extensions).each_with_object([]) do |path, memo|
           pieces = File.basename(path).split(".")
-          variant = pieces.second.split("+").second&.to_sym
 
-          # grab localized templates and fix regional dash (pt-BR, en-GB...)
-          localized_template = pieces.second.downcase.tr("-", "_")
-
-          # if template is a localized (ie file.country_code.html.erb) append as variant
-          variant = [variant, localized_template].compact.reduce { |s, x| s + "_" + x } if pieces.size >= 4
+          # if template is a localized file (ie file.country_code.html.erb)
+          # append into locale inside variant and fix regional dash (pt-BR, en-GB...)
+          if pieces.length >= 4
+            variant = [
+              pieces.third.split("+").second&.to_sym,
+              pieces.second.downcase.tr("-", "_")
+            ].compact.reduce { |s, x| "#{s}_#{x}" }
+          else
+            variant = pieces.second.split("+").second&.to_sym
+          end
 
           memo << {
             path: path,

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -126,7 +126,7 @@ module ViewComponent
 
     def templates
       @templates ||= begin
-        extensions = %w[builder erb haml html jbuilder raw ruby slim]
+        extensions = ActionView::Template.template_handler_extensions
 
         component_class._sidecar_files(extensions).each_with_object([]) do |path, memo|
           pieces = File.basename(path).split(".")
@@ -136,9 +136,7 @@ module ViewComponent
           localized_template = pieces.second.downcase.tr("-", "_")
 
           # if template is a localized (ie file.country_code.html.erb) append as variant
-          if !localized_template.match(/builder|erb|html|jbuilder|raw|ruby|slim|tablet|iphone|json|html|\+/).present?
-            variant = [variant, localized_template].join("_")
-          end
+          variant = [variant, localized_template].compact.reduce { |s, x| s + "_" + x } if pieces.size >= 4
 
           memo << {
             path: path,

--- a/test/app/components/mi_componente.html.erb
+++ b/test/app/components/mi_componente.html.erb
@@ -1,0 +1,1 @@
+<div>hola,mundo!</div>

--- a/test/app/components/mi_componente.rb
+++ b/test/app/components/mi_componente.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class MiComponente < ViewComponent::Base
+end

--- a/test/app/components/my_component.es.html.erb
+++ b/test/app/components/my_component.es.html.erb
@@ -1,0 +1,1 @@
+<div>Hola,mundo!</div>

--- a/test/app/components/my_component.pt-BR.html.erb
+++ b/test/app/components/my_component.pt-BR.html.erb
@@ -1,0 +1,1 @@
+<div>olá,mundo!</div>

--- a/test/app/components/variants_component.pt-BR.html+phone.erb
+++ b/test/app/components/variants_component.pt-BR.html+phone.erb
@@ -1,0 +1,1 @@
+Telefone

--- a/test/config/environments/test.rb
+++ b/test/config/environments/test.rb
@@ -34,6 +34,8 @@ Dummy::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  I18n.available_locales = [:ru, :en, :es, 'pt-BR']
+
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
   # like if you have constraints or database-specific column types

--- a/test/config/locales/es.yml
+++ b/test/config/locales/es.yml
@@ -1,0 +1,13 @@
+es:
+  hello: Hola!
+  from:
+    rails: This is coming from Rails
+  translations_component:
+    title: Lorem ipsum
+    subtitle: More lorem ipsum
+
+  translatable_component:
+    relative_rails_key: Relative key from Rails
+
+  editorb_component:
+    title: Editorb!

--- a/test/config/locales/pt-BR.yml
+++ b/test/config/locales/pt-BR.yml
@@ -1,0 +1,13 @@
+pt-BR:
+  hello: Oi das traduções do Rails.
+  from:
+    rails: This is coming from Rails
+  translations_component:
+    title: Lorem ipsum
+    subtitle: More lorem ipsum
+
+  translatable_component:
+    relative_rails_key: Relative key from Rails
+
+  editorb_component:
+    title: Editorb!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,28 +33,17 @@ def with_preview_paths(new_value)
   Rails.application.config.view_component.preview_paths = old_value
 end
 
-# Accepts any config, so we dont need to create one function for each attribute
-#
-# @param configs [Array<String>] Use 'parameter = value'
-# @yield Test code to run
-# @return [void]
-# rubocop:disable Security/Eval
-def with_custom_config(*configs)
-  old_config = configs.map do |config|
-    config_name = config.split("=").first.strip
-    val = eval(config_name)
-    val = val.is_a?(Symbol) ? ":#{val}" : val
-
-    "#{config_name} = #{val}"
-  end
-
-  apply_config = ->(c) { c.each { |ee| eval(ee) } }
-
+def with_locale(locale, default_locale = I18n.default_locale)
+  old_locale = I18n.locale
+  old_default_locale = I18n.default_locale
+  
   begin
-    apply_config.call(configs)
+    I18n.locale = locale
+    I18n.default_locale = default_locale
     yield
   ensure
-    apply_config.call(old_config)
+     I18n.locale = old_locale
+     I18n.default_locale = old_default_locale
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,30 @@ def with_preview_paths(new_value)
   Rails.application.config.view_component.preview_paths = old_value
 end
 
+# Accepts any config, so we dont need to create one function for each attribute
+#
+# @param configs [Array<String>] Use 'parameter = value'
+# @yield Test code to run
+# @return [void]
+def with_custom_config(*configs)
+  old_config = configs.map do |config|
+    config_name = config.split("=").first.strip
+    val = eval(config_name)
+    val = val.is_a?(Symbol) ? ":#{val}" : val
+
+    "#{config_name} = #{val}"
+  end
+
+  apply_config = ->(c) { c.each { |ee| eval(ee) } }
+
+  begin
+    apply_config.call(configs)
+    yield
+  ensure
+    apply_config.call(old_config)
+  end
+end
+
 def with_preview_route(new_value)
   old_value = Rails.application.config.view_component.preview_route
   Rails.application.config.view_component.preview_route = new_value

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,6 +38,7 @@ end
 # @param configs [Array<String>] Use 'parameter = value'
 # @yield Test code to run
 # @return [void]
+# rubocop:disable Security/Eval
 def with_custom_config(*configs)
   old_config = configs.map do |config|
     config_name = config.split("=").first.strip

--- a/test/view_component/localized_test.rb
+++ b/test/view_component/localized_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LocalizedTest < ViewComponent::TestCase
+  def test_render_component_in_two_languages
+    render_inline(MyComponent.new)
+    assert_text("hello,world!")
+
+    with_custom_config("I18n.locale = :es") do
+      render_inline(MyComponent.new)
+      assert_text("Hola,mundo!")
+    end
+
+    render_inline(MyComponent.new)
+    assert_text("hello,world!")
+  end
+
+  # some regional locales (pt-BR, en-GB...) contains a dash and
+  # and functions names can't have name dashs... :thinking:
+  def test_render_component_with_dashed_language
+    render_inline(MyComponent.new)
+    assert_text("hello,world!")
+
+    with_custom_config("I18n.locale = 'pt-BR'") do
+      render_inline(MyComponent.new)
+      assert_text("olá,mundo!")
+    end
+
+    render_inline(MyComponent.new)
+    assert_text("hello,world!")
+  end
+
+  # def test_render_component_localized_with_custom_view
+  # end
+
+  # def test_render_component_localized_with_variants
+  # end
+
+end

--- a/test/view_component/localized_test.rb
+++ b/test/view_component/localized_test.rb
@@ -31,6 +31,13 @@ class LocalizedTest < ViewComponent::TestCase
     assert_text("hello,world!")
   end
 
+  def test_render_component_methods
+    methods = MyComponent.new.methods.grep(/call/)
+    assert_includes methods, :call
+    assert_includes methods, :call_es
+    assert_includes methods, :call_pt_br
+  end
+
   # def test_render_component_localized_with_custom_view
   # end
 

--- a/test/view_component/localized_test.rb
+++ b/test/view_component/localized_test.rb
@@ -7,7 +7,7 @@ class LocalizedTest < ViewComponent::TestCase
     render_inline(MyComponent.new)
     assert_text("hello,world!")
 
-    with_custom_config("I18n.locale = :es") do
+    with_locale(:es) do
       render_inline(MyComponent.new)
       assert_text("Hola,mundo!")
     end
@@ -17,9 +17,16 @@ class LocalizedTest < ViewComponent::TestCase
   end
 
   def test_render_component_with_dashed_regional_locale_name
-    with_custom_config("I18n.locale = 'pt-BR'") do
+    with_locale('pt-BR') do
       render_inline(MyComponent.new)
       assert_text("olá,mundo!")
+    end
+  end
+
+  def test_render_component_fallback
+    with_locale('ru') do
+      render_inline(MyComponent.new)
+      assert_text("hello,world!")
     end
   end
 
@@ -27,19 +34,13 @@ class LocalizedTest < ViewComponent::TestCase
     assert I18n.locale, :en
     assert I18n.default_locale, :en
 
-    with_custom_config(
-      "I18n.default_locale = :es",
-      "I18n.locale = 'pt-BR'"
-    ) do
+    with_locale('pt-BR', :es) do
       render_inline(MyComponent.new)
       assert_text("olá,mundo!")
     end
 
     # if both locale and default_locale are equal, we use 'component_name.html.erb'
-    with_custom_config(
-      "I18n.locale = :es",
-      "I18n.default_locale = :es",
-    ) do
+    with_locale(:es, :es) do
       render_inline(MiComponente.new)
       assert_text("hola,mundo!")
     end
@@ -53,7 +54,7 @@ class LocalizedTest < ViewComponent::TestCase
   end
 
   def test_render_component_localized_with_variant
-    with_custom_config("I18n.locale = 'pt-BR'") do
+    with_locale('pt-BR') do
       render_inline(VariantsComponent.new.with_variant(:phone))
       assert_text("Telefone")
     end

--- a/test/view_component/localized_test.rb
+++ b/test/view_component/localized_test.rb
@@ -16,19 +16,33 @@ class LocalizedTest < ViewComponent::TestCase
     assert_text("hello,world!")
   end
 
-  # some regional locales (pt-BR, en-GB...) contains a dash and
-  # and functions names can't have name dashs... :thinking:
-  def test_render_component_with_dashed_language
-    render_inline(MyComponent.new)
-    assert_text("hello,world!")
-
+  def test_render_component_with_dashed_regional_locale_name
     with_custom_config("I18n.locale = 'pt-BR'") do
       render_inline(MyComponent.new)
       assert_text("olá,mundo!")
     end
+  end
 
-    render_inline(MyComponent.new)
-    assert_text("hello,world!")
+  def test_render_component_with_default_locale
+    assert I18n.locale, :en
+    assert I18n.default_locale, :en
+
+    with_custom_config(
+      "I18n.default_locale = :es",
+      "I18n.locale = 'pt-BR'"
+    ) do
+      render_inline(MyComponent.new)
+      assert_text("olá,mundo!")
+    end
+
+    # if both locale and default_locale are equal, we use 'component_name.html.erb'
+    with_custom_config(
+      "I18n.locale = :es",
+      "I18n.default_locale = :es",
+    ) do
+      render_inline(MiComponente.new)
+      assert_text("hola,mundo!")
+    end
   end
 
   def test_render_component_methods
@@ -38,10 +52,10 @@ class LocalizedTest < ViewComponent::TestCase
     assert_includes methods, :call_pt_br
   end
 
-  # def test_render_component_localized_with_custom_view
-  # end
-
-  # def test_render_component_localized_with_variants
-  # end
-
+  def test_render_component_localized_with_variant
+    with_custom_config("I18n.locale = 'pt-BR'") do
+      render_inline(VariantsComponent.new.with_variant(:phone))
+      assert_text("Telefone")
+    end
+  end
 end


### PR DESCRIPTION
Related: #894 

I just combined the "localized" information from component files (my_component.**es**.html.erb) into variant attribute to avoid adding new parameters or functions and worked well :smile: 

It's not done yet, needs some work, more tests, benchmarks... but I wanted to see some opinions about this approach, if there's something else I'm not seeing.