### PR TITLE
Move Ruby 2.7 deprecation to engine.rb

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Move Ruby 2.7 deprecation notice to engine.
+
+    *Henrik Hauge Bjørnskov*
+
 * Require Rails 5.2+ in gemspec and update documentation.
 
     *Drew Bragg*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Move Ruby 2.7 deprecation notice to engine.
+* Display Ruby 2.7 deprecation notice only once, when starting the application.
 
     *Henrik Hauge Bjørnskov*
 

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -30,10 +30,6 @@ module ViewComponent
       return if compiled? && !force
       return if component_class == ViewComponent::Base
 
-      if RUBY_VERSION < "2.7.0"
-        ViewComponent::Deprecation.deprecation_warning("Support for Ruby versions < 2.7.0")
-      end
-
       component_class.superclass.compile(raise_errors: raise_errors) if should_compile_superclass?
       subclass_instance_methods = component_class.instance_methods(false)
 

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -141,6 +141,10 @@ module ViewComponent
   end
 end
 
+if RUBY_VERSION < "2.7.0"
+  ViewComponent::Deprecation.deprecation_warning("Support for Ruby versions < 2.7.0")
+end
+
 # :nocov:
 unless defined?(ViewComponent::Base)
   require "view_component/deprecation"


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/ViewComponent/view_component/issues/1608

Prevent a deprecation notice on every compile of every component.

### What approach did you choose and why?

Move the deprecation notice to the `engine.rb` file. As it already had another deprecation notice (the require thing)

### Anything you want to highlight for special attention from reviewers?

Nope