### PR TITLE
Move system test endpoint out of preview controller to avoid issues when previews have authentication

### DIFF
--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -39,12 +39,6 @@ module ViewComponent
       end
     end
 
-    if Rails.env.test?
-      def system_test_entrypoint
-        render file: "./tmp/view_components/#{params.permit(:file)[:file]}"
-      end
-    end
-
     private
 
     # :doc:

--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -3,9 +3,7 @@
 require "rails/application_controller"
 
 class ViewComponentsSystemTestController < Rails::ApplicationController # :nodoc:
-
   def system_test_entrypoint
     render file: "./tmp/view_components/#{params.permit(:file)[:file]}"
   end
-
 end

--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails/application_controller"
+
+class ViewComponentsSystemTestController < Rails::ApplicationController # :nodoc:
+
+  def system_test_entrypoint
+    render file: "./tmp/view_components/#{params.permit(:file)[:file]}"
+  end
+
+end

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Move system test endpoint out of the unrelated previews controller
+* Move system test endpoint out of the unrelated previews controller.
 
     *Edwin Mak*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Move system test endpoint out of the unrelated previews controller
+
+    *Edwin Mak*
+
 * Display Ruby 2.7 deprecation notice only once, when starting the application.
 
     *Henrik Hauge Bjørnskov*

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -121,16 +121,18 @@ module ViewComponent
             internal: true
           )
 
-          if Rails.env.test?
-            get("_system_test_entrypoint", to: "#{preview_controller}#system_test_entrypoint")
-          end
-
           get(
             "#{options.preview_route}/*path",
             to: "#{preview_controller}#previews",
             as: :preview_view_component,
             internal: true
           )
+        end
+      end
+
+      if Rails.env.test?
+        app.routes.prepend do
+          get("_system_test_entrypoint", to: "view_components_system_test#system_test_entrypoint")
         end
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR aims to address an issue discovered in https://github.com/ViewComponent/view_component/pull/1606#issuecomment-1349640678 in which adding authentication to the previews controller causes the JS testing approach to not work. The solution we agreed upon in https://github.com/ViewComponent/view_component/pull/1606#issuecomment-1351728446 is to move the `_system_test_endpoint` into its own controller, since it isn't related to previews.

### What approach did you choose and why?

This approach was taken because it seemed the easiest and safest way to get the desired outcome.

### Anything you want to highlight for special attention from reviewers?

N/A