### PR TITLE
Remove more deprecations for V3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: Remove deprecated `generate_*` methods. Use `generate.*` instead.
+
+    *Joel Hawksley*
+
 * BREAKING: Remove deprecated `with_variant` method.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: Remove deprecated support for loading ViewComponent engine manually.
+
+    *Joel Hawksley*
+
 * BREAKING: Remove deprecated `generate_*` methods. Use `generate.*` instead.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: Remove deprecated `rendered_component` in favor of `rendered_content`.
+
+    *Joel Hawksley*
+
 * BREAKING: Remove deprecated `config.preview_path` in favor of `config.preview_paths`.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Remove deprecated support for loading ViewComponent engine manually. Make sure you removed `require "view_component/engine"` from your `Gemfile`.
+* BREAKING: Remove deprecated support for loading ViewComponent engine manually. Make sure `require "view_component/engine"` is removed from `Gemfile`.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: Remove deprecated `with_variant` method.
+
+    *Joel Hawksley*
+
 * BREAKING: Remove deprecated `rendered_component` in favor of `rendered_content`.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Remove deprecated support for loading ViewComponent engine manually.
+* BREAKING: Remove deprecated support for loading ViewComponent engine manually. Make sure you removed `require "view_component/engine"` from your `Gemfile`.
 
     *Joel Hawksley*
 

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -81,11 +81,6 @@ end
 ```
 
 _**Note**: `call_*` methods must be public._
-
-To override the `variant` set by the request, use `with_variant`:
-
-```erb
-<%= render InlineVariantComponent.new.with_variant(:phone) %>
 ```
 
 ## Inherited

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -81,7 +81,6 @@ end
 ```
 
 _**Note**: `call_*` methods must be public._
-```
 
 ## Inherited
 

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -21,13 +21,4 @@ module ViewComponent
   autoload :Translatable
 end
 
-# :nocov:
-if defined?(ViewComponent::Engine)
-  ViewComponent::Deprecation.warn(
-    "Manually loading the engine is deprecated and will be removed in v3.0.0. " \
-    "Remove `require \"view_component/engine\"`."
-  )
-elsif defined?(Rails::Engine)
-  require "view_component/engine"
-end
-# :nocov:
+require "view_component/engine" if defined?(Rails::Engine)

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -260,18 +260,6 @@ module ViewComponent
       @__vc_variant if defined?(@__vc_variant)
     end
 
-    # Use the provided variant instead of the one determined by the current request.
-    #
-    # @deprecated Will be removed in v3.0.0.
-    # @param variant [Symbol] The variant to be used by the component.
-    # @return [self]
-    def with_variant(variant)
-      @__vc_variant = variant
-
-      self
-    end
-    deprecate :with_variant, deprecator: ViewComponent::Deprecation
-
     # The current request. Use sparingly as doing so introduces coupling that
     # inhibits encapsulation & reuse, often making testing difficult.
     #

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -66,11 +66,6 @@ module ViewComponent
       self.__vc_original_view_context = view_context
     end
 
-    _deprecated_generate_mattr_accessor :distinct_locale_files
-    _deprecated_generate_mattr_accessor :locale
-    _deprecated_generate_mattr_accessor :sidecar
-    _deprecated_generate_mattr_accessor :stimulus_controller
-
     # Entrypoint for rendering components.
     #
     # - `view_context`: ActionView context from calling view

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -66,18 +66,6 @@ module ViewComponent
       self.__vc_original_view_context = view_context
     end
 
-    # @!macro [attach] deprecated_generate_mattr_accessor
-    #   @method generate_$1
-    #   @deprecated Use `#generate.$1` instead. Will be removed in v3.0.0.
-    def self._deprecated_generate_mattr_accessor(name)
-      define_singleton_method("generate_#{name}".to_sym) do
-        generate.public_send(name)
-      end
-      define_singleton_method("generate_#{name}=".to_sym) do |value|
-        generate.public_send("#{name}=".to_sym, value)
-      end
-    end
-
     _deprecated_generate_mattr_accessor :distinct_locale_files
     _deprecated_generate_mattr_accessor :locale
     _deprecated_generate_mattr_accessor :sidecar

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -136,16 +136,3 @@ module ViewComponent
     end
   end
 end
