### PR TITLE
Use npm instead of yarn to install PVC dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,18 +79,18 @@ jobs:
         ruby-version: 2.7
     - uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: 16
     - uses: actions/cache@v2
       with:
         path: |
           node_modules
           vendor/bundle
-        key: gems-build-pvc-${{ hashFiles('**/Gemfile.lock') }}-${{ hashFiles('**/yarn.lock') }}
+        key: gems-build-pvc-${{ hashFiles('**/Gemfile.lock') }}-${{ hashFiles('**/package-json.lock') }}
     - name: Build and test with Rake
       run: |
         cd primer_view_components
-        yarn
-        cd demo && yarn && cd ..
+        npm ci
+        cd demo && npm ci && cd ..
         bundle config path vendor/bundle
         bundle install
         bundle exec rake docs:preview

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Fix issue causing PVC tests to fail in CI.
+
+    *Cameron Dutro*
+
 * Add ability to pass in the preview class to `render_preview`.
 
     *Jon Rohan*


### PR DESCRIPTION
### What are you trying to accomplish?

Our PVC test runs have been [failing recently](https://github.com/ViewComponent/view_component/actions/runs/3441193868/jobs/5740477527) in CI. This PR should fix things.

### What approach did you choose and why?

PVC [migrated](https://github.com/primer/view_components/pull/1388) away from Yarn in favor of npm a few months ago, but view_component's CI scripts were never updated. Don't ask me why, but using npm fixes the test issues.

The linting issues should be fixed by [this PR](https://github.com/ViewComponent/view_component/pull/1576).