### PR TITLE
Allow component tests to define the current_user

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Allow component tests to define the current user.
+
+    *Connor McQuillan*
+
 * Add a test to ensure blocks can be passed into lambda slots without the need for any other arguments.
 
     *Simon Fish*

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -150,6 +150,27 @@ class ExampleComponentTest < ViewComponent::TestCase
 end
 ```
 
+## Setting the current user
+
+Authentication gems like [clearance] and [devise] define a `current_user` helper method that can be used in controllers and views.
+
+When a component delegates `:current_user` to the Rails helpers, the component can be rendered as a given user in tests using `with_current_user` from `ViewComponent::TestHelpers`:
+
+```ruby
+class ExampleComponentTest < ViewComponent::TestCase
+  def test_with_current_user
+    with_current_user User.new(name: "Test User") do
+      render_inline ExampleComponent.new # contains i.e `<h1>Hello, <%= current_user.name %>!</h1>
+
+      assert_text "Hello, Test User!
+    end
+  end
+end
+```
+
+[clearance]: https://github.com/thoughtbot/clearance
+[devise]: https://github.com/heartcombo/devise
+
 ## RSpec configuration
 
 To use RSpec, add the following:

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,6 +119,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/bradparker?s=64" alt="bradparker" width="32" />
 <img src="https://avatars.githubusercontent.com/cesariouy?s=64" alt="cesariouy" width="32" />
 <img src="https://avatars.githubusercontent.com/cover?s=64" alt="cover" width="32" />
+<img src="https://avatars.githubusercontent.com/cpjmcquillan?s=64" alt="cpjmcquillan" width="32" />
 <img src="https://avatars.githubusercontent.com/czj?s=64" alt="czj" width="32" />
 <img src="https://avatars.githubusercontent.com/dark-panda?s=64" alt="dark-panda" width="32" />
 <img src="https://avatars.githubusercontent.com/davekaro?s=64" alt="davekaro" width="32" />

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -126,6 +126,22 @@ module ViewComponent
       @controller = old_controller
     end
 
+    # Set the current_user in the given controller to the given value:
+    #
+    # ```ruby
+    # with_current_user(user) do
+    #  render_inline(MyComponent.new)
+    # end
+    # ```
+    #
+    # @param user [Object] The user to set as the current_user.
+    def with_current_user(user)
+      controller.define_singleton_method(:current_user) { user }
+      yield
+    ensure
+      controller.define_singleton_method(:current_user) { nil }
+    end
+
     # @private
     def build_controller(klass)
       klass.new.tap { |c| c.request = request }.extend(Rails.application.routes.url_helpers)

--- a/test/sandbox/app/components/current_user_component.html.erb
+++ b/test/sandbox/app/components/current_user_component.html.erb
@@ -1,0 +1,1 @@
+<div><%= current_user || "No user present" %></div>

--- a/test/sandbox/app/components/current_user_component.rb
+++ b/test/sandbox/app/components/current_user_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CurrentUserComponent < ViewComponent::Base
+  delegate :current_user, to: :helpers
+end

--- a/test/sandbox/app/controllers/integration_examples_controller.rb
+++ b/test/sandbox/app/controllers/integration_examples_controller.rb
@@ -3,6 +3,8 @@
 class IntegrationExamplesController < ActionController::Base
   layout false
 
+  helper_method :current_user
+
   def variants
     request.variant = params[:variant].to_sym if params[:variant]
   end
@@ -46,5 +48,11 @@ class IntegrationExamplesController < ActionController::Base
     products = [OpenStruct.new(name: "Radio clock"), OpenStruct.new(name: "Mints")]
 
     render(ProductComponent.with_collection(products, notice: "Today only"))
+  end
+
+  private
+
+  def current_user
+    nil
   end
 end

--- a/test/view_component/view_component_test.rb
+++ b/test/view_component/view_component_test.rb
@@ -915,6 +915,16 @@ class ViewComponentTest < ViewComponent::TestCase
     end
   end
 
+  def test_with_current_user
+    with_current_user "A user object" do
+      render_inline CurrentUserComponent.new
+      assert_text "A user object"
+    end
+
+    render_inline CurrentUserComponent.new
+    assert_text "No user present"
+  end
+
   def test_components_share_helpers_state
     PartialHelper::State.reset
 


### PR DESCRIPTION
### Summary

Authentication gems like [clearance] and [devise] define a `current_user` helper
method that can be used in controllers and views to access the currently signed
in user.

When building components that depend on the currently signed in user and
delegating `:current_user` to the Rails helpers, it is useful to be able to
define `current_user` in tests.

The `with_current_user` helper method defines a current_user method on the
controller so that these components can be tested easily.

[clearance]: https://github.com/thoughtbot/clearance
[devise]: https://github.com/heartcombo/devise

### Other Information

[Discussion](https://github.com/github/view_component/discussions/371) a while back indicated there could be appetite for a test helper like this
in `ViewComponent::TestHelpers`.
