### PR TITLE
Prevent `standardrb` from breaking CI unless its version is bumped directly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Lint with Rubocop and ERB Lint
       run: |
         bundle config path vendor/bundle
-        bundle update
+        bundle install
         bundle exec standardrb
         bundle exec erblint **/*.html.erb
       env:


### PR DESCRIPTION
### What are you trying to accomplish?

This follows on from [my earlier PR where I applied the updated linting rules](https://github.com/ViewComponent/view_component/pull/1576).

@CamerTron made an excellent point that `bundle install` with a checked-in Gemfile.lock results in laggy feedback about breaking changes in upstream packages.

And @BlakeWilliams made an excellent point that tooling like `standardrb` is not technically "breaking changes."

### What approach did you choose and why?

Theoretically, this should please both Blake and Cameron, as we continue to run `bundle update` in CI as part of the ["Build and test with Rake" github
action](https://github.com/ViewComponent/view_component/blob/2cfe54fdd81f8c2f9f79b7d1e4148a2ce3cfdb9c/.github/workflows/ci.yml#L51-L55), while using `bundle install` in the lint action, thus releasing the `standardrb` canary from it's cage.

### Anything you want to highlight for special attention from reviewers?

Again, since this is an internal-facing change I didn't want to clutter the Changelog.