### PR TITLE
Add PrintReleaf to list of who uses ViewComponent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add PrintReleaf to list of companies using ViewComponent.
+
+    *Ry Kulp*
+
 * Simplify CI configuration to a single build per Ruby/Rails version.
 
     *Joel Hawksley*

--- a/docs/index.md
+++ b/docs/index.md
@@ -225,6 +225,7 @@ ViewComponent is built by over a hundred members of the community, including:
 * [Nikola Motor](https://www.nikolamotor.com/) (50+ components and counting)
 * [Orbit](https://orbit.love)
 * [Podia](https://www.podia.com/)
+* [PrintReleaf](https://www.printreleaf.com/)
 * [QuickNode](https://www.quicknode.com/)
 * [Shogun](https://getshogun.com/)
 * [Wecasa](https://www.wecasa.fr/)


### PR DESCRIPTION
### What are you trying to accomplish?

Add PrintReleaf to list of who uses ViewComponent

### What approach did you choose and why?

Added PrintReleaf and link to site to the docs. PrintReleaf started using ViewComponent about a month ago and has already implemented over 20+ components allowing us to remove logic from our views and greatly increase our test coverage.

### Anything you want to highlight for special attention from reviewers?

Thanks for helping us improve our code base with such a great tool!