### PR TITLE
Feature/multiple templates arguments

### DIFF
--- a/adr/0003-multiple-templates-per-component.md
+++ b/adr/0003-multiple-templates-per-component.md
@@ -1,0 +1,88 @@
+# 1. Allow multiple templates 
+
+Date: 2021-10-13
+
+## Status
+
+Proposed.
+
+## Context
+
+As components become larger (for example, because you are implementing a whole page), it becomes
+useful to be able to extract sections of the view to a different file. ActionView has
+partials, and ViewComponent lacks a similar mechanism. 
+
+ActionView partials have the problem that their interface is not introspectable. Data
+may be passed into the partial via ivars or locals, and it is impossible to know
+which without actually opening up the file. Additionally, partials are globally
+invocable, thus making it difficult to detect if a given partial is in use or not,
+and who are its users.
+
+## Considered Options
+
+* Introduce component partials to components
+* Keep components as-is
+
+### Component partials
+
+Allow multiple ERB templates available within the component, and make it possible to
+invoke them from the main view.Templates are compiled to methods in the format `render_#{template_basename}(locals = {})`
+
+**Pros:**
+* Better performance due to lack of GC pressure and object creation
+* Reduces the number of components needed to express a more complex view.
+* Extracted sections are not exposed outside the component, thus reducing component library API surface.
+
+**Cons:**
+* Another concept for users of ViewComponent to learn and understand.
+* Components are no longer the only way to encapsulate behavior.
+
+### Partial components by [fstaler](https://github.com/fsateler)
+
+In this approach the template arguments are previously defined in the `template_arguments` method
+
+[See here](https://github.com/github/view_component/pull/451):
+
+**Pros:**
+* Better performance due to lack of GC pressure and object creation
+* Reduces the number of components needed to express a more complex view.
+* Extracted sections are not exposed outside the component, thus reducing component library API surface.
+
+**Cons:**
+* Another concept for users of ViewComponent to learn and understand.
+* Components are no longer the only way to encapsulate behavior.
+* `call_foo` api feels awkward and not very Rails like
+* Declare templates and their arguments explicitly before using them
+
+### Keeping components as-is
+
+**Pros:**
+* The API remains simple and components are the only way to encapsulate behavior.
+* Encourages creating reusable sub-components.
+
+**Cons:**
+* Extracting a component results in more GC and intermediate objects.
+* Extracting a component may result in tightly coupled but split components.
+* Creates new public components thus expanding component library API surface.
+
+## Decision
+
+We will allow having multiple templates in the sidecar asset. Each asset will be compiled to
+it's own method `render_<template_name>`. I think it is simple, similar to rails and meets what is expected
+
+## Consequences
+
+This implementation has better performance characteristics over both an extracted component
+and ActionView partials, because it avoids creating intermediate objects, and the overhead of
+creating bindings and `instance_exec`. 
+Having explicit arguments makes the interface explicit.
+
+TODO: The following are consequences of the current approach, but the approach might be extended
+to avoid them:
+
+The interface to render a sidecar partial would be a method call, and depart from the usual 
+`render(*)` interface used in ActionView.
+
+The generated methods cannot have arguments with default values.
+
+The generated methods are public, and thus could be invoked by a third party.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -113,6 +113,10 @@ title: Changelog
 
     *Joel Hawksley*
 
+* Add support for multiple templates.
+
+    *Rob Sterner*, *Joel Hawksley*
+
 ## 2.36.0
 
 * Add `slot_type` helper method.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,10 @@ title: Changelog
 
     *Hans Lemuet*
 
+* Add support for multiple templates.
+
+    *Rob Sterner*, *Joel Hawksley*
+
 ## 2.40.0
 
 * Replace antipatterns section in the documentation with best practices.
@@ -112,10 +116,6 @@ title: Changelog
 * Run benchmarks in CI.
 
     *Joel Hawksley*
-
-* Add support for multiple templates.
-
-    *Rob Sterner*, *Joel Hawksley*
 
 ## 2.36.0
 

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -92,3 +92,36 @@ Component subclasses inherit the parent component's template if they don't defin
 class MyLinkComponent < LinkComponent
 end
 ```
+
+#### Multiple templates
+
+ViewComponents can render multiple templates defined in the sidecar directory:
+
+```
+app/components
+├── ...
+├── test_component.rb
+├── test_component
+|   ├── list.html.erb
+|   └── summary.html.erb
+├── ...
+```
+
+Templates are compiled to methods in the format `call_#{template_basename}`, which can then be called in the component.
+
+```ruby
+class TestComponent < ViewComponent::Base
+  def initialize(mode:)
+    @mode = mode
+  end
+
+  def call
+    case @mode
+    when :list
+      call_list
+    when :summary
+      call_summary
+    end
+  end
+end
+```

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -93,11 +93,11 @@ class MyLinkComponent < LinkComponent
 end
 ```
 
-#### Multiple templates
+## Multiple templates with arguments
 
-ViewComponents can render multiple templates defined in the sidecar directory:
+ViewComponents can render multiple templates defined in the sidecar directory and send arguments to it:
 
-```
+```console
 app/components
 ├── ...
 ├── test_component.rb
@@ -107,7 +107,7 @@ app/components
 ├── ...
 ```
 
-Templates are compiled to methods in the format `call_#{template_basename}`, which can then be called in the component.
+Templates are compiled to methods in the format `render_#{template_basename}(locals = {})`, which can then be called in the component.
 
 ```ruby
 class TestComponent < ViewComponent::Base
@@ -118,9 +118,9 @@ class TestComponent < ViewComponent::Base
   def call
     case @mode
     when :list
-      call_list
+      render_list number: 1
     when :summary
-      call_summary
+      render_summary string: "foo"
     end
   end
 end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -331,7 +331,7 @@ module ViewComponent
         # view files in the same directory as the component
         sidecar_files = Dir["#{directory}/#{component_name}.*{#{extensions}}"]
 
-        sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
+        sidecar_directory_files = Dir["#{directory}/#{component_name}/*.*{#{extensions}}"]
 
         (sidecar_files - [source_location] + sidecar_directory_files + nested_component_files).uniq
       end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -50,20 +50,22 @@ module ViewComponent
           # set the method name with call_method_name
           if pieces.first == component_class.name.demodulize.underscore
             call_method_name(template[:variant])
-          # Otherwise, append the name of the template to
-          # call_method_name
+          # Otherwise, append the name of the template to render_
           else
-            "#{call_method_name(template[:variant])}_#{pieces.first.to_sym}"
+            "render_#{pieces.first.to_sym}"
           end
 
         if component_class.instance_methods.include?(method_name.to_sym)
           component_class.send(:undef_method, method_name.to_sym)
         end
 
-        component_class.class_eval <<-RUBY, template[:path], -1
-          def #{method_name}
+        component_class.class_eval <<-RUBY, template[:path], -2
+          def #{method_name}(**locals)
+            old_buffer = @output_buffer if defined? @output_buffer
             @output_buffer = ActionView::OutputBuffer.new
             #{compiled_template(template[:path])}
+          ensure
+            @output_buffer = old_buffer
           end
         RUBY
       end

--- a/test/sandbox/app/components/multiple_templates_component.rb
+++ b/test/sandbox/app/components/multiple_templates_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class MultipleTemplatesComponent < ViewComponent::Base
+  def initialize(mode:)
+    @mode = mode
+
+    @items = ["Apple", "Banana", "Pear"]
+  end
+
+  def call
+    case @mode
+    when :list
+      call_list
+    when :summary
+      call_summary
+    end
+  end
+end

--- a/test/sandbox/app/components/multiple_templates_component.rb
+++ b/test/sandbox/app/components/multiple_templates_component.rb
@@ -1,18 +1,7 @@
 # frozen_string_literal: true
 
 class MultipleTemplatesComponent < ViewComponent::Base
-  def initialize(mode:)
-    @mode = mode
-
+  def initialize
     @items = ["Apple", "Banana", "Pear"]
-  end
-
-  def call
-    case @mode
-    when :list
-      call_list
-    when :summary
-      call_summary
-    end
   end
 end

--- a/test/sandbox/app/components/multiple_templates_component/list.html.erb
+++ b/test/sandbox/app/components/multiple_templates_component/list.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <% @items.each do |item| %>
+    <li><%= item %></li>
+  <% end %>
+</ul>

--- a/test/sandbox/app/components/multiple_templates_component/list.html.erb
+++ b/test/sandbox/app/components/multiple_templates_component/list.html.erb
@@ -1,4 +1,4 @@
-<ul>
+<ul data-number="<%= locals[:number] %>">
   <% @items.each do |item| %>
     <li><%= item %></li>
   <% end %>

--- a/test/sandbox/app/components/multiple_templates_component/multiple_templates_component.html.erb
+++ b/test/sandbox/app/components/multiple_templates_component/multiple_templates_component.html.erb
@@ -1,0 +1,4 @@
+<div class="container">
+  <%= render_summary string: "foo" %>
+  <%= render_list number: 1 %>
+</div>

--- a/test/sandbox/app/components/multiple_templates_component/summary.html.erb
+++ b/test/sandbox/app/components/multiple_templates_component/summary.html.erb
@@ -1,0 +1,1 @@
+<div>The items are: <%= @items.to_sentence %></div>

--- a/test/sandbox/app/components/multiple_templates_component/summary.html.erb
+++ b/test/sandbox/app/components/multiple_templates_component/summary.html.erb
@@ -1,1 +1,1 @@
-<div>The items are: <%= @items.to_sentence %></div>
+<div>The items are: <%= @items.to_sentence %>, <%= locals[:string] %></div>

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -777,15 +777,14 @@ class ViewComponentTest < ViewComponent::TestCase
   end
 
   def test_render_multiple_templates
-    render_inline(MultipleTemplatesComponent.new(mode: :list))
+    render_inline(MultipleTemplatesComponent.new)
 
+    assert_selector("div", text: "The items are: Apple, Banana, and Pear, foo")
     assert_selector("li", text: "Apple")
     assert_selector("li", text: "Banana")
     assert_selector("li", text: "Pear")
 
-    render_inline(MultipleTemplatesComponent.new(mode: :summary))
-
-    assert_selector("div", text: "Apple, Banana, and Pear")
+    assert_selector("div.container")
   end
 
   def test_renders_component_using_rails_config
@@ -899,18 +898,5 @@ class ViewComponentTest < ViewComponent::TestCase
     render_inline(AfterRenderComponent.new)
 
     assert_text("Hello, World!")
-  end
-
-  private
-
-  def modify_file(file, content)
-    filename = Rails.root.join(file)
-    old_content = File.read(filename)
-    begin
-      File.open(filename, "wb+") { |f| f.write(content) }
-      yield
-    ensure
-      File.open(filename, "wb+") { |f| f.write(old_content) }
-    end
   end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -776,6 +776,18 @@ class ViewComponentTest < ViewComponent::TestCase
     assert_match(/ProductReaderOopsComponent initializer is empty or invalid/, exception.message)
   end
 
+  def test_render_multiple_templates
+    render_inline(MultipleTemplatesComponent.new(mode: :list))
+
+    assert_selector("li", text: "Apple")
+    assert_selector("li", text: "Banana")
+    assert_selector("li", text: "Pear")
+
+    render_inline(MultipleTemplatesComponent.new(mode: :summary))
+
+    assert_selector("div", text: "Apple, Banana, and Pear")
+  end
+
   def test_renders_component_using_rails_config
     render_inline(RailsConfigComponent.new)
 
@@ -887,5 +899,18 @@ class ViewComponentTest < ViewComponent::TestCase
     render_inline(AfterRenderComponent.new)
 
     assert_text("Hello, World!")
+  end
+
+  private
+
+  def modify_file(file, content)
+    filename = Rails.root.join(file)
+    old_content = File.read(filename)
+    begin
+      File.open(filename, "wb+") { |f| f.write(content) }
+      yield
+    ensure
+      File.open(filename, "wb+") { |f| f.write(old_content) }
+    end
   end
 end


### PR DESCRIPTION
Summary
Fixes #387

This PR builds on the branch by @joelhawksley, @fermion, @fsateler and adds the ability to specify arguments for the generated functions, based on what was discussed https://github.com/github/view_component/issues/387#issuecomment-926668950. In this PR:

1- Each template would define a method called `render_<template_name>(locals = {})`
2- We will not be defining the locals inside the generated method like rails does. They would need to be accessed with locals[:foo]

The logic being that one may want to use templates to extract sections, without wanting to build a full component. For example, I could have a Table component, and I would want to have the row definition in a sidecar template. This requires being able to pass in each item for every iteration:
```ruby
class TableComponent < ViewComponent::Base
  def initialize(models)
    @models = models
  end
end
```
```erb
<%# table_component.html.erb %>
<table>
  <% @models.each do |model| %>
    <%= render_row model: model %>
  <% end %>
</table>
```
```erb
<%# row.html.erb %>
<tr>
  <%# I can use `model` here %>
  <td><%= locals[:model].name  %></td>
</tr>
```

