### PR TITLE
Simplify CI configuration to a single build per Ruby/Rails version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,25 +27,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails_version: ['5.2.6', '6.0.4.4', '6.1.4.4', '7.0.2.3', 'main']
-        ruby_version: ['2.5', '2.6', '2.7', '3.0', '3.1']
-        exclude:
-          - rails_version: '5.2.6'
-            ruby_version: '3.0'
-          - rails_version: '5.2.6'
-            ruby_version: '3.1'
-          - rails_version: '6.0.4.4'
-            ruby_version: '3.0'
-          - rails_version: '6.0.4.4'
-            ruby_version: '3.1'
-          - rails_version: '7.0.2.3'
-            ruby_version: '2.5'
-          - rails_version: '7.0.2.3'
-            ruby_version: '2.6'
-          - rails_version: 'main'
-            ruby_version: '2.5'
-          - rails_version: 'main'
-            ruby_version: '2.6'
+        include:
+          - rails_version: "5.2.6"
+            ruby_version: "2.5"
+          - rails_version: "6.0.4.4"
+            ruby_version: "2.6"
+          - rails_version: "6.1.4.4"
+            ruby_version: "2.7"
+          - rails_version: "7.0.2.3"
+            ruby_version: "3.0"
+          - rails_version: "main"
+            ruby_version: "3.1"
     steps:
     - uses: actions/checkout@master
     - name: Setup Ruby

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Simplify CI configuration to a single build per Ruby/Rails version.
+
+    *Joel Hawksley*
+
 * Correctly document `generate.sidecar` config option.
 
     *Ruben Smit*


### PR DESCRIPTION
Our existing CI configuration runs a 17-build matrix for the main test suite. I think this is overkill for our needs. In my experience, our matrix builds have mainly served us by testing each version of Rails and Ruby we support, *not* every *combination* of Ruby and Rails we support. I think we can get by with just 5 builds.