### PR TITLE
Fix helpers not reloading in previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,12 @@ jobs:
       run: |
         bundle config path vendor/bundle
         bundle update
-        bundle exec rake test spec
+        # Code-reloading isn't compatible with simplecov, so we need to run once
+        # to collect coverage, and again to test reloads.
+        MEASURE_COVERAGE=true bundle exec rake test spec
+        ENABLE_RELOADING=true bundle exec rake test spec
       env:
         RAISE_ON_WARNING: 1
-        MEASURE_COVERAGE: true
         RAILS_VERSION: ${{ matrix.rails_version }}
         CAPTURE_PATCH_ENABLED: ${{ matrix.mode == 'capture_patch_enabled' && 'true' || 'false' }}
     - name: Upload coverage results

--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -11,6 +11,10 @@ module ViewComponent
       before_action :require_local!, unless: :show_previews?
 
       content_security_policy(false) if respond_to?(:content_security_policy)
+
+      # Including helpers here ensures that we're loading the
+      # latest version of helpers if code-reloading is enabled
+      helper :all if include_all_helpers
     end
 
     def index

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,17 +10,21 @@ nav_order: 5
 
 ## main
 
+* Fix helpers not reloading in development.
+
+    *Jonathan del Strother*
+
 * Add `SECURITY.md`.
 
-  *Joel Hawksley*
+    *Joel Hawksley*
 
 * Add Ophelos to list of companies using ViewComponent.
 
-   *Graham Rogers*
+    *Graham Rogers*
 
 * Add FlightLogger to list of companies using ViewComponent.
 
-   *Joseph Carpenter*
+    *Joseph Carpenter*
 
 ### v3.0.0
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -19,7 +19,7 @@ module ViewComponent
 
       # Returns the current config.
       #
-      # @return [ViewComponent::Config]
+      # @return [ActiveSupport::OrderedOptions]
       def config
         @config ||= ActiveSupport::OrderedOptions.new
       end

--- a/test/sandbox/app/controllers/default_form_builder_controller.rb
+++ b/test/sandbox/app/controllers/default_form_builder_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class OtherFormBuilder < ActionView::Helpers::FormBuilder
-  def text_field(*)
-    "changed by default form builder"
-  end
-end
-
 class DefaultFormBuilderController < ActionController::Base
+  class OtherFormBuilder < ActionView::Helpers::FormBuilder
+    def text_field(*)
+      "changed by default form builder"
+    end
+  end
+
   default_form_builder OtherFormBuilder
 end

--- a/test/sandbox/app/controllers/integration_examples_controller.rb
+++ b/test/sandbox/app/controllers/integration_examples_controller.rb
@@ -34,6 +34,10 @@ class IntegrationExamplesController < ActionController::Base
     render_component(ControllerInlineComponent.new(message: "bar"))
   end
 
+  def helpers_proxy_component
+    render(plain: render_to_string(HelpersProxyComponent.new))
+  end
+
   def controller_to_string_render_component
     render(plain: render_component_to_string(ControllerInlineComponent.new(message: "bar")))
   end

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -7,6 +7,8 @@ Sandbox::Application.configure do
   # test suite.  You never need to work with it otherwise.  Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs.  Don't rely on the data there!
+
+  # `cache_classes=false` is necessary to test code-reloading for people using VC in development
   config.cache_classes = false
 
   # Show full error reports and disable caching

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -8,8 +8,9 @@ Sandbox::Application.configure do
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs.  Don't rely on the data there!
 
-  # `cache_classes=false` is necessary to test code-reloading for people using VC in development
-  config.cache_classes = false
+  # `cache_classes=false` is necessary to test code-reloading for people using VC in development.
+  # However, it's incompatible with collecting simplecov coverage reports.
+  config.cache_classes = !ENV["ENABLE_RELOADING"]
 
   # Show full error reports and disable caching
   config.consider_all_requests_local = true

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -7,7 +7,7 @@ Sandbox::Application.configure do
   # test suite.  You never need to work with it otherwise.  Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs.  Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Show full error reports and disable caching
   config.consider_all_requests_local = true

--- a/test/sandbox/config/routes.rb
+++ b/test/sandbox/config/routes.rb
@@ -33,4 +33,5 @@ Sandbox::Application.routes.draw do
   constraints(lambda { |request| request.env["warden"].authenticate! }) do
     get :constraints_with_env, to: "integration_examples#index"
   end
+  get :helpers_proxy_component, to: "integration_examples#helpers_proxy_component"
 end

--- a/test/sandbox/test/components/previews/helpers_proxy_component_preview.rb
+++ b/test/sandbox/test/components/previews/helpers_proxy_component_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class HelpersProxyComponentPreview < ViewComponent::Preview
+  def default
+    render(HelpersProxyComponent.new)
+  end
+end

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -52,21 +52,21 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def test_template_changes_are_not_reflected_on_new_request_when_cache_template_loading_is_true
-    # cache_template_loading is set to true on the initializer
+    with_template_caching do
+      get "/controller_inline"
+      assert_select("div", "bar")
+      assert_response :success
 
-    get "/controller_inline"
-    assert_select("div", "bar")
-    assert_response :success
+      modify_file "app/components/controller_inline_component.html.erb", "<div>Goodbye world!</div>" do
+        get "/controller_inline"
+        assert_select("div", "bar")
+        assert_response :success
+      end
 
-    modify_file "app/components/controller_inline_component.html.erb", "<div>Goodbye world!</div>" do
       get "/controller_inline"
       assert_select("div", "bar")
       assert_response :success
     end
