### PR TITLE
Add source_code_uri to gemspec

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add source_code_uri to gemspec.
+
+    *Yoshiyuki Hirano*
+
 ## 2.71.0
 
 **ViewComponent has moved to a new organization: [https://github.com/viewcomponent/view_component](https://github.com/viewcomponent/view_component). See [https://github.com/viewcomponent/view_component/issues/1424](https://github.com/viewcomponent/view_component/issues/1424) for more details.**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Add source_code_uri to gemspec.
+* Add `source_code_uri` to gemspec.
 
     *Yoshiyuki Hirano*
 

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
     spec.metadata["allowed_push_host"] = "https://rubygems.org"
+    spec.metadata["source_code_uri"] = "https://github.com/viewcomponent/view_component"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide a description of the changes. Link to any related issues or projects. -->

Since #1472, we cannot confirm source code url from rubygems. So, it added `metadata["source_code_uri"]` in gemspec.

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

Not in particular.

### Anything you want to highlight for special attention from reviewers?

Not in particular.