### PR TITLE
Deprecate support for Ruby < 2.7

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Deprecate support for Ruby < 2.7.
+
+    *Joel Hawksley*
+
 * Add `source_code_uri` to gemspec.
 
     *Yoshiyuki Hirano*

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -33,6 +33,10 @@ module ViewComponent
       return if compiled? && !force
       return if component_class == ViewComponent::Base
 
+      if RUBY_VERSION < "2.7.0"
+        ViewComponent::Deprecation.warn("Support for Ruby versions < 2.7.0 will be removed in v3.0.0.")
+      end
+
       component_class.superclass.compile(raise_errors: raise_errors) if should_compile_superclass?
 
       with_write_lock do


### PR DESCRIPTION
### What are you trying to accomplish?

We are deprecating support for Ruby < 2.7 in the coming ViewComponent release: https://github.com/ViewComponent/view_component/issues/617

### What approach did you choose and why?

I added a deprecation warning to the component compiler as I thought it would be fairly visible here.