### PR TITLE
Fragment Caching POC

### DIFF
--- a/lib/view_component/caching/component_tracker.rb
+++ b/lib/view_component/caching/component_tracker.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Caching
+    class ComponentTracker < ERBTracker
+      def initialize(name, template, view_paths = nil)
+        super
+        @component_class = name.safe_constantize
+      end
+
+      def dependencies
+        return [] unless view_component?
+
+        super + templates + relevant_ancestors
+      end
+
+      private
+
+      attr_reader :component_class
+
+      def view_component?
+        component_class&.ancestors&.include? ViewComponent::Base
+      end
+
+      # Returns relevant templates for the component
+      def templates
+        component_class.
+          _sidecar_files(ActionView::Template.template_handler_extensions).
+          map { |path| path.gsub(%r{(.*app/components/)|(\..*)}, "") }
+      end
+
+      # Returns relevant ancestors the component inherits from (if any)
+      def relevant_ancestors
+        ((component_class.ancestors & ViewComponent::Base.descendants) - [component_class]).
+          map(&:to_s)
+      end
+    end
+  end
+end

--- a/lib/view_component/caching/component_tracker.rb
+++ b/lib/view_component/caching/component_tracker.rb
@@ -24,9 +24,9 @@ module ViewComponent
 
       # Returns relevant templates for the component
       def templates
