### PR TITLE
Add test showing that form helpers aren't used by View Components

### DIFF
--- a/test/sandbox/app/components/form_component.html.erb
+++ b/test/sandbox/app/components/form_component.html.erb
@@ -1,0 +1,1 @@
+<%= form_tag do %><% end %>

--- a/test/sandbox/app/components/form_component.rb
+++ b/test/sandbox/app/components/form_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class FormComponent < ViewComponent::Base
+end

--- a/test/sandbox/app/helpers/form_helper.rb
+++ b/test/sandbox/app/helpers/form_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module FormHelper
+  def form_tag_html(options = {})
+    safe_join [
+      "<span>Hello, World!</span>".html_safe,
+      super(options),
+    ]
+  end
+end

--- a/test/sandbox/app/views/integration_examples/form_helper.erb
+++ b/test/sandbox/app/views/integration_examples/form_helper.erb
@@ -1,0 +1,1 @@
+<%= render FormComponent.new %>

--- a/test/sandbox/config/routes.rb
+++ b/test/sandbox/config/routes.rb
@@ -20,4 +20,5 @@ Sandbox::Application.routes.draw do
   get :render_component, to: "integration_examples#render_component"
   get :controller_inline_render_component, to: "integration_examples#controller_inline_render_component"
   get :controller_to_string_render_component, to: "integration_examples#controller_to_string_render_component"
+  get :form_helper, to: "integration_examples#form_helper"
 end

--- a/test/view_component/integration_test.rb
+++ b/test/view_component/integration_test.rb
@@ -583,4 +583,13 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       assert_equal ViewComponent::Compiler::DEVELOPMENT_MODE, ViewComponent::Compiler.mode
     end
   end
+
+  def test_uses_form_helper_methods
+    get "/form_helper"
+
+    # The FormHelper module overrides form_tag_html to add this HTML
+    # fragment, so it should get included when form_tag is called
+    # from a ViewComponent.
+    assert_includes response.body, "<span>Hello, World!</span>"
+  end
 end


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

This PR adds a test showing that form helpers aren't used when a View Component calls `form_tag`. CI will fail because of the failing test, but I'm envisaging that having the test will provide a helpful starting point for addressing this issue.

### Other Information

I'd expect form helpers to be picked up automatically. `form_tag_html` is an override of [this method](https://github.com/wycats/rails-api/blob/4aa40d1381fac5bc69bae6bb8e24dfb421997b40/vendor/rails/actionpack/lib/action_view/helpers/form_tag_helper.rb#L550-L553) which is called by `form_tag` directly [here](https://github.com/wycats/rails-api/blob/4aa40d1381fac5bc69bae6bb8e24dfb421997b40/vendor/rails/actionpack/lib/action_view/helpers/form_tag_helper.rb#L558) and indirectly [here](https://github.com/wycats/rails-api/blob/4aa40d1381fac5bc69bae6bb8e24dfb421997b40/vendor/rails/actionpack/lib/action_view/helpers/form_tag_helper.rb#L558).