-
-# :nocov:
-unless defined?(ViewComponent::Base)
-  require "view_component/deprecation"
-
-  ViewComponent::Deprecation.warn(
-    "This manually engine loading is deprecated and will be removed in v3.0.0. " \
-    'Remove `require "view_component/engine"`.'
-  )
-
-  require "view_component"
-end
-# :nocov:

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -31,18 +31,6 @@ module ViewComponent
     # @private
     attr_reader :rendered_content
 
-    # Returns the result of a render_inline call.
-    #
-    # @return [String]
-    def rendered_component
-      ViewComponent::Deprecation.warn(
-        "`rendered_component` is deprecated and will be removed in v3.0.0. " \
-        "Use `page` instead."
-      )
-
-      rendered_content
-    end
-
     # Render a component inline. Internally sets `page` to be a `Capybara::Node::Simple`,
     # allowing for Capybara assertions to be used:
     #

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -82,10 +82,10 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     skip unless Rails::VERSION::MAJOR >= 7
     without_template_annotations do
       ActionView::Template::Handlers::ERB.strip_trailing_newlines = true
-      rendered_component = Array.new(2) {
+      rendered_output = Array.new(2) {
         DisplayInlineComponent.new.render_in(ActionController::Base.new.view_context)
       }.join
-      assert_includes rendered_component, "<span>Hello, world!</span><span>Hello, world!</span>"
+      assert_includes rendered_output, "<span>Hello, world!</span><span>Hello, world!</span>"
     end
   ensure
     ActionView::Template::Handlers::ERB.strip_trailing_newlines = false if Rails::VERSION::MAJOR >= 7

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -25,12 +25,6 @@ class RenderingTest < ViewComponent::TestCase
     assert_includes rendered_content, "hello,world!"
   end
 
-  def test_render_inline_sets_rendered_component
-    render_inline(MyComponent.new)
-
-    assert_includes rendered_component, "hello,world!"
-  end
-
   def test_child_component
     render_inline(ChildComponent.new)
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1017,21 +1017,6 @@ class RenderingTest < ViewComponent::TestCase
     assert_selector("div", text: "foo", count: 2)
   end
 
-  def test_deprecated_generate_mattr_accessor
-    ViewComponent::Base._deprecated_generate_mattr_accessor(:test_accessor)
-    assert(ViewComponent::Base.respond_to?(:generate_test_accessor))
-    assert_equal(ViewComponent::Base.generate_test_accessor, ViewComponent::Base.generate.test_accessor)
-    ViewComponent::Base.generate_test_accessor = "changed"
-    assert_equal(ViewComponent::Base.generate_test_accessor, ViewComponent::Base.generate.test_accessor)
-    ViewComponent::Base.generate.test_accessor = "changed again"
-    assert_equal(ViewComponent::Base.generate_test_accessor, ViewComponent::Base.generate.test_accessor)
-  ensure
-    ViewComponent::Base.class_eval do
-      singleton_class.undef_method :generate_test_accessor
-      singleton_class.undef_method :generate_test_accessor=
-    end
-  end
-
   def test_inherited_component_renders_when_lazy_loading
     # Simulate lazy loading by manually removing the classes in question. This will completely
     # undo the changes made by self.class.compile and friends, forcing a compile the next time

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -81,13 +81,6 @@ class RenderingTest < ViewComponent::TestCase
     assert_selector("input[type='text'][name='name']")
   end
 
-  def test_render_without_template_variant
-    render_inline(InlineComponent.new.with_variant(:email))
-
-    assert_predicate InlineComponent, :compiled?
-    assert_selector("input[type='text'][name='email']")
-  end
-
   def test_render_child_without_template
     render_inline(InlineChildComponent.new)
 
@@ -172,12 +165,6 @@ class RenderingTest < ViewComponent::TestCase
     assert_selector("input[type='hidden'][name='authenticity_token']", visible: false)
 
     ActionController::Base.allow_forgery_protection = old_value
-  end
-
-  def test_renders_component_with_variant_method
-    render_inline(VariantsComponent.new.with_variant(:phone))
-
-    assert_text("Phone")
   end
 
   def test_renders_component_with_variant


### PR DESCRIPTION
### What are you trying to accomplish?

This PR removes more deprecated functionality for V3:

* BREAKING: Remove deprecated support for loading ViewComponent engine manually.
* BREAKING: Remove deprecated `generate_*` methods. Use `generate.*` instead.
* BREAKING: Remove deprecated `with_variant` method.
* BREAKING: Remove deprecated `rendered_component` in favor of `rendered_content`.
