### PR TITLE
Fix layout nesting in system tests when using `with_rendered_component_path` with custom layouts

### DIFF
--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "rails/application_controller"
-
-class ViewComponentsSystemTestController < Rails::ApplicationController # :nodoc:
+class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
   def system_test_entrypoint
     render file: "./tmp/view_components/#{params.permit(:file)[:file]}"
   end

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Fix tests using `with_rendered_component_path` with custom layouts.
+
+    *Ian Hollander*
+
 ## 2.80.0
 
 * Move system test endpoint out of the unrelated previews controller.

--- a/docs/index.md
+++ b/docs/index.md
@@ -205,6 +205,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/yykamei?s=64" alt="yykamei" width="32" />
 <img src="https://avatars.githubusercontent.com/matheuspolicamilo?s=64" alt="matheuspolicamilo" width="32" />
 <img src="https://avatars.githubusercontent.com/erinnachen?s=64" alt="erinnachen" width="32" />
+<img src="https://avatars.githubusercontent.com/ihollander?s=64" alt="ihollander" width="32" />
 
 ## Who uses ViewComponent?
 

--- a/test/sandbox/app/views/layouts/application.html.erb
+++ b/test/sandbox/app/views/layouts/application.html.erb
@@ -6,15 +6,15 @@
 </head>
 <body data-layout="application">
   <%= yield %>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", function(event) {
+      let button = document.querySelector('[data-button]')
+      let hiddenField = document.querySelector('[data-hidden-field]')
+      button.addEventListener('click', function() {
+        hiddenField.style.display = "block"
+      })
+    })
+  </script>
 </body>
 </html>
-
-<script>
-  document.addEventListener("DOMContentLoaded", function(event) {
-    let button = document.querySelector('[data-button]')
-    let hiddenField = document.querySelector('[data-hidden-field]')
-    button.addEventListener('click', function() {
-      hiddenField.style.display = "block"
-    })
-  })
-</script>

--- a/test/sandbox/test/view_component_system_test.rb
+++ b/test/sandbox/test/view_component_system_test.rb
@@ -44,4 +44,13 @@ class ViewComponentSystemTest < ViewComponent::SystemTestCase
       find(".title", text: "This is my title!")
     end
   end
+
+  def test_layout_is_not_nested
+    with_rendered_component_path(render_inline(MyComponent.new), layout: "application") do |path|
+      visit path
+
+      assert find("div", text: "hello,world!")
+      assert_no_selector "body > title", visible: false
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #1618

This PR fixes an issue where using the `with_rendered_component_path` helper with a custom layout results in that layout being nested in the body of the [default `Rails::ApplicationController` layout](https://github.com/rails/rails/blob/main/railties/lib/rails/templates/layouts/application.html.erb).

This also fixes another issue where layouts with script or stylesheet tags were being blocked by Content Secure Policy:

<img width="556" alt="Screen Shot 2022-12-26 at 9 46 38 AM" src="https://user-images.githubusercontent.com/39830572/209560309-fe6e56fa-57ef-4790-999b-c7378716ed7e.png">

...because `Rails::ApplicationController` includes a CSP header, which means that only layouts with inline scripts are allowed by CSP:

```rb
# https://github.com/rails/rails/blob/main/railties/lib/rails/application_controller.rb#L9-L12
  content_security_policy do |policy|
    policy.script_src :self, :unsafe_inline
    policy.style_src :self, :unsafe_inline
  end
```

### What approach did you choose and why?

The approach I took was to have the `ViewComponentsSystemTestController` inherit from `ActionController::Base`, which doesn't have a default layout defined so no layout is used unless one is explicitly passed to the helper. `ActionController::Base` also doesn't set any CSP header.

Another possible approach that I didn't pursue too far would be to not use a layout when rendering the component to a file [here](https://github.com/ViewComponent/view_component/blob/main/lib/view_component/system_test_helpers.rb#L18), and instead pass layout as a param to the `ViewComponentsSystemTestController`:

```rb
        file.write(controller.render_to_string(html: fragment.to_html.html_safe))
        file.rewind

        block.call("/_system_test_entrypoint?file=#{file.path.split("/").last}&layout=#{layout.to_s}")
```

This wouldn't fix the CSP issue, however.

### Anything you want to highlight for special attention from reviewers?

Curious to get the reviewer's thoughts on what spec coverage is helpful here - I added a test case that checks if a `<title>` tag is rendered inside the `<body>` as a way to indirectly check for the nested layout issue, but I'm not sure how worthwhile that test is outside of fixing this specific issue.