### PR TITLE
Support variants with dots in their names

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Support variants with dots in their names.
+
+    *Javi Martín*
+
 ## 2.77.0
 
 * Support variants with dashes in their names.

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -189,7 +189,7 @@ module ViewComponent
             pieces = File.basename(path).split(".")
             memo << {
               path: path,
-              variant: pieces.second.split("+").second&.to_sym,
+              variant: pieces[1..-2].join(".").split("+").second&.to_sym,
               handler: pieces.last
             }
           end
@@ -254,7 +254,7 @@ module ViewComponent
     end
 
     def normalized_variant_name(variant)
-      variant.to_s.gsub("-", "__")
+      variant.to_s.gsub("-", "__").gsub(".", "___")
     end
 
     def should_compile_superclass?

--- a/test/sandbox/app/components/variants_component.html+mini-watch.erb
+++ b/test/sandbox/app/components/variants_component.html+mini-watch.erb
@@ -1,1 +1,1 @@
-Mini Watch
+Mini Watch with dash

--- a/test/sandbox/app/components/variants_component.html+mini.watch.erb
+++ b/test/sandbox/app/components/variants_component.html+mini.watch.erb
@@ -1,0 +1,1 @@
+Mini Watch with dot

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -198,7 +198,15 @@ class RenderingTest < ViewComponent::TestCase
     with_variant :"mini-watch" do
       render_inline(VariantsComponent.new)
 
-      assert_text("Mini Watch")
+      assert_text("Mini Watch with dash")
+    end
+  end
+
+  def test_renders_component_with_variant_containing_a_dot
+    with_variant :"mini.watch" do
+      render_inline(VariantsComponent.new)
+
+      assert_text("Mini Watch with dot")
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Just like we were implementing multitenancy in our application, using variants with subdomain names (see #1570), we're planning to support variants with domain names. However, ViewComponent defines methods dynamically with `def call_#{variant}`, which results in invalid Ruby code if the variant contains a dot.

### What approach did you choose and why?

As mentioned during the [pull request #1570 review](https://github.com/ViewComponent/view_component/pull/1570#discussion_r1024405549), it looks like [Bundler converts dots to triple underscores in environment variables names](https://bundler.io/man/bundle-config.1.html#CONFIGURE-BUNDLER-DIRECTORIES). The same principle was used in #1570 to replace dashes with double underscores.