### PR TITLE
Avoid running PVC tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
       env:
         VIEW_COMPONENT_PATH: ../view_component
         RAILS_VERSION: '~> 6.1.0'
+        PARALLEL_WORKERS: '1'
   coverage:
     needs: test
     runs-on: ubuntu-latest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Run PVC's accessibility tests in a single process to avoid resource contention in CI.
+
+    *Cameron Dutro*
+
 ## 2.75.0
 
 * Avoid loading ActionView::Base during Rails initialization.


### PR DESCRIPTION
### What are you trying to accomplish?

I made a [recent change](https://github.com/primer/view_components/pull/1553) to PVC that speeds up our accessibility tests by running them in parallel. To get things running, I had to wrangle access to larger actions runners for the Primer org. The regular actions runners available to free orgs like ViewComponent only have 2 CPU cores, which isn't enough to run even two parallel test workers (2 server processes + test process). To avoid resource contention, view_component should continue to run PVC's accessibility tests in a single process.

### What approach did you choose and why?

This PR effectively disables parallel test execution for PVC tests by setting the `PARALLEL_WORKERS` environment variable to 1.