### PR TITLE
Preview controller fix for recent Rails main change

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Adjust the way response objects are set on the preview controller to work around a recent change in Rails main.
+
+    *Cameron Dutro*
+
 * Fix typo in "Generate a Stimulus controller" documentation.
 
     *Ben Trewern*

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -91,7 +91,7 @@ module ViewComponent
       end
 
       previews_controller.request.params[:path] = "#{from.preview_name}/#{name}"
-      previews_controller.response = ActionDispatch::Response.new
+      previews_controller.set_response!(ActionDispatch::Response.new)
       result = previews_controller.previews
 
       @rendered_content = result


### PR DESCRIPTION
### What are you trying to accomplish?

[This change](https://github.com/rails/rails/pull/46916) was recently merged into Rails main that changes the way `ActionController::Base#response=` works. Unfortunately it breaks our preview controller. This PR should fix it.

### What approach did you choose and why?

The change linked above defines `response=` which explicitly sets `@_response_body` to `true`. Doing so [prevents the controller](https://github.com/rails/rails/blob/2e28ae403d9247181220b8a79273f953a892df69/actionpack/lib/action_controller/metal/rendering.rb#L137) from rendering any other response. This then prevents rendering any previews.