-        component_class.
-          _sidecar_files(ActionView::Template.template_handler_extensions).
-          map { |path| path.gsub(%r{(.*app/components/)|(\..*)}, "") }
+        component_class._sidecar_files(ActionView::Template.template_handler_extensions).map do |path|
+          path.gsub(%r{(.*#{Regexp.quote(ViewComponent::Base.view_component_path)}/)|(\..*)}, "")
+        end
       end
 
       # Returns relevant ancestors the component inherits from (if any)

--- a/lib/view_component/caching/digestor_monkey_patch.rb
+++ b/lib/view_component/caching/digestor_monkey_patch.rb
@@ -52,7 +52,7 @@ module ViewComponent
 
         def component_finder
           @component_finder ||= ActionView::LookupContext.new(
-            ActionView::PathSet.new([Rails.root.join("app/components")]),
+            ActionView::PathSet.new([Rails.root.join(ViewComponent::Base.view_component_path)]),
             formats: [:rb]
           )
         end

--- a/lib/view_component/caching/digestor_monkey_patch.rb
+++ b/lib/view_component/caching/digestor_monkey_patch.rb
@@ -52,7 +52,7 @@ module ViewComponent
 
         def component_finder
           @component_finder ||= ActionView::LookupContext.new(
-            ActionView::PathSet.new(["app/components"]),
+            ActionView::PathSet.new([Rails.root.join("app/components")]),
             formats: [:rb]
           )
         end

--- a/lib/view_component/caching/digestor_monkey_patch.rb
+++ b/lib/view_component/caching/digestor_monkey_patch.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Caching
+    module DigestorMonkeyPatch
+      def self.prepended(base)
+        base.singleton_class.prepend(ClassMethods)
+      end
+
+      module ClassMethods
+        def tree(name, finder, partial = false, seen = {})
+          logical_name = name.gsub(%r|/_|, "/")
+          interpolated = name.include?("#")
+          component    = name.end_with?("Component")
+
+          if !interpolated && (template = find_template(finder, logical_name, [], partial, component))
+            if node = seen[template.identifier] # handle cycles in the tree
+              node
+            else
+              node = seen[template.identifier] = ActionView::Digestor::Node.create(name, logical_name, template, partial)
+
+              deps = ActionView::DependencyTracker.find_dependencies(name, template, finder.view_paths)
+              deps.uniq { |n| n.gsub(%r|/_|, "/") }.each do |dep_file|
+                # The `partial` argument needs to be forced to `false` if passing a component's
+                # template files to #tree, but `true` if we're handling a rails template.
+                node.children << tree(dep_file, finder, !component, seen)
+              end
+              node
+            end
+          else
+            unless interpolated # Dynamic template partial names can never be tracked
+              logger.error "  Couldn't find template for digesting: #{name}"
+            end
+
+            seen[name] ||= ActionView::Digestor::Missing.new(name, logical_name, nil)
+          end
+        end
+
+        private
+
+        def find_template(finder, name, prefixes, partial, component)
+          if component
+            finder = component_finder
+            partial = false
+            name = name.underscore
+          end
+
+          finder.disable_cache do
+            finder.find_all(name, prefixes, partial, []).first
+          end
+        end
+
+        def component_finder
+          @component_finder ||= ActionView::LookupContext.new(
+            ActionView::PathSet.new(["app/components"]),
+            formats: [:rb]
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/view_component/caching/erb_tracker.rb
+++ b/lib/view_component/caching/erb_tracker.rb
@@ -34,10 +34,10 @@ module ViewComponent
 
       def add_dependencies(render_dependencies, arguments, pattern)
         arguments.scan(pattern) do
-          match = Regexp.last_match
-          add_component_dependency(render_dependencies, match[:component])
-          add_dynamic_dependency(render_dependencies, match[:dynamic])
-          add_static_dependency(render_dependencies, match[:static], match[:quote])
+          match = Regexp.last_match.named_captures
+          add_component_dependency(render_dependencies, match["component"])
+          add_dynamic_dependency(render_dependencies, match["dynamic"])
+          add_static_dependency(render_dependencies, match["static"], match["quote"])
         end
       end
 

--- a/lib/view_component/caching/erb_tracker.rb
+++ b/lib/view_component/caching/erb_tracker.rb
@@ -34,14 +34,30 @@ module ViewComponent
 
       def add_dependencies(render_dependencies, arguments, pattern)
         arguments.scan(pattern) do
-          add_component_dependency(render_dependencies, Regexp.last_match[:component])
-          add_dynamic_dependency(render_dependencies, Regexp.last_match[:dynamic])
-          add_static_dependency(render_dependencies, Regexp.last_match[:static])
+          match = Regexp.last_match
+          add_component_dependency(render_dependencies, match[:component])
+          add_dynamic_dependency(render_dependencies, match[:dynamic])
+          add_static_dependency(render_dependencies, match[:static], match[:quote])
         end
       end
 
       def add_component_dependency(dependencies, dependency)
         dependencies << dependency if dependency
+      end
+
+      def add_static_dependency(dependencies, dependency, quote_type)
+        if quote_type == '"'
+          # Ignore if there is interpolation
+          return if dependency.include?('#{')
+        end
+
+        if dependency
+          if dependency.include?("/")
+            dependencies << dependency
+          else
+            dependencies << "#{directory}/#{dependency}"
+          end
+        end
       end
     end
   end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -105,7 +105,7 @@ module ViewComponent
     initializer "view_component.fragment_caching" do |app|
       next unless app.config.view_component.fragment_caching_enabled
 
-      ActionController::Base.view_paths.unshift "app/components"
+      ActionController::Base.view_paths.unshift ViewComponent::Base.view_component_path
 
       if Rails.version.to_f >= 6.1
         Mime::Type.register "text/ruby", :rb

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -105,6 +105,11 @@ module ViewComponent
     initializer "view_component.fragment_caching" do |app|
       next unless app.config.view_component.fragment_caching_enabled
 
+      if Rails.version.to_f < 6.0
+        logger.error "Fragment Caching with ViewComponent is not supported in Rails < 6.0"
+        next
+      end
+
       ActionController::Base.view_paths.unshift ViewComponent::Base.view_component_path
 
       if Rails.version.to_f >= 6.1

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -107,6 +107,10 @@ module ViewComponent
 
       ActionController::Base.view_paths.unshift "app/components"
 
+      if Rails.version.to_f >= 6.1
+        Mime::Type.register "text/ruby", :rb
+      end
+
       ActiveSupport.on_load(:action_view) do
         require "view_component/caching/digestor_monkey_patch"
         require "view_component/caching/erb_tracker"

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -105,6 +105,8 @@ module ViewComponent
     initializer "view_component.fragment_caching" do |app|
       next unless app.config.view_component.fragment_caching_enabled
 
+      ActionController::Base.view_paths.unshift "app/components"
+
       ActiveSupport.on_load(:action_view) do
         require "view_component/caching/digestor_monkey_patch"
         require "view_component/caching/erb_tracker"

--- a/test/support/fragment_caching_helper.rb
+++ b/test/support/fragment_caching_helper.rb
@@ -34,6 +34,10 @@ module FragmentCachingHelper
     )
   end
 
+  def clear_digest_cache!(finder)
+    finder.digest_cache.clear
+  end
+
   def fragment_caching_setup
     # Apply monkey patch to ActionView::Digestor
     ActionView::Digestor.prepend ViewComponent::Caching::DigestorMonkeyPatch

--- a/test/support/fragment_caching_helper.rb
+++ b/test/support/fragment_caching_helper.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "view_component/caching/digestor_monkey_patch"
+require "view_component/caching/erb_tracker"
+require "view_component/caching/component_tracker"
+
+module FragmentCachingHelper
+  def set_tracker(extension, tracker)
+    ActionView::DependencyTracker.remove_tracker ActionView::Template.handler_for_extension(extension)
+    ActionView::DependencyTracker.register_tracker extension, tracker if tracker
+  end
+
+  def find_template(name, finder)
+    finder.find_all(name, [], false, []).first
+  end
+
+  def template_finder
+    ActionView::LookupContext.new(
+      ActionView::PathSet.new([Rails.root.join("app/views")]),
+      formats: [:html]
+    )
+  end
+
+  def component_finder
+    ActionView::LookupContext.new(
+      ActionView::PathSet.new([Rails.root.join("app/components")]),
+      formats: [:rb]
+    )
+  end
+
+  def digest(name, template, finder)
+    ActionView::Digestor.digest(
+      name: name, format: template.format, finder: finder
+    )
+  end
+
+  def fragment_caching_setup
+    # Apply monkey patch to ActionView::Digestor
+    ActionView::Digestor.prepend ViewComponent::Caching::DigestorMonkeyPatch
+
+    Mime::Type.register "text/ruby", :rb
+    set_tracker :erb, ViewComponent::Caching::ERBTracker
+    set_tracker :rb, ViewComponent::Caching::ComponentTracker
+  end
+
+  def fragment_caching_teardown
+    # Reset ActionView::Digestor to it's pre-patched state
+    ActionView.send :remove_const, :Digestor
+    load "action_view/digestor.rb"
+
+    Mime::Type.unregister :rb
+    set_tracker :erb, ActionView::DependencyTracker::ERBTracker
+    set_tracker :rb, nil
+  end
+end

--- a/test/view_component/fragment_caching_test.rb
+++ b/test/view_component/fragment_caching_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "view_component/caching/erb_tracker"
+require "view_component/caching/component_tracker"
+
+class DependencyTrackingTest < ActionDispatch::IntegrationTest
+  def setup
+    Mime::Type.register "text/ruby", :rb
+    set_tracker :erb, ViewComponent::Caching::ERBTracker
+    set_tracker :rb, ViewComponent::Caching::ComponentTracker
+  end
+
+  def teardown
+    Mime::Type.unregister :rb
+    set_tracker :erb, ActionView::DependencyTracker::ERBTracker
+    set_tracker :rb, nil
+  end
+
+  test "finds dependencies of rails templates including components" do
+    name = "integration_examples/partial"
+    template = find_template name, "test/app/views", :html
+
+    dependencies = ActionView::DependencyTracker.find_dependencies name, template
+
+    assert_equal ["integration_examples/test_partial", "PartialComponent"], dependencies
+  end
+
+  test "finds dependencies of components including template files and parent classes" do
+    name = "InheritedWithOwnTemplateComponent"
+    template = find_template name.underscore, "test/app/components", :rb
+
+    dependencies = ActionView::DependencyTracker.find_dependencies name, template
+
+    assert_equal ["inherited_with_own_template_component", "MyComponent"], dependencies
+  end
+
+  private
+
+    def set_tracker(extension, tracker)
+      ActionView::DependencyTracker.remove_tracker ActionView::Template.handler_for_extension(extension)
+      ActionView::DependencyTracker.register_tracker extension, tracker if tracker
+    end
+
+    def find_template(name, path, format)
+      template_finder(path, format).find_all(name, [], false, []).first
+    end
+
+    def template_finder(path, format)
+      ActionView::LookupContext.new(
+        ActionView::PathSet.new([path]),
+        formats: [format]
+      )
+    end
+end

--- a/test/view_component/fragment_caching_test.rb
+++ b/test/view_component/fragment_caching_test.rb
@@ -3,76 +3,78 @@
 require "test_helper"
 require "support/fragment_caching_helper"
 
-class DependencyTrackingTest < ActiveSupport::TestCase
-  include FragmentCachingHelper
+if Rails.version.to_f >= 6.0
+  class DependencyTrackingTest < ActiveSupport::TestCase
+    include FragmentCachingHelper
 
-  def setup
-    fragment_caching_setup
-  end
-
-  def teardown
-    fragment_caching_teardown
-  end
-
-  test "finds dependencies of rails templates including components" do
-    name = "integration_examples/partial"
-    template = find_template name, template_finder
-
-    dependencies = ActionView::DependencyTracker.find_dependencies name, template
-
-    assert_equal ["integration_examples/test_partial", "PartialComponent"], dependencies
-  end
-
-  test "finds dependencies of components including template files and parent classes" do
-    name = "InheritedWithOwnTemplateComponent"
-    template = find_template name.underscore, component_finder
-
-    dependencies = ActionView::DependencyTracker.find_dependencies name, template
-
-    assert_equal ["inherited_with_own_template_component", "MyComponent"], dependencies
-  end
-end
-
-class DigestorTest < ActiveSupport::TestCase
-  include FragmentCachingHelper
-
-  def setup
-    fragment_caching_setup
-  end
-
-  def teardown
-    fragment_caching_teardown
-  end
-
-  test "changes in component class are reflected in rendering view's digest" do
-    name = "integration_examples/partial"
-    finder = template_finder
-    template = find_template name, finder
-
-    first_digest = digest name, template, finder
-
-    clear_digest_cache! finder
-
-    second_digest = modify_file("app/components/partial_component.rb", "# Modified!") do
-      digest name, template, finder
+    def setup
+      fragment_caching_setup
     end
 
-    assert_not_equal first_digest, second_digest
-  end
-
-  test "changes in a component's parent class are reflected in the component's digest" do
-    name = "ChildComponent"
-    finder = component_finder
-    template = find_template name.underscore, finder
-
-    first_digest = digest name, template, finder
-
-    clear_digest_cache! finder
-
-    second_digest = modify_file("app/components/parent_component.rb", "# Modified!") do
-      digest name, template, finder
+    def teardown
+      fragment_caching_teardown
     end
 
-    assert_not_equal first_digest, second_digest
+    test "finds dependencies of rails templates including components" do
+      name = "integration_examples/partial"
+      template = find_template name, template_finder
+
+      dependencies = ActionView::DependencyTracker.find_dependencies name, template
+
+      assert_equal ["integration_examples/test_partial", "PartialComponent"], dependencies
+    end
+
+    test "finds dependencies of components including template files and parent classes" do
+      name = "InheritedWithOwnTemplateComponent"
+      template = find_template name.underscore, component_finder
+
+      dependencies = ActionView::DependencyTracker.find_dependencies name, template
+
+      assert_equal ["inherited_with_own_template_component", "MyComponent"], dependencies
+    end
+  end
+
+  class DigestorTest < ActiveSupport::TestCase
+    include FragmentCachingHelper
+
+    def setup
+      fragment_caching_setup
+    end
+
+    def teardown
+      fragment_caching_teardown
+    end
+
+    test "changes in component class are reflected in rendering view's digest" do
+      name = "integration_examples/partial"
+      finder = template_finder
+      template = find_template name, finder
+
+      first_digest = digest name, template, finder
+
+      clear_digest_cache! finder
+
+      second_digest = modify_file("app/components/partial_component.rb", "# Modified!") do
+        digest name, template, finder
+      end
+
+      assert_not_equal first_digest, second_digest
+    end
+
+    test "changes in a component's parent class are reflected in the component's digest" do
+      name = "ChildComponent"
+      finder = component_finder
+      template = find_template name.underscore, finder
+
+      first_digest = digest name, template, finder
+
+      clear_digest_cache! finder
+
+      second_digest = modify_file("app/components/parent_component.rb", "# Modified!") do
+        digest name, template, finder
+      end
+
+      assert_not_equal first_digest, second_digest
+    end
   end
 end

--- a/test/view_component/fragment_caching_test.rb
+++ b/test/view_component/fragment_caching_test.rb
@@ -51,7 +51,7 @@ class DigestorTest < ActiveSupport::TestCase
 
     first_digest = digest name, template, finder
 
-    finder.digest_cache.clear
+    clear_digest_cache! finder
 
     second_digest = modify_file("app/components/partial_component.rb", "# Modified!") do
       digest name, template, finder
@@ -67,7 +67,7 @@ class DigestorTest < ActiveSupport::TestCase
 
     first_digest = digest name, template, finder
 
-    finder.digest_cache.clear
+    clear_digest_cache! finder
 
     second_digest = modify_file("app/components/parent_component.rb", "# Modified!") do
       digest name, template, finder


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

This is a rough draft POC to explore adding compatibility for Fragment Caching in ViewComponent. 

It makes some modifications to `ActionView::Digestor` and `ActionView::ERBTracker` in order to get **digests** working correctly with components, which means (for example) if you cache a rails view that renders a component inside it and the contents of the component class file change, the digest used in the cache key will be updated and the cached fragment will be correctly invalidated.

Initial notes in issue https://github.com/github/view_component/pull/476#issuecomment-843063274

#### Current state:

- It more or less works :partying_face: (see point two)
- It needs a lot of tests
- It was thrown together with the aim of getting quick results, but the way these ActionView classes are being overridden probably needs a rethink and iterating on before it'll start to look like something acceptable :sweat_smile: 
- Currently works with ERB, but other template engines register dependency trackers in different ways, for example here in the [haml-rails gem](https://github.com/haml/haml-rails/blob/fc6d0ace6e1e24079a6c879129e37a3396b558fd/lib/haml-rails.rb)
