### PR TITLE
DO NOT MERGE Add support for relative translations in initializer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add support for relative translations in initializer.
+
+    *Joel Hawksley*
+
 * Move system test endpoint out of the unrelated previews controller.
 
     *Edwin Mak*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -83,6 +83,18 @@ module ViewComponent
     _deprecated_generate_mattr_accessor :sidecar
     _deprecated_generate_mattr_accessor :stimulus_controller
 
+    # In order for translations to work in an initializer,
+    # ActionView requires @virtual_path to be set. To set it,
+    # we allocate the component, set @virtual_path, then
+    # call the component's initializer. This is either terrible,
+    # brilliant, or both.
+    def self.new(...)
+      precursor = self.allocate
+      precursor.instance_variable_set(:@virtual_path, virtual_path)
+      precursor.send(:initialize, ...)
+      precursor
+    end
+
     # Entrypoint for rendering components.
     #
     # - `view_context`: ActionView context from calling view
@@ -106,9 +118,6 @@ module ViewComponent
 
       # For content_for
       @view_flow ||= view_context.view_flow
-
-      # For i18n
-      @virtual_path ||= virtual_path
 
       # For template variants (+phone, +desktop, etc.)
       @__vc_variant ||= @lookup_context.variants.first

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -89,7 +89,7 @@ module ViewComponent
     # call the component's initializer. This is either terrible,
     # brilliant, or both.
     def self.new(...)
-      precursor = self.allocate
+      precursor = allocate
       precursor.instance_variable_set(:@virtual_path, virtual_path)
       precursor.send(:initialize, ...)
       precursor

--- a/performance/components/translatable_component.rb
+++ b/performance/components/translatable_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Performance::TranslatableComponent < ViewComponent::Base
-  include ViewComponent::Translatable
-
   def initialize(key)
     @key = key
   end

--- a/test/sandbox/app/components/initializer_translations_component.rb
+++ b/test/sandbox/app/components/initializer_translations_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class InitializerTranslationsComponent < ViewComponent::Base
+  def initialize
+    @title = t('.title')
+    @subtitle = t('translations_component.subtitle')
+  end
+
+  def call
+    @title + @subtitle
+  end
+end

--- a/test/sandbox/app/components/translatable_component.rb
+++ b/test/sandbox/app/components/translatable_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class TranslatableComponent < ViewComponent::Base
-  include ViewComponent::Translatable
 end

--- a/test/sandbox/config/locales/en.yml
+++ b/test/sandbox/config/locales/en.yml
@@ -5,6 +5,9 @@ en:
   translations_component:
     title: Lorem ipsum
     subtitle: More lorem ipsum
+  initializer_translations_component:
+    title: Lorem ipsum
+    subtitle: More lorem ipsum
 
   translatable_component:
     relative_rails_key: Relative key from Rails

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -462,6 +462,13 @@ class RenderingTest < ViewComponent::TestCase
     assert_selector("h2", text: I18n.t("translations_component.subtitle"))
   end
 
+  def test_renders_component_with_initializer_translations
+    render_inline(InitializerTranslationsComponent.new)
+
+    assert_text(I18n.t("initializer_translations_component.title"))
+    assert_text(I18n.t("initializer_translations_component.subtitle"))
+  end
+
   def test_renders_component_with_rb_in_its_name
     render_inline(EditorbComponent.new)
 


### PR DESCRIPTION
In order for translations to work in an initializer, ActionView requires @virtual_path to be set. To set it, we allocate the component, set @virtual_path, then call the component's initializer. 

This is either terrible, brilliant, or both. What do you think?

Closes #1577

(I used the new argument forwarding syntax from Ruby 2.7, so we won't be able to land this before v3.0.0)