### PR TITLE
Make render_in_view_context forward its args to the block

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,1 @@
+ruby_version: 2.5

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Modify the `render_in_view_context` test helper to forward its args to the block.
+
+    *Cameron Dutro*
+
 ## 2.80.0
 
 * Move system test endpoint out of the unrelated previews controller.

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -99,21 +99,23 @@ module ViewComponent
       Nokogiri::HTML.fragment(@rendered_content)
     end
 
-    # Execute the given block in the view context. Internally sets `page` to be a
-    # `Capybara::Node::Simple`, allowing for Capybara assertions to be used:
+    # Execute the given block in the view context (using `instance_exec`).
+    # Internally sets `page` to be a `Capybara::Node::Simple`, allowing for
+    # Capybara assertions to be used. All arguments are forwarded to the block.
     #
     # ```ruby
-    # render_in_view_context do
-    #   render(MyComponent.new)
+    # render_in_view_context(arg1, arg2:) do |arg1, arg2:|
+    #   render(MyComponent.new(arg1, arg2))
     # end
     #
     # assert_text("Hello, World!")
     # ```
-    def render_in_view_context(&block)
+    def render_in_view_context(*args, &block)
       @page = nil
-      @rendered_content = controller.view_context.instance_exec(&block)
+      @rendered_content = controller.view_context.instance_exec(*args, &block)
       Nokogiri::HTML.fragment(@rendered_content)
     end
+    ruby2_keywords(:render_in_view_context) if respond_to?(:ruby2_keywords, true)
 
     # @private
     def controller

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -15,6 +15,17 @@ class RenderingTest < ViewComponent::TestCase
     assert_selector("div", text: "hello,world!")
   end
 
+  def test_render_in_view_context_forwards_arguments
+    @foo = "foo"
+    @bar = "bar"
+
+    render_in_view_context(@foo, bar: @bar) do |foo, bar:|
+      render(MyComponent.new) { foo + bar }
+    end
+
+    assert_text "hello,world!\nfoobar"
+  end
+
   def test_render_inline_returns_nokogiri_fragment
     assert_includes render_inline(MyComponent.new).css("div").to_html, "hello,world!"
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Our `render_in_view_context` test helper uses `instance_exec` to evaluate the given block in the view context. Since `instance_exec` changes the value of `self`, instance variables, methods, etc defined in the caller's context are not available inside the block, which can be pretty confusing. For example, consider this test:

```ruby
class MyTest < Minitest::Test
  def setup
    @user = create(:user)
  end

  def test_my_component
    render_in_view_context do
      render(MyComponent.new(@user))
    end
  end
end
```

As a direct result of using `instance_exec`, `@user` will be `nil` inside the block.

### What approach did you choose and why?

Presumably to provide an escape hatch for this problem, `instance_exec` forwards its arguments when calling the block. This PR modifies `render_in_view_context` to forward _its_ arguments to `instance_exec`, so this is now possible:

```ruby
class MyTest < Minitest::Test
  def setup
    @user = create(:user)
  end

  def test_my_component
    render_in_view_context(@user) do |user|
      render(MyComponent.new(user))
    end
  end
end
```