### PR TITLE
Avoid loading ActionView::Base during initialization

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Avoid loading ActionView::Base during Rails initialization. Originally submitted in #1528.
+
+    *Jonathan del Strother*
+
 * Improve documentation of known incompatibilities with Rails form helpers.
 
     *Tobias L. Maier*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -21,7 +21,7 @@ module ViewComponent
       #
       # @return [ViewComponent::Config]
       def config
-        @config ||= ViewComponent::Config.defaults
+        @config ||= ActiveSupport::OrderedOptions.new
       end
 
       # Replaces the entire config. You shouldn't need to use this directly

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 require "rails"
-require "view_component/base"
+require "view_component/config"
 
 module ViewComponent
   class Engine < Rails::Engine # :nodoc:
-    config.view_component = ViewComponent::Base.config
+    config.view_component = ViewComponent::Config.defaults
 
     rake_tasks do
       load "view_component/rails/tasks/view_component.rake"
@@ -14,9 +14,6 @@ module ViewComponent
     initializer "view_component.set_configs" do |app|
       options = app.config.view_component
 
-      %i[generate preview_controller preview_route show_previews_source].each do |config_option|
-        options[config_option] ||= ViewComponent::Base.public_send(config_option)
-      end
       options.instrumentation_enabled = false if options.instrumentation_enabled.nil?
       options.render_monkey_patch_enabled = true if options.render_monkey_patch_enabled.nil?
       options.show_previews = (Rails.env.development? || Rails.env.test?) if options.show_previews.nil?
@@ -39,6 +36,8 @@ module ViewComponent
 
     initializer "view_component.enable_instrumentation" do |app|
       ActiveSupport.on_load(:view_component) do
+        Base.config = app.config.view_component
+
         if app.config.view_component.instrumentation_enabled.present?
           # :nocov:
           ViewComponent::Base.prepend(ViewComponent::Instrumentation)

--- a/test/sandbox/config/application.rb
+++ b/test/sandbox/config/application.rb
@@ -8,6 +8,24 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
 
+# Track when different Rails frameworks get loaded.
+# Ideally, none of them should be loaded until after initialization is complete.
+# See config/initializers/zzz_complete_initialization.rb for the other half of this.
+RAILS_FRAMEWORKS = [
+  :action_cable,
+  :action_controller,
+  :action_mailer,
+  :action_view,
+  :active_job,
+  :active_record
+]
+FRAMEWORK_LOAD_POINTS = {}
+RAILS_FRAMEWORKS.each do |feature|
+  ActiveSupport.on_load(feature) do
+    FRAMEWORK_LOAD_POINTS[feature] = caller
+  end
+end
+
 require "view_component"
 
 require "haml"

--- a/test/sandbox/config/initializers/zzz_complete_initialization.rb
+++ b/test/sandbox/config/initializers/zzz_complete_initialization.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# FRAMEWORK_LOAD_POINTS ought to be empty - we shouldn't have
+# autoloaded ActionView::Base during initialization, for example.
+FRAMEWORK_LOAD_POINTS.each do |framework, caller|
+  warn "#{framework} loaded too soon, from:"
+  warn caller
+  exit 1
+end


### PR DESCRIPTION
### What are you trying to accomplish?

This un-reverts the revert of #1528. I was unable to reproduce the Sorbet issue that caused us to revert, and there are a lot of good reasons to avoid loading `ActionView::Base` during initialization.

All credit goes to @jdelStrother for the implementation.