### PR TITLE
Add rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+require:
+  - standard


### PR DESCRIPTION
This removes errors from rubocop in editors due to `.rubocop.yml` not being present and falling back to defaults.

Here's the before pic:

<img width="1257" alt="Screenshot 2023-01-28 at 1 51 47 PM" src="https://user-images.githubusercontent.com/342554/215285678-5198c98f-39d7-4238-97c7-fa997a1258ae.png">

After looks as expected (no errors on `main`).