### PR TITLE
Add special case for `renders_one :content`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ nav_order: 5
 
     *Daniel Diekmeier*
 
+* Add special exception message for `renders_one :content` explaining that content passed as a block will be assigned to the `content` accessor without having to create an explicit slot.
+
+    *Daniel Diekmeier*
+
 ## 2.71.0
 
 **ViewComponent has moved to a new organization: [https://github.com/viewcomponent/view_component](https://github.com/viewcomponent/view_component). See [https://github.com/viewcomponent/view_component/issues/1424](https://github.com/viewcomponent/view_component/issues/1424) for more details.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,6 +127,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/cpjmcquillan?s=64" alt="cpjmcquillan" width="32" />
 <img src="https://avatars.githubusercontent.com/czj?s=64" alt="czj" width="32" />
 <img src="https://avatars.githubusercontent.com/dani-sc?s=64" alt="dani-sc" width="32" />
+<img src="https://avatars.githubusercontent.com/danieldiekmeier?s=64" alt="danieldiekmeier" width="32" />
 <img src="https://avatars.githubusercontent.com/dark-panda?s=64" alt="dark-panda" width="32" />
 <img src="https://avatars.githubusercontent.com/davekaro?s=64" alt="davekaro" width="32" />
 <img src="https://avatars.githubusercontent.com/dixpac?s=64" alt="dixpac" width="32" />

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -272,6 +272,14 @@ module ViewComponent
       end
 
       def validate_singular_slot_name(slot_name)
+        if slot_name.to_sym == :content
+          raise ArgumentError.new(
+            "#{self} declares a slot named content, which is a reserved word in the ViewComponent framework.\n\n" \
+            "Content passed to a ViewComponent as a block is captured and assigned to the `content` accessor without having to create an explicit slot.\n\n" \
+            "To fix this issue, either use the `content` accessor directly or choose a different name."
+          )
+        end
+
         if RESERVED_NAMES[:singular].include?(slot_name.to_sym)
           raise ArgumentError.new(
             "#{self} declares a slot named #{slot_name}, which is a reserved word in the ViewComponent framework.\n\n" \

--- a/lib/view_component/slotable_v2.rb
+++ b/lib/view_component/slotable_v2.rb
@@ -274,9 +274,9 @@ module ViewComponent
       def validate_singular_slot_name(slot_name)
         if slot_name.to_sym == :content
           raise ArgumentError.new(
-            "#{self} declares a slot named content, which is a reserved word in the ViewComponent framework.\n\n" \
+            "#{self} declares a slot named content, which is a reserved word in ViewComponent.\n\n" \
             "Content passed to a ViewComponent as a block is captured and assigned to the `content` accessor without having to create an explicit slot.\n\n" \
-            "To fix this issue, either use the `content` accessor directly or choose a different name."
+            "To fix this issue, either use the `content` accessor directly or choose a different slot name."
           )
         end
 

--- a/test/sandbox/test/slotable_v2_test.rb
+++ b/test/sandbox/test/slotable_v2_test.rb
@@ -333,7 +333,7 @@ class SlotsV2sTest < ViewComponent::TestCase
     refute_selector("div.table div.table__header span", text: "Selectable")
   end
 
-  def test_component_raises_when_given_invalid_slot_name
+  def test_component_raises_when_given_content_slot_name
     exception =
       assert_raises ArgumentError do
         Class.new(ViewComponent::Base) do
@@ -342,6 +342,18 @@ class SlotsV2sTest < ViewComponent::TestCase
       end
 
     assert_includes exception.message, "declares a slot named content"
+    assert_includes exception.message, "without having to create"
+  end
+
+  def test_component_raises_when_given_invalid_slot_name
+    exception =
+      assert_raises ArgumentError do
+        Class.new(ViewComponent::Base) do
+          renders_one :render
+        end
+      end
+
+    assert_includes exception.message, "declares a slot named render"
   end
 
   def test_component_raises_when_given_one_slot_name_ending_with_question_mark


### PR DESCRIPTION
### What are you trying to accomplish?

As proposed in #1498, this PR adds a special error message when calling `renders_one :content`. 

The new error message looks like this:

```
ArgumentError: ExampleComponent declares a slot named content, which is a reserved word in the ViewComponent framework.

Content passed to a ViewComponent as a block is captured and assigned to the `content` accessor without having to create an explicit slot.

To fix this issue, either use the `content` accessor directly or choose a different name.
```

`content` is already very similar to a slot, so suggesting to the user that it may do what they want seems like a nice idea to help them improve their code.

### What approach did you choose and why?

I decided to add the special case above the general case in `validate_singular_slot_name`, instead of somehow generalizing it. I also didn't touch `RESERVED_NAMES[:singular]`, even though it is only used in this one spot and the `:content` check will now never happen. If you want me to clean this up, feel free to indicate that!

### Anything you want to highlight for special attention from reviewers?

Not at the moment.