-
-    get "/controller_inline"
-    assert_select("div", "bar")
-    assert_response :success
   end
 
   def test_template_changes_are_reflected_on_new_request_when_cache_template_loading_is_false

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -128,6 +128,8 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def test_helper_changes_are_reflected_on_new_request
+    skip if Rails.application.config.cache_classes
+
     get "/helpers_proxy_component"
     assert_select("div", "Hello helper method")
     assert_response :success
@@ -151,6 +153,8 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def test_helper_changes_are_reflected_on_new_request_with_previews
+    skip if Rails.application.config.cache_classes
+
     with_preview_route("/previews") do
       get "/previews/helpers_proxy_component/default"
       assert_select("div", "Hello helper method")

--- a/test/sandbox/test/rake_tasks_test.rb
+++ b/test/sandbox/test/rake_tasks_test.rb
@@ -5,7 +5,9 @@ require "test_helper"
 module ViewComponent
   class RakeTasksTest < TestCase
     def setup
-      Sandbox::Application.load_tasks
+      Kernel.silence_warnings do
+        Sandbox::Application.load_tasks
+      end
     end
 
     def test_statsetup_task

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -419,6 +419,8 @@ class RenderingTest < ViewComponent::TestCase
   def test_compiles_unrendered_component
     skip "this might not still be compiled if it's been reloaded since boot"
     assert UnreferencedComponent.compiled?
+    # Or a possible alternative is booting a fresh process:
+    # assert_equal "true\n", `ruby -r bundler/setup -r ./test/sandbox/config/environment.rb -e "puts UnreferencedComponent.compiled?"`
   end
 
   def test_compiles_components_without_initializers

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -417,10 +417,12 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_compiles_unrendered_component
+    skip "this might not still be compiled if it's been reloaded since boot"
     assert UnreferencedComponent.compiled?
   end
 
   def test_compiles_components_without_initializers
+    MissingInitializerComponent.compile
     assert MissingInitializerComponent.compiled?
   end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -931,8 +931,8 @@ class RenderingTest < ViewComponent::TestCase
     # undo the changes made by self.class.compile and friends, forcing a compile the next time
     # #render_template_for is called. This shouldn't be necessary except in the test environment,
     # since eager loading is turned on here.
-    Object.send(:remove_const, :MyComponent)
-    Object.send(:remove_const, :InheritedWithOwnTemplateComponent)
+    Object.send(:remove_const, :MyComponent) if defined?(MyComponent)
+    Object.send(:remove_const, :InheritedWithOwnTemplateComponent) if defined?(InheritedWithOwnTemplateComponent)
 
     load "test/sandbox/app/components/my_component.rb"
     load "test/sandbox/app/components/inherited_with_own_template_component.rb"

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -417,14 +417,18 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_compiles_unrendered_component
-    skip "this might not still be compiled if it's been reloaded since boot"
+    # The UnreferencedComponent will get compiled at boot,
+    # but that might have been thrown away if code-reloading is enabled
+    skip unless Rails.env.cache_classes?
+
     assert UnreferencedComponent.compiled?
-    # Or a possible alternative is booting a fresh process:
-    # assert_equal "true\n", `ruby -r bundler/setup -r ./test/sandbox/config/environment.rb -e "puts UnreferencedComponent.compiled?"`
   end
 
   def test_compiles_components_without_initializers
-    MissingInitializerComponent.compile
+    # MissingInitializerComponent will get compiled at boot,
+    # but that might have been thrown away if code-reloading is enabled
+    skip unless Rails.env.cache_classes?
+
     assert MissingInitializerComponent.compiled?
   end
 

--- a/test/sandbox/test/tasks_test.rb
+++ b/test/sandbox/test/tasks_test.rb
@@ -4,7 +4,9 @@ require "test_helper"
 
 class TasksTest < ActiveSupport::TestCase
   setup do
-    Rails.application.load_tasks
+    Kernel.silence_warnings do
+      Rails.application.load_tasks
+    end
   end
 
   teardown do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -114,6 +114,15 @@ def with_generate_sidecar(enabled, &block)
   with_generate_option(:sidecar, enabled, &block)
 end
 
+def with_template_caching
+  old_cache_template_loading = ActionView::Base.cache_template_loading
+  ActionView::Base.cache_template_loading = true
+
+  yield
+ensure
+  ActionView::Base.cache_template_loading = old_cache_template_loading
+end
+
 def with_new_cache
   old_cache = ViewComponent::CompileCache.cache
   ViewComponent::CompileCache.cache = Set.new


### PR DESCRIPTION
### Summary

Helpers don't seem to get reloaded when working with component previews (https://github.com/github/view_component/issues/1069).

This PR adds 2 tests.
[One](https://github.com/github/view_component/compare/main...jdelStrother:helper-reloads?expand=1#diff-c7634fb9ae4108c9cbf3eaebf452a2cdd2d87466586cab6923a007f36f6f34d8R86) demonstrating that helpers _are_ successfully reloaded when components are rendered through a 'normal' controller.
[The other](https://github.com/github/view_component/compare/main...jdelStrother:helper-reloads?expand=1#diff-c7634fb9ae4108c9cbf3eaebf452a2cdd2d87466586cab6923a007f36f6f34d8R109) attempts to do the same via `ViewComponentsController#previews`, but the test fails since the helper isn't reloaded.

Unfortunately I had to set `config.cache_classes=false` to get this working, which causes a couple of other test failures. I'm not sure there's a good way to only set that for the two tests I added, unless we want to spawn a brand new test process for them.