### PR TITLE
Add documentation to test component with behaviors and POROs as input

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ nav_order: 5
 
     *Javi Martín*
 
+* Add documentation for testing component behaviors and POROs as input
+
+    *Nicolò Rebughini*
+
 ## 2.77.0
 
 * Support variants with dashes in their names.


### PR DESCRIPTION
### What are you trying to accomplish?

Currently in the docs [there's a handy way to test component with behaviors](https://github.com/ViewComponent/view_component/blob/main/docs/guide/testing.md#previews-as-test-cases) leveraging the previews through system specs. This method works well for components without arguments or taking simple inputs such as strings and numbers.

If we want to test components taking ActiveRecord objects as input, we can pass the IDs in the URL and then find those records in the preview, but this causes tight coupling between the specs and the preview class, forcing developers to tweak multiple files at a time.

However, this method breaks if we want to pass in POROs, or other generic objects in these preview URLs.

Here's an example of how I implemented a rough solution to this problem using RSpec and Capybara:
```rb
class OrderSummaryComponent < ApplicationComponent
  def initialize(order:)
    @order = order
  end
end

class OrderSummaryComponentPreview < ApplicationPreview
  # The default preview is not needed to make this work, we can have a empty class as well
  def default
    render(OrderSummaryComponent.new(order: Order.complete.last))
  end
end

module Helpers
  module ViewComponentSystemSpecHelpers
    def with_spec_preview(&preview_proc)
      preview_class.define_method(:spec, &preview_proc)
    end
  end
end

RSpec.describe OrderSummaryComponent do
  it 'is expandable by clicking on the button' do
    order = create(:order)
    # not saving the record intentionally to prove we display non-persisted data
    order.shipment_total = 24
    with_spec_preview do
      render(described_class.new(order: order))
    end
    visit "/rails/view_components/#{described_class.to_s.underscore}/spec"

    expect(page).to have_text("Order Summary")
    expect(page).not_to have_text("Shipping: $24.00")

    click_button "Order Summary"

    expect(page).to have_text("Shipping: $24.00")
  end
end
```

### What approach did you choose and why?

For now I'm adding this as documentation. I'll try to submit other commits or a different PR to implement such a test helper if the team feels is useful.

### Anything you want to highlight for special attention from reviewers?