### PR TITLE
Docs: Update link to benchmark script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ nav_order: 5
 
     *Yoshiyuki Hirano*
 
-* Update link to benchmark script.
+* Update link to benchmark script in docs.
 
     *Daniel Diekmeier*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ nav_order: 5
 
     *Yoshiyuki Hirano*
 
+* Update link to benchmark script.
+
+    *Daniel Diekmeier*
+
 ## 2.71.0
 
 **ViewComponent has moved to a new organization: [https://github.com/viewcomponent/view_component](https://github.com/viewcomponent/view_component). See [https://github.com/viewcomponent/view_component/issues/1424](https://github.com/viewcomponent/view_component/issues/1424) for more details.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ ViewComponents use a standard Ruby initializer that clearly defines what's neede
 
 ### Performance
 
-Based on several [benchmarks](https://github.com/viewcomponent/view_component/blob/main/performance/benchmark.rb), ViewComponents are ~10x faster than partials in real-world use-cases.
+Based on several [benchmarks](https://github.com/viewcomponent/view_component/blob/main/performance/partial_benchmark.rb), ViewComponents are ~10x faster than partials in real-world use-cases.
 
 The primary optimization is pre-compiling all ViewComponent templates at application boot, instead of at runtime like traditional Rails views.
 


### PR DESCRIPTION
### What are you trying to accomplish?

The Performance section to the Docs links to a benchmark script. The script was recently renamed to `partial_benchmark.rb`: https://github.com/ViewComponent/view_component/commits/main/performance/partial_benchmark.rb

This PR updates the link!

### What approach did you choose and why?

Edited the markdown with the new link.

### Anything you want to highlight for special attention from reviewers?

Nope!