### PR TITLE
Add documentation to utilize JS testing for RSpec

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Add missing documentation to use `with_rendered_component_path` with RSpec.
+* Add documentation to use `with_rendered_component_path` with RSpec.
 
     *Edwin Mak*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add missing documentation to use `with_rendered_component_path` with RSpec.
+
+    *Edwin Mak*
+
 ## 2.79.0
 
 * Add ability to pass explicit `preview_path` to preview generator.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Add documentation to use `with_rendered_component_path` with RSpec.
+* Add documentation for using `with_rendered_component_path` with RSpec.
 
     *Edwin Mak*
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -197,7 +197,6 @@ RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include ViewComponent::SystemTestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
-  config.include Capybara::DSL, type: :component
 end
 ```
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -195,7 +195,9 @@ require "capybara/rspec"
 
 RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
+  config.include ViewComponent::SystemTestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+  config.include Capybara::DSL, type: :component
 end
 ```
 


### PR DESCRIPTION
### What are you trying to accomplish?

Adding setup instructions for utilizing the [newly added JS testing approach](https://github.com/ViewComponent/view_component/pull/1061) when using RSpec. Without these configurations, using the `with_rendered_component_path` would not work.

This was sparked by a comment left here - https://github.com/ViewComponent/view_component/pull/1061#issuecomment-1347567212

### What approach did you choose and why?

N/A

### Anything you want to highlight for special attention from reviewers?

This is assuming Capybara is being used in RSpec setup, which is common. This may need some updates once we want to include instructions that don't rely on Capybara.