### PR TITLE
Fix default sidecar generation documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Correctly document `generate.sidecar` config option
+* Correctly document `generate.sidecar` config option.
 
     *Ruben Smit*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Correctly document `generate.sidecar` config option
+
+    *Ruben Smit*
+
 ## 2.72.0
 
 * Deprecate support for Ruby < 2.7 for removal in v3.0.0.

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -140,7 +140,7 @@ bin/rails generate component Example title --sidecar
       create    app/components/example_component/example_component.html.erb
 ```
 
-To always generate in the sidecar directory, set `config.view_component.generate_sidecar = true`.
+To always generate in the sidecar directory, set `config.view_component.generate.sidecar = true`.
 
 ### Use [inline rendering](/guide/templates.html#inline) (no template file)
 


### PR DESCRIPTION
The documentation about [placing the view in a sidecar](https://viewcomponent.org/guide/generators.html#place-the-view-in-a-sidecar-directory) contains a mistake when describing how to set this as a default. The config documentation contained a underscore where a dot is needed. See also [lib/rails/generators/abstract_generator.rb:45](https://github.com/ViewComponent/view_component/blob/e8365e52c3cf7c84d896eb969e39d1854a27c413/lib/rails/generators/abstract_generator.rb#L45). This pull request fixes the documentation.