### PR TITLE
Extract ViewComponent::Core class

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ namespace :docs do
       meths.
       select do |method|
         !method.tag(:private) &&
-          method.path.include?("ViewComponent::Base") &&
+          method.path.match?("ViewComponent::(Base|Core)") &&
           method.visibility == :public
       end.sort_by { |method| method[:name] }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Extract `ViewComponent::Core` class from `ViewComponent::Base`.
+
+    *Blake Williams*
+
 * Fix bug where calling lambda slots without arguments would break in Ruby < 2.7.
 
     *Manuel Puyol*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -72,8 +72,6 @@ module ViewComponent
       @request ||= controller.request if controller.respond_to?(:request)
     end
 
-    private
-
     # Set the controller used for testing components:
     #
     #     config.view_component.test_controller = "MyTestController"

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -72,6 +72,8 @@ module ViewComponent
       @request ||= controller.request if controller.respond_to?(:request)
     end
 
+    private # rubocop:disable Lint/UselessAccessModifier
+
     # Set the controller used for testing components:
     #
     #     config.view_component.test_controller = "MyTestController"

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -2,146 +2,22 @@
 
 require "action_view"
 require "active_support/configurable"
-require "view_component/collection"
-require "view_component/compile_cache"
+require "view_component/core"
 require "view_component/content_areas"
-require "view_component/previewable"
 require "view_component/slotable"
 require "view_component/slotable_v2"
-require "view_component/with_content_helper"
 
 module ViewComponent
-  class Base < ActionView::Base
-    include ActiveSupport::Configurable
+  class Base < Core
     include ViewComponent::ContentAreas
-    include ViewComponent::Previewable
     include ViewComponent::SlotableV2
-    include ViewComponent::WithContentHelper
-
-    ViewContextCalledBeforeRenderError = Class.new(StandardError)
-
-    RESERVED_PARAMETER = :content
-
-    # For CSRF authenticity tokens in forms
-    delegate :form_authenticity_token, :protect_against_forgery?, :config, to: :helpers
+    include ActiveSupport::Configurable
 
     class_attribute :content_areas
     self.content_areas = [] # class_attribute:default doesn't work until Rails 5.2
 
-    attr_accessor :original_view_context
-
-    # EXPERIMENTAL: This API is experimental and may be removed at any time.
-    # Hook for allowing components to do work as part of the compilation process.
-    #
-    # For example, one might compile component-specific assets at this point.
-    # @private TODO: add documentation
-    def self._after_compile
-      # noop
-    end
-
-    # Entrypoint for rendering components.
-    #
-    # - `view_context`: ActionView context from calling view
-    # - `block`: optional block to be captured within the view context
-    #
-    # Returns HTML that has been escaped by the respective template handler.
-    #
-    # @return [String]
-    def render_in(view_context, &block)
-      self.class.compile(raise_errors: true)
-
-      @view_context = view_context
-      self.original_view_context ||= view_context
-
-      @lookup_context ||= view_context.lookup_context
-
-      # required for path helpers in older Rails versions
-      @view_renderer ||= view_context.view_renderer
-
-      # For content_for
-      @view_flow ||= view_context.view_flow
-
-      # For i18n
-      @virtual_path ||= virtual_path
-
-      # For template variants (+phone, +desktop, etc.)
-      @__vc_variant ||= @lookup_context.variants.first
-
-      # For caching, such as #cache_if
-      @current_template = nil unless defined?(@current_template)
-      old_current_template = @current_template
-      @current_template = self
-
-      if block && defined?(@__vc_content_set_by_with_content)
-        raise ArgumentError.new(
-          "It looks like a block was provided after calling `with_content` on #{self.class.name}, " \
-          "which means that ViewComponent doesn't know which content to use.\n\n" \
-          "To fix this issue, use either `with_content` or a block."
-        )
-      end
-
-      @__vc_content_evaluated = false
-      @__vc_render_in_block = block
-
-      before_render
-
-      if render?
-        render_template_for(@__vc_variant).to_s + _output_postamble
-      else
-        ""
-      end
-    ensure
-      @current_template = old_current_template
-    end
-
-    # EXPERIMENTAL: Optional content to be returned after the rendered template.
-    #
-    # @return [String]
-    def _output_postamble
-      ""
-    end
-
-    # Called before rendering the component. Override to perform operations that
-    # depend on having access to the view context, such as helpers.
-    #
-    # @return [void]
-    def before_render
-      before_render_check
-    end
-
-    # Called after rendering the component.
-    #
-    # @deprecated Use `#before_render` instead. Will be removed in v3.0.0.
-    # @return [void]
-    def before_render_check
-      # noop
-    end
-
-    # Override to determine whether the ViewComponent should render.
-    #
-    # @return [Boolean]
-    def render?
-      true
-    end
-
-    # @private
-    def initialize(*); end
-
-    # Re-use original view_context if we're not rendering a component.
-    #
-    # This prevents an exception when rendering a partial inside of a component that has also been rendered outside
-    # of the component. This is due to the partials compiled template method existing in the parent `view_context`,
-    #  and not the component's `view_context`.
-    #
-    # @private
-    def render(options = {}, args = {}, &block)
-      if options.is_a? ViewComponent::Base
-        options.original_view_context = original_view_context
-        super
-      else
-        original_view_context.render(options, args, &block)
-      end
-    end
+    # For CSRF authenticity tokens in forms
+    delegate :form_authenticity_token, :protect_against_forgery?, :config, to: :helpers
 
     # The current controller. Use sparingly as doing so introduces coupling
     # that inhibits encapsulation & reuse, often making testing difficult.
