### PR TITLE
Drop support for Rails <= 5.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Officially drop support for Rails versions <= 5.1.
+
+    *Cameron Dutro*
+
 * Avoid loading ActionView::Base during Rails initialization.
 
     *Jonathan del Strother*

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_runtime_dependency "activesupport", [">= 5.0.0", "< 8.0"]
+  spec.add_runtime_dependency "activesupport", [">= 5.2.0", "< 8.0"]
   spec.add_runtime_dependency "method_source", "~> 1.0"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_development_dependency "appraisal", "~> 2.4"


### PR DESCRIPTION
### What are you trying to accomplish?

This PR officially drops support for Rails versions <= 5.1. Not only are versions <= 5.1 end-of-life, we don't even test against them in CI.

### What approach did you choose and why?

I changed the constraint on activesupport in the .gemspec file.