### PR TITLE
Remove `evironment` dependency of rake task `view_component:statsetup`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Remove dependency on environment task from view_component:statsetup
+* Remove dependency on environment task from `view_component:statsetup`.
 
     *Svetlin Simonyan*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ nav_order: 5
 # Changelog
 
 ## main
+
 * Remove dependency on environment task from view_component:statsetup
 
     *Svetlin Simonyan*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ nav_order: 5
 # Changelog
 
 ## main
+* Remove dependency on environment task from view_component:statsetup
+
+    *Svetlin Simonyan*
 
 * Add experimental `config.view_component.capture_compatibility_patch_enabled` option resolving rendering issues related to forms, capture, turbo frames, etc.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -206,6 +206,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/matheuspolicamilo?s=64" alt="matheuspolicamilo" width="32" />
 <img src="https://avatars.githubusercontent.com/erinnachen?s=64" alt="erinnachen" width="32" />
 <img src="https://avatars.githubusercontent.com/ihollander?s=64" alt="ihollander" width="32" />
+<img src="https://avatars.githubusercontent.com/svetlins?s=64" alt="svetlins" width="32" />
 
 ## Who uses ViewComponent?
 

--- a/lib/view_component/rails/tasks/view_component.rake
+++ b/lib/view_component/rails/tasks/view_component.rake
@@ -3,7 +3,7 @@
 task stats: "view_component:statsetup"
 
 namespace :view_component do
-  task statsetup: :environment do
+  task :statsetup do
     require "rails/code_statistics"
 
     ::STATS_DIRECTORIES << ["ViewComponents", ViewComponent::Base.view_component_path]

--- a/test/sandbox/test/rake_tasks_test.rb
+++ b/test/sandbox/test/rake_tasks_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ViewComponent
+  class RakeTasksTest < TestCase
+    def setup
+      Sandbox::Application.load_tasks
+    end
+
+    def test_statsetup_task
+      Rake::Task['view_component:statsetup'].invoke
+      assert_includes ::STATS_DIRECTORIES, ["ViewComponents", "app/components"]
+    end
+  end
+end

--- a/test/sandbox/test/rake_tasks_test.rb
+++ b/test/sandbox/test/rake_tasks_test.rb
@@ -9,7 +9,7 @@ module ViewComponent
     end
 
     def test_statsetup_task
-      Rake::Task['view_component:statsetup'].invoke
+      Rake::Task["view_component:statsetup"].invoke
       assert_includes ::STATS_DIRECTORIES, ["ViewComponents", "app/components"]
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Running `rake stats` in a Rails app that's using `view_component` may fail if the app is not bootable in the current environment (e.g. CI). That differs from the behavior of `rake stats` if `view_component` is not installed

The reason is that the gem hooks its own setup task as a dependency of the `stats` task and prepended task itself depends on `environment`, thus introducing `environment` as a transitive dependency of `stats`.

What's more it doesn't seem there's a reason for adding this dependency (at least I can't see one).

My goal is to restore the behavior of stats being runnable even if the app is not bootable.

The specific problem we hit arising from this is that we run `rake stats` as CI step which started breaking once we introduced `view_component` because we have initializers that depend on Rails credentials for which we don't setup a key on the CI. This is also a problem of our code base in itself as depending on credentials in initializers is wrong but that's a separate issue :)

I think this should be fixed as I suspect other people run into it and the errors arising from this are completely dependent on the actual details of the app and can be quite mysterious. There's also a (very small) performance overhead.

### What approach did you choose and why?

I simply changed the `view_component:statssetup` task to not depend on `environment`. I added a test case even though I'm not sure adding is the correct trade-off as it has some side effects and doesn't test a whole lot.

### Anything you want to highlight for special attention from reviewers?

* I would kindly ask if anybody has knowledge of a reason for `view_component:statssetup` depending on `environment` that I have missed.
* I would like feedback on the viability of the added test case - it calls `.load_tasks` and invokes the task itself which modifies a top level constant both of which have side effects and might have unintended consequences in the future.