### PR TITLE
Add prefix option to polymorphic slots

### DIFF
--- a/lib/view_component/polymorphic_slots.rb
+++ b/lib/view_component/polymorphic_slots.rb
@@ -57,7 +57,8 @@ module ViewComponent
 
           setter_name =
             if collection
-              prefix ? "#{ActiveSupport::Inflector.singularize(slot_name)}_#{poly_type}" : "#{poly_type}_#{ActiveSupport::Inflector.singularize(slot_name)}"
+              singular_slot_name = ActiveSupport::Inflector.singularize(slot_name)
+              prefix ? "#{singular_slot_name}_#{poly_type}" : "#{poly_type}_#{singular_slot_name}"
             else
               poly_slot_name
             end

--- a/test/sandbox/app/components/polymorphic_content_slot_component.rb
+++ b/test/sandbox/app/components/polymorphic_content_slot_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PolymorphicContentSlotComponent < ViewComponent::Base
-  renders_one :leading_visual, types: {
+  renders_one :leading_visual, prefix: true, types: {
     icon: lambda { |title|
       content_tag("h1") do
         title

--- a/test/sandbox/app/components/polymorphic_slot_component.rb
+++ b/test/sandbox/app/components/polymorphic_slot_component.rb
@@ -6,7 +6,7 @@ class PolymorphicSlotComponent < ViewComponent::Base
     special: lambda { |&block| content_tag(:div, class: "special", &block) }
   }
 
-  renders_many :items, types: {
+  renders_many :items, prefix: true, types: {
     foo: "FooItem",
     bar: lambda { |class_names: "", **_system_arguments|
       classes = (class_names.split(" ") + ["bar"]).join(" ")

--- a/test/sandbox/test/slotable_v2_test.rb
+++ b/test/sandbox/test/slotable_v2_test.rb
@@ -492,7 +492,7 @@ class SlotsV2sTest < ViewComponent::TestCase
 
   def test_polymorphic_slot_with_setters
     render_inline(PolymorphicSlotComponent.new) do |component|
-      component.with_header_standard { "standard" }
+      component.with_standard_header { "standard" }
       component.with_item_foo(class_names: "custom-foo")
       component.with_item_bar(class_names: "custom-bar")
     end
@@ -538,7 +538,7 @@ class SlotsV2sTest < ViewComponent::TestCase
 
   def test_polymorphic_slot
     render_inline(PolymorphicSlotComponent.new) do |component|
-      component.with_header_standard { "standard" }
+      component.with_standard_header { "standard" }
       component.with_item_foo(class_names: "custom-foo")
       component.with_item_bar(class_names: "custom-bar")
     end
@@ -559,8 +559,8 @@ class SlotsV2sTest < ViewComponent::TestCase
   def test_singular_polymorphic_slot_raises_on_redefinition
     error = assert_raises ArgumentError do
       render_inline(PolymorphicSlotComponent.new) do |component|
-        component.with_header_standard { "standard" }
-        component.with_header_special { "special" }
+        component.with_standard_header { "standard" }
+        component.with_special_header { "special" }
       end
     end
 


### PR DESCRIPTION
Close #1526

### What are you trying to accomplish?

Add support for a `prefix: true` option when declaring a polymorphic slot, that flips the order of the slot accessor methods names.

### What approach did you choose and why?

This is a first draft, in order to move the discussion in #1526 forward.

### Anything you want to highlight for special attention from reviewers?

This PR introduces a breaking change to the current default behavior (put the slot name first and the type second).

Now the slot name is second, which makes more sense in most cases: `with_standard_header`, `with_text_field` etc.

Adding `prefix: true` to the slot definitions reverts to the previous behavior.