### PR TITLE
Lock compile cache while rendering

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,10 @@ nav_order: 5
 
     *Marc Köhlbrugge*
 
+* Fix potential deadlock scenario in the compiler's development mode.
+
+  *Paul-Henri Leobon*
+
 ## 2.69.0
 
 * Add missing `require` to fix `pvc` build.

--- a/lib/view_component/compile_cache.rb
+++ b/lib/view_component/compile_cache.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "view_component/compile_cache_lock"
+
 module ViewComponent
   # Keeps track of which templates have already been compiled
   # This isn't part of the public API
@@ -9,7 +11,7 @@ module ViewComponent
     end
 
     mattr_accessor :lock, instance_reader: false, instance_accessor: false do
-      Concurrent::ReadWriteLock.new
+      ViewComponent::Lock.new
     end
 
     module_function

--- a/lib/view_component/compile_cache.rb
+++ b/lib/view_component/compile_cache.rb
@@ -8,6 +8,10 @@ module ViewComponent
       Set.new
     end
 
+    mattr_accessor :lock, instance_reader: false, instance_accessor: false do
+      Concurrent::ReadWriteLock.new
+    end
+
     module_function
 
     def register(klass)
@@ -23,7 +27,11 @@ module ViewComponent
     end
 
     def invalidate!
-      cache.clear
+      lock.with_write_lock { cache.clear }
+    end
+
+    def with_read_lock(&block)
+      lock.with_read_lock(&block)
     end
   end
 end

--- a/lib/view_component/compile_cache_lock.rb
+++ b/lib/view_component/compile_cache_lock.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "concurrent-ruby"
+
+module ViewComponent
+  class Lock
+    RUNNING_WRITER = 1 << 29
+
+    def initialize
+      @counter = Concurrent::AtomicFixnum.new
+      @lock = Concurrent::Synchronization::Lock.new
+    end
+
+    def with_read_lock
+      acquire_read_lock
+      begin
+        yield
+      ensure
+        release_read_lock
+      end
+    end
+
+    def with_write_lock
+      acquire_write_lock
+      begin
+        yield
+      ensure
+        release_write_lock
+      end
+    end
+
+    def acquire_read_lock
+      while true
+        @lock.wait_until { !has_writer }
+        break if add_reader
+      end
+    end
+
+    def release_read_lock
+      while true
+        if remove_reader
+          @lock.broadcast unless read_write_locked
+          break
+        end
+      end
+
+      true
+    end
+
+    def acquire_write_lock
+      while true
+        @lock.wait_until { !read_write_locked }
+        break if lock_for_writing
+      end
+    end
+
+    def release_write_lock
+      false until unlock_from_writing
+      @lock.broadcast
+
+      true
+    end
+
+    private
+
+    def read_write_locked
+      @counter.value != 0
+    end
+
+    def has_writer
+      @counter.value >= RUNNING_WRITER
+    end
+
+    def add_reader
+      current_value = @counter.value
+      @counter.compare_and_set(current_value, current_value + 1)
+    end
+
+    def remove_reader
+      current_value = @counter.value
+      @counter.compare_and_set(current_value, current_value - 1)
+    end
+
+    def lock_for_writing
+      @counter.compare_and_set(0, 0 + RUNNING_WRITER)
+    end
+
+    def unlock_from_writing
+      @counter.compare_and_set(RUNNING_WRITER, 0)
+    end
+  end
+end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -130,7 +130,9 @@ module ViewComponent
         component_class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def render_template_for(variant = nil)
           self.class.compiler.with_read_lock do
-            #{body}
+              CompileCache.with_read_lock do
+                #{body}
+              end
           end
         end
         RUBY


### PR DESCRIPTION
### What are you trying to accomplish?

This should fix #1488 by preventing any thread to clear the compile cache while another thread is rendering.

### What approach did you choose and why?

Given that the deadlock is caused by one thread emptying the cache while another one is still rendering the simplest approach seemed to be waiting for the rendering to be done. As this only happens in development it should not impact performance.

Given that I don't usually write concurrent code in ruby I'm not sure I tested that in the best possible way 😄 