### PR TITLE
Promote experimental APIs to public

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Promote experimental `_sidecar_files` method to public API as `sidecar_files`.
+
+    *Joel Hawksley*
+
 * Remove experimental `_after_compile` lifecycle method.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Promote experimental `_output_postamble` method to public API as `output_postamble`.
+
+    *Joel Hawksley*
+
 * Promote experimental `_sidecar_files` method to public API as `sidecar_files`.
 
     *Joel Hawksley*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -128,7 +128,7 @@ module ViewComponent
         # component template is evaluated.
         content if self.class.use_consistent_rendering_lifecycle
 
-        render_template_for(@__vc_variant).to_s + _output_postamble
+        render_template_for(@__vc_variant).to_s + output_postamble
       else
         ""
       end
@@ -151,10 +151,10 @@ module ViewComponent
       nil
     end
 
-    # EXPERIMENTAL: Optional content to be returned after the rendered template.
+    # Optional content to be returned after the rendered template.
     #
     # @return [String]
-    def _output_postamble
+    def output_postamble
       ""
     end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -409,15 +409,14 @@ module ViewComponent
       # @private
       attr_accessor :source_location, :virtual_path
 
-      # EXPERIMENTAL: This API is experimental and may be removed at any time.
       # Find sidecar files for the given extensions.
       #
       # The provided array of extensions is expected to contain
       # strings starting without the "dot", example: `["erb", "haml"]`.
       #
       # For example, one might collect sidecar CSS files that need to be compiled.
-      # @private TODO: add documentation
-      def _sidecar_files(extensions)
+      # @param extensions [Array<String>] Extensions of which to return matching sidecar files.
+      def sidecar_files(extensions)
         return [] unless source_location
 
         extensions = extensions.join(",")

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -204,7 +204,7 @@ module ViewComponent
         begin
           extensions = ActionView::Template.template_handler_extensions
 
-          component_class._sidecar_files(extensions).each_with_object([]) do |path, memo|
+          component_class.sidecar_files(extensions).each_with_object([]) do |path, memo|
             pieces = File.basename(path).split(".")
             memo << {
               path: path,

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -23,7 +23,7 @@ module ViewComponent
       def build_i18n_backend
         return if CompileCache.compiled? self
 
-        self.i18n_backend = if (translation_files = _sidecar_files(%w[yml yaml])).any?
+        self.i18n_backend = if (translation_files = sidecar_files(%w[yml yaml])).any?
           # Returning nil cleans up if translations file has been removed since the last compilation
 
           I18nBackend.new(

--- a/test/sandbox/app/components/after_render_component.rb
+++ b/test/sandbox/app/components/after_render_component.rb
@@ -5,7 +5,7 @@ class AfterRenderComponent < ViewComponent::Base
     "Hello, "
   end
 
-  def _output_postamble
+  def output_postamble
     "World!"
   end
 end

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -17,7 +17,7 @@ class ViewComponent::Base::UnitTest < Minitest::Test
 
     compiler = ViewComponent::Compiler.new(ViewComponent::Base)
 
-    ViewComponent::Base.stub(:_sidecar_files, file_path) do
+    ViewComponent::Base.stub(:sidecar_files, file_path) do
       templates = compiler.send(:templates)
 
       templates.each_with_index do |template, index|
@@ -56,7 +56,7 @@ class ViewComponent::Base::UnitTest < Minitest::Test
         "#{root}/app/components/template_and_sidecar_directory_template_component/" \
         "template_and_sidecar_directory_template_component.html.erb"
       ],
-      TemplateAndSidecarDirectoryTemplateComponent._sidecar_files(["erb"])
+      TemplateAndSidecarDirectoryTemplateComponent.sidecar_files(["erb"])
     )
 
     assert_equal(
@@ -64,17 +64,17 @@ class ViewComponent::Base::UnitTest < Minitest::Test
         "#{root}/app/components/css_sidecar_file_component.css",
         "#{root}/app/components/css_sidecar_file_component.html.erb"
       ],
-      CssSidecarFileComponent._sidecar_files(["css", "erb"])
+      CssSidecarFileComponent.sidecar_files(["css", "erb"])
     )
 
     assert_equal(
       ["#{root}/app/components/css_sidecar_file_component.css"],
-      CssSidecarFileComponent._sidecar_files(["css"])
+      CssSidecarFileComponent.sidecar_files(["css"])
     )
 
     assert_equal(
       ["#{root}/app/components/translatable_component.yml"],
-      TranslatableComponent._sidecar_files(["yml"])
+      TranslatableComponent.sidecar_files(["yml"])
     )
   end
 

--- a/test/sandbox/test/translatable_test.rb
+++ b/test/sandbox/test/translatable_test.rb
@@ -81,7 +81,7 @@ class TranslatableTest < ViewComponent::TestCase
     ViewComponent::CompileCache.invalidate_class!(TranslatableComponent)
 
     ViewComponent::Base.stub(
-      :_sidecar_files,
+      :sidecar_files,
       ->(exts) { exts.include?("yml") ? [] : TranslatableComponent.__minitest_stub___sidecar_files(exts) }
     ) do
       assert_equal "MISSING", translate(".hello", default: "MISSING")


### PR DESCRIPTION
### What are you trying to accomplish?

Promote remaining experimental APIs to public methods.

### What approach did you choose and why?

I renamed the existing private APIs for `_sidecar_files` and `_output_postamble` to remove the underscore. As these were experimental/private APIs, this is not a breaking SemVer change.