### PR TITLE
Add startup.jobs to list of ViewComponent users

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add Startup Jobs to list of companies using ViewComponent.
+
+    *Marc Köhlbrugge*
+
 * Run PVC's accessibility tests in a single process to avoid resource contention in CI.
 
     *Cameron Dutro*

--- a/docs/index.md
+++ b/docs/index.md
@@ -236,6 +236,7 @@ ViewComponent is built by over a hundred members of the community, including:
 * [QuickNode](https://www.quicknode.com/)
 * [Shogun](https://getshogun.com/)
 * [Spina CMS](https://spinacms.com/)
+* [Startup Jobs](https://startup.jobs/)
 * [Wecasa](https://www.wecasa.fr/)
 * [WIP](https://wip.co/)
 * [Within3](https://www.within3.com/)


### PR DESCRIPTION
Moving an older codebase to use View Component. Works really well together with Tailwind CSS