### PR TITLE
Fix #1641: Conflict with private API in TestHelpers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Fixed conflict with private API in TestHelpers ([#1646](https://github.com/ViewComponent/view_component/pull/1646))
+
+    *Jacob Carlborg*
+
 * Added example of a custom preview controller.
 
     *Graham Rogers*

--- a/lib/view_component/system_test_helpers.rb
+++ b/lib/view_component/system_test_helpers.rb
@@ -15,7 +15,7 @@ module ViewComponent
 
       file = Tempfile.new(["rendered_#{fragment.class.name}", ".html"], "tmp/view_components/")
       begin
-        file.write(controller.render_to_string(html: fragment.to_html.html_safe, layout: layout))
+        file.write(_view_component_private.controller.render_to_string(html: fragment.to_html.html_safe, layout: layout))
         file.rewind
 
         block.call("/_system_test_entrypoint?file=#{file.path.split("/").last}")

--- a/test/sandbox/test/components/previews/conflicting_private_api_preview.rb
+++ b/test/sandbox/test/components/previews/conflicting_private_api_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ConflictingPrivateApiPreview < ViewComponent::Preview
+  def default
+    render(MyComponent.new)
+  end
+end

--- a/test/sandbox/test/conflicting_private_api_test.rb
+++ b/test/sandbox/test/conflicting_private_api_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ConflictingPrivateApiTest < ViewComponent::TestCase
+  def setup
+    ViewComponent::Preview.load_previews
+  end
+
+  def controller
+  end
+
+  def request
+  end
+
+  def build_controller(_)
+  end
+
+  def preview_class
+  end
+
+  def test_with_conflicting_private_api
+    render_inline(ErbComponent.new(message: "foo"))
+    assert_content("foo")
+  end
+
+  def test_with_conflicting_request
+    with_request_url("/") do
+      render_inline(ErbComponent.new(message: "foo"))
+      assert_content("foo")
+    end
+  end
+
+  def test_with_conflicting_preview_class
+    render_preview(:default)
+
+    assert_selector("div", text: "hello,world!")
+  end
+end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -33,7 +33,7 @@ class RenderingTest < ViewComponent::TestCase
   def test_render_inline_sets_rendered_content
     render_inline(MyComponent.new)
 
-    assert_includes rendered_content, "hello,world!"
+    assert_includes _view_component_private.rendered_content, "hello,world!"
   end
 
   def test_child_component
@@ -408,7 +408,7 @@ class RenderingTest < ViewComponent::TestCase
 
     assert_text("Rendered")
 
-    controller.view_context.cookies[:shown] = true
+    _view_component_private.controller.view_context.cookies[:shown] = true
 
     render_inline(RenderCheckComponent.new)
 
@@ -854,7 +854,7 @@ class RenderingTest < ViewComponent::TestCase
     end
 
     with_request_url "/products" do
-      assert_equal "/products", request.path
+      assert_equal "/products", _view_component_private.request.path
     end
   end
 
@@ -875,13 +875,13 @@ class RenderingTest < ViewComponent::TestCase
     end
 
     with_request_url "/products?mykey=myvalue&otherkey=othervalue" do
-      assert_equal "/products", request.path
-      assert_equal "mykey=myvalue&otherkey=othervalue", request.query_string
-      assert_equal "/products?mykey=myvalue&otherkey=othervalue", request.fullpath
+      assert_equal "/products", _view_component_private.request.path
+      assert_equal "mykey=myvalue&otherkey=othervalue", _view_component_private.request.query_string
+      assert_equal "/products?mykey=myvalue&otherkey=othervalue", _view_component_private.request.fullpath
     end
 
     with_request_url "/products?mykey[mynestedkey]=myvalue" do
-      assert_equal({"mynestedkey" => "myvalue"}, request.parameters["mykey"])
+      assert_equal({"mynestedkey" => "myvalue"}, _view_component_private.request.parameters["mykey"])
     end
   end
 
@@ -984,7 +984,7 @@ class RenderingTest < ViewComponent::TestCase
       render_inline(TrailingWhitespaceComponent.new)
     end
 
-    refute @rendered_content =~ /\s+\z/, "Rendered component contains trailing whitespace"
+    refute _view_component_private.rendered_content =~ /\s+\z/, "Rendered component contains trailing whitespace"
   end
 
   def test_renders_objects_in_component_view_context

--- a/test/sandbox/test/test_helper_test.rb
+++ b/test/sandbox/test/test_helper_test.rb
@@ -23,7 +23,7 @@ class TestHelperTest < ViewComponent::TestCase
     warden = Minitest::Mock.new
     warden.expect(:authenticate!, true)
 
-    request.env["warden"] = warden
+    _view_component_private.request.env["warden"] = warden
 
     with_request_url "/constraints_with_env" do
       render_inline(ControllerInlineComponent.new(message: "request.env is valid"))


### PR DESCRIPTION
### What are you trying to accomplish?

Reduce the risk of causing conflicts with the private API in ViewComponent tests, see #1641.

### What approach did you choose and why?

I chose to hide all existing private API behind one single method, to reduce the surface of the private API. Due to the way `include` in Ruby works, I don't think it's possible to completely fix this issue. Only reduce the risk of it occurring.

### Anything you want to highlight for special attention from reviewers?

Several of the existing tests use the private API. I've only made sure the tests continue to pass without trying to remove the usage of the private API. My changes clearly highlight where the private API is used.