### PR TITLE
Allow render_parent to facilitate setting slots

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -153,8 +153,17 @@ module ViewComponent
     # <% super %> # does not double-render
     # ```
     #
-    # Calls `super`, returning `nil` to avoid rendering the result twice.
+    # Calls `super`, returning `nil` to avoid rendering the result twice. Accepts a
+    # block that will be called with self, which can be used to define slots, eg:
+    #
+    # <%= render_parent do |c| %>
+    #   <% c.with_some_slot(...) %>
+    # <% end %>
+    #
     def render_parent
+      # yield the component here to make defining slots more ergonomic
+      yield self if block_given?
+
       mtd = @__vc_variant ? "call_#{@__vc_variant}" : "call"
       method(mtd).super_method.call
       nil

--- a/test/sandbox/app/components/super_base_component.html.erb
+++ b/test/sandbox/app/components/super_base_component.html.erb
@@ -1,1 +1,3 @@
-<div class="base-component"></div>
+<div class="base-component">
+  <%= parent_slot %>
+</div>

--- a/test/sandbox/app/components/super_base_component.rb
+++ b/test/sandbox/app/components/super_base_component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 class SuperBaseComponent < ViewComponent::Base
-  renders_one :parent_slot, lambda { |text:|
-    content_tag(:p) { text }
-  }
+  renders_one :parent_slot
 end

--- a/test/sandbox/app/components/super_base_component.rb
+++ b/test/sandbox/app/components/super_base_component.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class SuperBaseComponent < ViewComponent::Base
+  renders_one :parent_slot, lambda { |text:|
+    content_tag(:p) { text }
+  }
 end

--- a/test/sandbox/app/components/super_component.html.erb
+++ b/test/sandbox/app/components/super_component.html.erb
@@ -1,3 +1,5 @@
 <div class="derived-component">
-  <%= render_parent %>
+  <%= render_parent do |c| %>
+    <% c.with_parent_slot(text: "Foo") %>
+  <% end %>
 </div>

--- a/test/sandbox/app/components/super_component.html.erb
+++ b/test/sandbox/app/components/super_component.html.erb
@@ -1,5 +1,9 @@
 <div class="derived-component">
   <%= render_parent do |c| %>
-    <% c.with_parent_slot(text: "Foo") %>
+    <% c.with_parent_slot do %>
+      <%= render(TitleComponent.new) do |c| %>
+        <% c.with_body { "Foo" } %>
+      <% end %>
+    <% end %>
   <% end %>
 </div>

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1040,7 +1040,9 @@ class RenderingTest < ViewComponent::TestCase
 
     assert_selector(".base-component", count: 1)
     assert_selector(".derived-component", count: 1) do
-      assert_selector(".base-component", count: 1)
+      assert_selector(".base-component", count: 1) do
+        assert_selector("p", text: "Foo")
+      end
     end
   end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1041,7 +1041,7 @@ class RenderingTest < ViewComponent::TestCase
     assert_selector(".base-component", count: 1)
     assert_selector(".derived-component", count: 1) do
       assert_selector(".base-component", count: 1) do
-        assert_selector("p", text: "Foo")
+        assert_selector("h1", text: "Foo", count: 1)
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

A few months ago we introduced the `render_parent` method as a bit of sugar around calling `super` in template code (it prevents double-rendering). However `render_parent` doesn't accept a block, making it feel different than `render`. It also means setting slots is sort of awkward:

```html+erb
<% with_some_slot(args) do |slot| %>
  <% capture do %>
    <%= render(AnotherComponent.new)) %>
  <% end %>
<% end %>

<%= render_parent %>
```

This PR modifies `render_parent` to `yield self` so this is possible:

```html+erb
<%= render_parent do |parent| %>
  <% parent.with_some_slot(args) do |slot| %>
    <%= render(AnotherComponent.new)) %>
  <% end %>
<% end %>
```

### What approach did you choose and why?

I simply added a `yield self` in `render_parent`. Seems to work 👍 

### Anything you want to highlight for special attention from reviewers?

As @BlakeWilliams pointed out, it feels like `parent` in the example above is another object rather than `self`. I'm curious to hear what others think and reach a consensus.