@@ -188,44 +64,6 @@ module ViewComponent
       @__vc_helpers ||= original_view_context || controller.view_context
     end
 
-    # Exposes .virtual_path as an instance method
-    #
-    # @private
-    def virtual_path
-      self.class.virtual_path
-    end
-
-    # For caching, such as #cache_if
-    # @private
-    def view_cache_dependencies
-      []
-    end
-
-    # For caching, such as #cache_if
-    #
-    # @private
-    def format
-      # Ruby 2.6 throws a warning without checking `defined?`, 2.7 does not
-      if defined?(@__vc_variant)
-        @__vc_variant
-      end
-    end
-
-    # Use the provided variant instead of the one determined by the current request.
-    #
-    # @deprecated Will be removed in v3.0.0.
-    # @param variant [Symbol] The variant to be used by the component.
-    # @return [self]
-    def with_variant(variant)
-      ActiveSupport::Deprecation.warn(
-        "`with_variant` is deprecated and will be removed in ViewComponent v3.0.0."
-      )
-
-      @__vc_variant = variant
-
-      self
-    end
-
     # The current request. Use sparingly as doing so introduces coupling that
     # inhibits encapsulation & reuse, often making testing difficult.
     #
@@ -235,24 +73,6 @@ module ViewComponent
     end
 
     private
-
-    attr_reader :view_context
-
-    def content
-      @__vc_content_evaluated = true
-      return @__vc_content if defined?(@__vc_content)
-
-      @__vc_content =
-        if @view_context && @__vc_render_in_block
-          view_context.capture(self, &@__vc_render_in_block)
-        elsif defined?(@__vc_content_set_by_with_content)
-          @__vc_content_set_by_with_content
-        end
-    end
-
-    def content_evaluated?
-      @__vc_content_evaluated
-    end
 
     # Set the controller used for testing components:
     #
@@ -303,226 +123,14 @@ module ViewComponent
 
     class << self
       # @private
