### PR TITLE
chore: Bump activesupport version

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Require Rails 5.2+ in gemspec and update documentation.
+
+    *Drew Bragg*
+
 * Avoid loading ActionView::Base during Rails initialization.
 
     *Jonathan del Strother*

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -8,9 +8,9 @@ nav_order: 6
 
 ## Ruby & Rails
 
-ViewComponent is [supported natively](https://edgeguides.rubyonrails.org/layouts_and_rendering.html#rendering-objects) in Rails 6.1, and compatible with Rails 5.0+ via an included [monkey patch](https://github.com/viewcomponent/view_component/blob/main/lib/view_component/render_monkey_patch.rb).
+ViewComponent is [supported natively](https://edgeguides.rubyonrails.org/layouts_and_rendering.html#rendering-objects) in Rails 6.1, and compatible with Rails 5.2+ via an included [monkey patch](https://github.com/viewcomponent/view_component/blob/main/lib/view_component/render_monkey_patch.rb).
 
-ViewComponent is tested for compatibility [with combinations of](https://github.com/viewcomponent/view_component/blob/22e3d4ccce70d8f32c7375e5a5ccc3f70b22a703/.github/workflows/ruby_on_rails.yml#L10-L11) Ruby v2.5+ and Rails v5+. Ruby 2.4 is likely compatible, but is no longer tested.
+ViewComponent is tested for compatibility [with combinations of](https://github.com/viewcomponent/view_component/blob/22e3d4ccce70d8f32c7375e5a5ccc3f70b22a703/.github/workflows/ruby_on_rails.yml#L10-L11) Ruby v2.5+ and Rails v5.2+. Ruby 2.4 is likely compatible, but is no longer tested.
 
 ## Template languages
 

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_runtime_dependency "activesupport", [">= 5.0.0", "< 8.0"]
+  spec.add_runtime_dependency "activesupport", [">= 5.2.0", "< 8.0"]
   spec.add_runtime_dependency "method_source", "~> 1.0"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_development_dependency "appraisal", "~> 2.4"


### PR DESCRIPTION
### What are you trying to accomplish?

Changes in #1550 and #1536 caused `view_component` to no longer be compatible with Rails < 5.2. This PR updates the `.gemspec` file to require `activesupport` version >= 5.2 so folks know about the compatibility issue when installing/updating.  I also updated the compatibility documentation to reflect this.