### PR TITLE
Rename _after_compile to after_compile., Remove experimental docs labels

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Rename `_after_compile` to `after_compile`. `_after_compile` is deprecated and will be removed in `v3.0.0`.
+
+    *Joel Hawksley*
+
 * Remove experimental labels from docs.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Remove experimental labels from docs.
+
+    *Joel Hawksley*
+
 * Simplify CI configuration to a single build per Ruby/Rails version.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Rename `_after_compile` to `after_compile`. `_after_compile` is deprecated and will be removed in `v3.0.0`.
+* Rename experimental `_after_compile` to `after_compile`. `_after_compile` is deprecated and will be removed in `v3.0.0`.
 
     *Joel Hawksley*
 

--- a/docs/guide/javascript_and_css.md
+++ b/docs/guide/javascript_and_css.md
@@ -6,9 +6,6 @@ parent: How-to guide
 
 # Javascript and CSS
 
-Experimental
-{: .label .label-yellow }
-
 While ViewComponent doesn't provide any built-in tooling to do so, it’s possible to include Javascript and CSS alongside components.
 
 To use the Webpacker gem to compile assets located in `app/components`:

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -31,9 +31,6 @@ _Note: `assert_selector` only matches on visible elements by default. To match o
 Since 2.56.0
 {: .label }
 
-Experimental
-{: .label .label-yellow }
-
 Use `render_preview(name)` to render previews in ViewComponent unit tests:
 
 ```ruby

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -59,12 +59,10 @@ module ViewComponent
       self.__vc_original_view_context = view_context
     end
 
-    # EXPERIMENTAL: This API is experimental and may be removed at any time.
-    # Hook for allowing components to do work as part of the compilation process.
+    # Called after a component is compiled. Allows components to do work as part of the compilation process.
     #
-    # For example, one might compile component-specific assets at this point.
-    # @private TODO: add documentation
-    def self._after_compile
+    # @return [void]
+    def self.after_compile
       # noop
     end
 

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -90,7 +90,13 @@ module ViewComponent
         define_render_template_for
 
         component_class.build_i18n_backend
-        component_class._after_compile
+        component_class.after_compile
+
+        if component_class.methods.include? :_after_compile
+          ViewComponent::Deprecation.warn("`._after_compile` has been renamed to `.after_compile`. `._after_compile` will be removed in v3.0.0.")
+
+          component_class._after_compile
+        end
 
         CompileCache.register(component_class)
       end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -856,6 +856,10 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_after_compile
+    assert_deprecated(/_after_compile/, ViewComponent::Deprecation) do
+      AfterCompileComponent.compile(force: true)
+    end
+
     assert_equal AfterCompileComponent.compiled_value, "Hello, World!"
 
     render_inline(AfterCompileComponent.new)


### PR DESCRIPTION
### What are you trying to accomplish?

This PR renames `_after_compile` to `after_compile`, making it a public API.

### What approach did you choose and why?

I renamed the method, leaving the original in place while we deprecate it. As this is an experimental API we do not need to make a breaking SemVer change.