-      attr_accessor :source_location, :virtual_path
-
-      # EXPERIMENTAL: This API is experimental and may be removed at any time.
-      # Find sidecar files for the given extensions.
-      #
-      # The provided array of extensions is expected to contain
-      # strings starting without the "dot", example: `["erb", "haml"]`.
-      #
-      # For example, one might collect sidecar CSS files that need to be compiled.
-      # @private TODO: add documentation
-      def _sidecar_files(extensions)
-        return [] unless source_location
-
-        extensions = extensions.join(",")
-
-        # view files in a directory named like the component
-        directory = File.dirname(source_location)
-        filename = File.basename(source_location, ".rb")
-        component_name = name.demodulize.underscore
-
-        # Add support for nested components defined in the same file.
-        #
-        # e.g.
-        #
-        # class MyComponent < ViewComponent::Base
-        #   class MyOtherComponent < ViewComponent::Base
-        #   end
-        # end
-        #
-        # Without this, `MyOtherComponent` will not look for `my_component/my_other_component.html.erb`
-        nested_component_files =
-          if name.include?("::") && component_name != filename
-            Dir["#{directory}/#{filename}/#{component_name}.*{#{extensions}}"]
-          else
-            []
-          end
-
-        # view files in the same directory as the component
-        sidecar_files = Dir["#{directory}/#{component_name}.*{#{extensions}}"]
-
-        sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
-
-        (sidecar_files - [source_location] + sidecar_directory_files + nested_component_files).uniq
-      end
-
-      # Render a component for each element in a collection ([documentation](/guide/collections)):
-      #
-      #     render(ProductsComponent.with_collection(@products, foo: :bar))
-      #
-      # @param collection [Enumerable] A list of items to pass the ViewComponent one at a time.
-      # @param args [Arguments] Arguments to pass to the ViewComponent every time.
-      def with_collection(collection, **args)
-        Collection.new(self, collection, **args)
-      end
-
-      # Provide identifier for ActionView template annotations
-      #
-      # @private
-      def short_identifier
-        @short_identifier ||= defined?(Rails.root) ? source_location.sub("#{Rails.root}/", "") : source_location
-      end
-
-      # @private
       def inherited(child)
-        # Compile so child will inherit compiled `call_*` template methods that
-        # `compile` defines
-        compile
-
         # If Rails application is loaded, add application url_helpers to the component context
         # we need to check this to use this gem as a dependency
         if defined?(Rails) && Rails.application
           child.include Rails.application.routes.url_helpers unless child < Rails.application.routes.url_helpers
         end
 
-        # Derive the source location of the component Ruby file from the call stack.
-        # We need to ignore `inherited` frames here as they indicate that `inherited`
-        # has been re-defined by the consuming application, likely in ApplicationComponent.
-        child.source_location = caller_locations(1, 10).reject { |l| l.label == "inherited" }[0].absolute_path
-
-        # Removes the first part of the path and the extension.
-        child.virtual_path = child.source_location.gsub(
-          %r{(.*#{Regexp.quote(ViewComponent::Base.view_component_path)})|(\.rb)}, ""
-        )
-
-        # Set collection parameter to the extended component
-        child.with_collection_parameter provided_collection_parameter
-
         super
-      end
-
-      # @private
-      def compiled?
-        compiler.compiled?
-      end
-
-      # Compile templates to instance methods, assuming they haven't been compiled already.
-      #
-      # Do as much work as possible in this step, as doing so reduces the amount
-      # of work done each time a component is rendered.
-      # @private
-      def compile(raise_errors: false)
-        compiler.compile(raise_errors: raise_errors)
-      end
-
-      # @private
-      def compiler
-        @__vc_compiler ||= Compiler.new(self)
-      end
-
-      # we'll eventually want to update this to support other types
-      # @private
-      def type
-        "text/html"
-      end
-
-      # @private
-      def format
-        :html
-      end
-
-      # @private
-      def identifier
-        source_location
-      end
-
-      # Set the parameter name used when rendering elements of a collection ([documentation](/guide/collections)):
-      #
-      #     with_collection_parameter :item
-      #
-      # @param parameter [Symbol] The parameter name used when rendering elements of a collection.
-      def with_collection_parameter(parameter)
-        @provided_collection_parameter = parameter
-      end
-
-      # Ensure the component initializer accepts the
-      # collection parameter. By default, we do not
-      # validate that the default parameter name
-      # is accepted, as support for collection
-      # rendering is optional.
-      # @private TODO: add documentation
-      def validate_collection_parameter!(validate_default: false)
-        parameter = validate_default ? collection_parameter : provided_collection_parameter
-
-        return unless parameter
-        return if initialize_parameter_names.include?(parameter)
-
-        # If Ruby cannot parse the component class, then the initalize
-        # parameters will be empty and ViewComponent will not be able to render
-        # the component.
-        if initialize_parameters.empty?
-          raise ArgumentError.new(
-            "The #{self} initializer is empty or invalid." \
-            "It must accept the parameter `#{parameter}` to render it as a collection.\n\n" \
-            "To fix this issue, update the initializer to accept `#{parameter}`.\n\n" \
-            "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
-          )
-        end
-
-        raise ArgumentError.new(
-          "The initializer for #{self} does not accept the parameter `#{parameter}`, " \
-          "which is required in order to render it as a collection.\n\n" \
-          "To fix this issue, update the initializer to accept `#{parameter}`.\n\n" \
-          "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
-        )
-      end
-
-      # Ensure the component initializer does not define
-      # invalid parameters that could override the framework's
-      # methods.
-      # @private TODO: add documentation
-      def validate_initialization_parameters!
-        return unless initialize_parameter_names.include?(RESERVED_PARAMETER)
-
-        raise ViewComponent::ComponentError.new(
-          "#{self} initializer cannot accept the parameter `#{RESERVED_PARAMETER}`, as it will override a " \
-          "public ViewComponent method. To fix this issue, rename the parameter."
-        )
-      end
-
-      # @private
-      def collection_parameter
-        if provided_collection_parameter
-          provided_collection_parameter
-        else
-          name && name.demodulize.underscore.chomp("_component").to_sym
-        end
-      end
-
-      # @private
-      def collection_counter_parameter
-        "#{collection_parameter}_counter".to_sym
-      end
-
-      # @private
-      def counter_argument_present?
-        initialize_parameter_names.include?(collection_counter_parameter)
-      end
-
-      # @private
-      def collection_iteration_parameter
-        "#{collection_parameter}_iteration".to_sym
-      end
-
-      # @private
-      def iteration_argument_present?
-        initialize_parameter_names.include?(collection_iteration_parameter)
-      end
-
-      private
-
-      def initialize_parameter_names
-        initialize_parameters.map(&:last)
-      end
-
-      def initialize_parameters
-        instance_method(:initialize).parameters
-      end
-
-      def provided_collection_parameter
-        @provided_collection_parameter ||= nil
       end
     end
 

--- a/lib/view_component/core.rb
+++ b/lib/view_component/core.rb
@@ -16,8 +16,6 @@ module ViewComponent
 
     RESERVED_PARAMETER = :content
 
-    attr_accessor :original_view_context
-
     # EXPERIMENTAL: This API is experimental and may be removed at any time.
     # Hook for allowing components to do work as part of the compilation process.
     #
@@ -410,5 +408,9 @@ module ViewComponent
         @provided_collection_parameter ||= nil
       end
     end
+
+    protected
+
+    attr_accessor :original_view_context
   end
 end

--- a/lib/view_component/core.rb
+++ b/lib/view_component/core.rb
@@ -1,0 +1,414 @@
+# frozen_string_literal: true
+
+require "action_view"
+require "view_component/collection"
+require "view_component/compile_cache"
+require "view_component/previewable"
+require "view_component/with_content_helper"
+
+module ViewComponent
+  # @private
+  class Core < ActionView::Base
+    include ViewComponent::Previewable
+    include ViewComponent::WithContentHelper
+
+    ViewContextCalledBeforeRenderError = Class.new(StandardError)
+
+    RESERVED_PARAMETER = :content
+
+    attr_accessor :original_view_context
+
+    # EXPERIMENTAL: This API is experimental and may be removed at any time.
+    # Hook for allowing components to do work as part of the compilation process.
+    #
+    # For example, one might compile component-specific assets at this point.
+    # @private TODO: add documentation
+    def self._after_compile
+      # noop
+    end
+
+    # Entrypoint for rendering components.
+    #
+    # - `view_context`: ActionView context from calling view
+    # - `block`: optional block to be captured within the view context
+    #
+    # Returns HTML that has been escaped by the respective template handler.
+    #
+    # @return [String]
+    def render_in(view_context, &block)
+      self.class.compile(raise_errors: true)
+
+      @view_context = view_context
+      self.original_view_context ||= view_context
+
+      @lookup_context ||= view_context.lookup_context
+
+      # required for path helpers in older Rails versions
+      @view_renderer ||= view_context.view_renderer
+
+      # For content_for
+      @view_flow ||= view_context.view_flow
+
+      # For i18n
+      @virtual_path ||= virtual_path
+
+      # For template variants (+phone, +desktop, etc.)
+      @__vc_variant ||= @lookup_context.variants.first
+
+      # For caching, such as #cache_if
+      @current_template = nil unless defined?(@current_template)
+      old_current_template = @current_template
+      @current_template = self
+
+      if block && defined?(@__vc_content_set_by_with_content)
+        raise ArgumentError.new(
+          "It looks like a block was provided after calling `with_content` on #{self.class.name}, " \
+          "which means that ViewComponent doesn't know which content to use.\n\n" \
+          "To fix this issue, use either `with_content` or a block."
+        )
+      end
+
+      @__vc_content_evaluated = false
+      @__vc_render_in_block = block
+
+      before_render
+
+      if render?
+        render_template_for(@__vc_variant).to_s + _output_postamble
+      else
+        ""
+      end
+    ensure
+      @current_template = old_current_template
+    end
+
+    # EXPERIMENTAL: Optional content to be returned after the rendered template.
+    #
+    # @return [String]
+    def _output_postamble
+      ""
+    end
+
+    # Called before rendering the component. Override to perform operations that
+    # depend on having access to the view context, such as helpers.
+    #
+    # @return [void]
+    def before_render
+      before_render_check
+    end
+
+    # Called after rendering the component.
+    #
+    # @deprecated Use `#before_render` instead. Will be removed in v3.0.0.
+    # @return [void]
+    def before_render_check
+      # noop
+    end
+
+    # Override to determine whether the ViewComponent should render.
+    #
+    # @return [Boolean]
+    def render?
+      true
+    end
+
+    # @private
+    def initialize(*); end
+
+    # Re-use original view_context if we're not rendering a component.
+    #
+    # This prevents an exception when rendering a partial inside of a component that has also been rendered outside
+    # of the component. This is due to the partials compiled template method existing in the parent `view_context`,
+    #  and not the component's `view_context`.
+    #
+    # @private
+    def render(options = {}, args = {}, &block)
+      if options.is_a? ViewComponent::Base
+        options.original_view_context = original_view_context
+        super
+      else
+        original_view_context.render(options, args, &block)
+      end
+    end
+
+    # Exposes .virtual_path as an instance method
+    #
+    # @private
+    def virtual_path
+      self.class.virtual_path
+    end
+
+    # For caching, such as #cache_if
+    # @private
+    def view_cache_dependencies
+      []
+    end
+
+    # For caching, such as #cache_if
+    #
+    # @private
+    def format
+      # Ruby 2.6 throws a warning without checking `defined?`, 2.7 does not
+      if defined?(@__vc_variant)
+        @__vc_variant
+      end
+    end
+
+    # Use the provided variant instead of the one determined by the current request.
+    #
+    # @deprecated Will be removed in v3.0.0.
+    # @param variant [Symbol] The variant to be used by the component.
+    # @return [self]
+    def with_variant(variant)
+      ActiveSupport::Deprecation.warn(
+        "`with_variant` is deprecated and will be removed in ViewComponent v3.0.0."
+      )
+
+      @__vc_variant = variant
+
+      self
+    end
+
+    private
+
+    attr_reader :view_context
+
+    def content
+      @__vc_content_evaluated = true
+      return @__vc_content if defined?(@__vc_content)
+
+      @__vc_content =
+        if @view_context && @__vc_render_in_block
+          view_context.capture(self, &@__vc_render_in_block)
+        elsif defined?(@__vc_content_set_by_with_content)
+          @__vc_content_set_by_with_content
+        end
+    end
+
+    def content_evaluated?
+      @__vc_content_evaluated
+    end
+
+    class << self
+      # @private
+      attr_accessor :source_location, :virtual_path
+
+      # EXPERIMENTAL: This API is experimental and may be removed at any time.
+      # Find sidecar files for the given extensions.
+      #
+      # The provided array of extensions is expected to contain
+      # strings starting without the "dot", example: `["erb", "haml"]`.
+      #
+      # For example, one might collect sidecar CSS files that need to be compiled.
+      # @private TODO: add documentation
+      def _sidecar_files(extensions)
+        return [] unless source_location
+
+        extensions = extensions.join(",")
+
+        # view files in a directory named like the component
+        directory = File.dirname(source_location)
+        filename = File.basename(source_location, ".rb")
+        component_name = name.demodulize.underscore
+
+        # Add support for nested components defined in the same file.
+        #
+        # e.g.
+        #
+        # class MyComponent < ViewComponent::Base
+        #   class MyOtherComponent < ViewComponent::Base
+        #   end
+        # end
+        #
+        # Without this, `MyOtherComponent` will not look for `my_component/my_other_component.html.erb`
+        nested_component_files =
+          if name.include?("::") && component_name != filename
+            Dir["#{directory}/#{filename}/#{component_name}.*{#{extensions}}"]
+          else
+            []
+          end
+
+        # view files in the same directory as the component
+        sidecar_files = Dir["#{directory}/#{component_name}.*{#{extensions}}"]
+
+        sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
+
+        (sidecar_files - [source_location] + sidecar_directory_files + nested_component_files).uniq
+      end
+
+      # Render a component for each element in a collection ([documentation](/guide/collections)):
+      #
+      #     render(ProductsComponent.with_collection(@products, foo: :bar))
+      #
+      # @param collection [Enumerable] A list of items to pass the ViewComponent one at a time.
+      # @param args [Arguments] Arguments to pass to the ViewComponent every time.
+      def with_collection(collection, **args)
+        Collection.new(self, collection, **args)
+      end
+
+      # Provide identifier for ActionView template annotations
+      #
+      # @private
+      def short_identifier
+        @short_identifier ||= defined?(Rails.root) ? source_location.sub("#{Rails.root}/", "") : source_location
+      end
+
+      # @private
+      def inherited(child)
+        # Ignore the base class inheritance case
+        return if child == Base
+
+        # Compile so child will inherit compiled `call_*` template methods that
+        # `compile` defines
+        compile
+
+        # Derive the source location of the component Ruby file from the call stack.
+        # We need to ignore `inherited` frames here as they indicate that `inherited`
+        # has been re-defined by the consuming application, likely in ApplicationComponent.
+        child.source_location = caller_locations(1, 10).reject { |l| l.label == "inherited" }[0].absolute_path
+
+        # Removes the first part of the path and the extension.
+        child.virtual_path = child.source_location.gsub(
+          %r{(.*#{Regexp.quote(ViewComponent::Base.view_component_path)})|(\.rb)}, ""
+        )
+
+        # Set collection parameter to the extended component
+        child.with_collection_parameter provided_collection_parameter
+
+        super
+      end
+
+      # @private
+      def compiled?
+        compiler.compiled?
+      end
+
+      # Compile templates to instance methods, assuming they haven't been compiled already.
+      #
+      # Do as much work as possible in this step, as doing so reduces the amount
+      # of work done each time a component is rendered.
+      # @private
+      def compile(raise_errors: false)
+        compiler.compile(raise_errors: raise_errors)
+      end
+
+      # @private
+      def compiler
+        @__vc_compiler ||= Compiler.new(self)
+      end
+
+      # we'll eventually want to update this to support other types
+      # @private
+      def type
+        "text/html"
+      end
+
+      # @private
+      def format
+        :html
+      end
+
+      # @private
+      def identifier
+        source_location
+      end
+
+      # Set the parameter name used when rendering elements of a collection ([documentation](/guide/collections)):
+      #
+      #     with_collection_parameter :item
+      #
+      # @param parameter [Symbol] The parameter name used when rendering elements of a collection.
+      def with_collection_parameter(parameter)
+        @provided_collection_parameter = parameter
+      end
+
+      # Ensure the component initializer accepts the
+      # collection parameter. By default, we do not
+      # validate that the default parameter name
+      # is accepted, as support for collection
+      # rendering is optional.
+      # @private TODO: add documentation
+      def validate_collection_parameter!(validate_default: false)
+        parameter = validate_default ? collection_parameter : provided_collection_parameter
+
+        return unless parameter
+        return if initialize_parameter_names.include?(parameter)
+
+        # If Ruby cannot parse the component class, then the initalize
+        # parameters will be empty and ViewComponent will not be able to render
+        # the component.
+        if initialize_parameters.empty?
+          raise ArgumentError.new(
+            "The #{self} initializer is empty or invalid." \
+            "It must accept the parameter `#{parameter}` to render it as a collection.\n\n" \
+            "To fix this issue, update the initializer to accept `#{parameter}`.\n\n" \
+            "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
+          )
+        end
+
+        raise ArgumentError.new(
+          "The initializer for #{self} does not accept the parameter `#{parameter}`, " \
+          "which is required in order to render it as a collection.\n\n" \
+          "To fix this issue, update the initializer to accept `#{parameter}`.\n\n" \
+          "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
+        )
+      end
+
+      # Ensure the component initializer does not define
+      # invalid parameters that could override the framework's
+      # methods.
+      # @private TODO: add documentation
+      def validate_initialization_parameters!
+        return unless initialize_parameter_names.include?(RESERVED_PARAMETER)
+
+        raise ViewComponent::ComponentError.new(
+          "#{self} initializer cannot accept the parameter `#{RESERVED_PARAMETER}`, as it will override a " \
+          "public ViewComponent method. To fix this issue, rename the parameter."
+        )
+      end
+
+      # @private
+      def collection_parameter
+        if provided_collection_parameter
+          provided_collection_parameter
+        else
+          name && name.demodulize.underscore.chomp("_component").to_sym
+        end
+      end
+
+      # @private
+      def collection_counter_parameter
+        "#{collection_parameter}_counter".to_sym
+      end
+
+      # @private
+      def counter_argument_present?
+        initialize_parameter_names.include?(collection_counter_parameter)
+      end
+
+      # @private
+      def collection_iteration_parameter
+        "#{collection_parameter}_iteration".to_sym
+      end
+
+      # @private
+      def iteration_argument_present?
+        initialize_parameter_names.include?(collection_iteration_parameter)
+      end
+
+      private
+
+      def initialize_parameter_names
+        initialize_parameters.map(&:last)
+      end
+
+      def initialize_parameters
+        instance_method(:initialize).parameters
+      end
+
+      def provided_collection_parameter
+        @provided_collection_parameter ||= nil
+      end
+    end
+  end
+end

--- a/test/view_component/core_test.rb
+++ b/test/view_component/core_test.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/view_component/core_test.rb
+++ b/test/view_component/core_test.rb
@@ -1,0 +1,20 @@
+
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ViewComponentTest < ViewComponent::TestCase
+  class MyCoreComponent < ViewComponent::Core
+    def call
+      content_tag :div do
+        "hello,world"
+      end
+    end
+  end
+
+  def test_render_inline
+    render_inline(MyCoreComponent.new)
+
+    assert_selector("div", text: "hello,world!")
+  end
+end


### PR DESCRIPTION
This extracts a new class, `ViewComponent::Core` which implements the
minimum amount of functionality to have a functioning component library.

The difference between `ViewComponent::Core` and `ViewComponent::Base`
is that Base includes extra functionality and compatibility with Rails,
such as slots, built-in route helpers, access to `request` and
`controller`, etc.

This new `Core` class is marked as private and should still be
considered experimental.
