### PR TITLE
Protect against Arbitrary File Read in System Test Controller

### DIFF
--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -19,7 +19,7 @@ class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
   # Ensure that the file path is valid and doesn't target files outside
   # the expected directory (e.g. via a path traversal or symlink attack)
   def validate_file_path
-    base_path = ::File.realpath(TEMP_DIR).freeze
+    base_path = ::File.realpath(TEMP_DIR)
     @path = ::File.realpath(params.permit(:file)[:file], base_path)
     unless @path.start_with?(base_path)
       raise ArgumentError, "Invalid file path"

--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -1,7 +1,27 @@
 # frozen_string_literal: true
 
 class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
+  BASE_VIEW_COMPONENT_PATH = ::File.realpath("./tmp/view_components/").freeze
+
+  before_action :validate_test_env
+  before_action :validate_file_path
+
   def system_test_entrypoint
-    render file: "./tmp/view_components/#{params.permit(:file)[:file]}"
+    render file: @path
+  end
+
+  private
+
+  def validate_test_env
+    raise "ViewComponentsSystemTestController must only be called in a test environment" unless Rails.env.test?
+  end
+
+  # Ensure that the file path is valid and doesn't target files outside
+  # the expected directory (e.g. via a path traversal or symlink attack)
+  def validate_file_path
+    @path = ::File.realpath(params.permit(:file)[:file], BASE_VIEW_COMPONENT_PATH)
+    unless @path.start_with?(BASE_VIEW_COMPONENT_PATH)
+      raise ArgumentError, "Invalid file path"
+    end
   end
 end

--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
+  TEMP_DIR = "./tmp/view_components/"
+
   before_action :validate_test_env
   before_action :validate_file_path
 
@@ -17,9 +19,9 @@ class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
   # Ensure that the file path is valid and doesn't target files outside
   # the expected directory (e.g. via a path traversal or symlink attack)
   def validate_file_path
-    FileUtils.mkdir_p("./tmp/view_components/")
+    FileUtils.mkdir_p(TEMP_DIR)
 
-    base_path = ::File.realpath("./tmp/view_components/").freeze
+    base_path = ::File.realpath(TEMP_DIR).freeze
     @path = ::File.realpath(params.permit(:file)[:file], base_path)
     unless @path.start_with?(base_path)
       raise ArgumentError, "Invalid file path"

--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
-  TEMP_DIR = "./tmp/view_components/"
+  TEMP_DIR = FileUtils.mkdir_p("./tmp/view_components/").first
 
   before_action :validate_test_env
   before_action :validate_file_path
@@ -19,8 +19,6 @@ class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
   # Ensure that the file path is valid and doesn't target files outside
   # the expected directory (e.g. via a path traversal or symlink attack)
   def validate_file_path
-    FileUtils.mkdir_p(TEMP_DIR)
-
     base_path = ::File.realpath(TEMP_DIR).freeze
     @path = ::File.realpath(params.permit(:file)[:file], base_path)
     unless @path.start_with?(base_path)

--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
-  BASE_VIEW_COMPONENT_PATH = ::File.realpath("./tmp/view_components/").freeze
-
   before_action :validate_test_env
   before_action :validate_file_path
 
@@ -19,8 +17,11 @@ class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
   # Ensure that the file path is valid and doesn't target files outside
   # the expected directory (e.g. via a path traversal or symlink attack)
   def validate_file_path
-    @path = ::File.realpath(params.permit(:file)[:file], BASE_VIEW_COMPONENT_PATH)
-    unless @path.start_with?(BASE_VIEW_COMPONENT_PATH)
+    FileUtils.mkdir_p("./tmp/view_components/")
+
+    base_path = ::File.realpath("./tmp/view_components/").freeze
+    @path = ::File.realpath(params.permit(:file)[:file], base_path)
+    unless @path.start_with?(base_path)
       raise ArgumentError, "Invalid file path"
     end
   end

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Protect against Arbitrary File Read in `ViewComponentsSystemTestController`
+* Protect against Arbitrary File Read edge case in `ViewComponentsSystemTestController`.
 
     *Nick Malcolm*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Protect against Arbitrary File Read in `ViewComponentsSystemTestController`
+
+    *Nick Malcolm*
+
 ## v3.0.0.rc2
 
 Run into an issue with this release? [Let us know](https://github.com/ViewComponent/view_component/issues/1629).

--- a/docs/index.md
+++ b/docs/index.md
@@ -207,6 +207,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/erinnachen?s=64" alt="erinnachen" width="32" />
 <img src="https://avatars.githubusercontent.com/ihollander?s=64" alt="ihollander" width="32" />
 <img src="https://avatars.githubusercontent.com/svetlins?s=64" alt="svetlins" width="32" />
+<img src="https://avatars.githubusercontent.com/nickmalcolm?s=64" alt="nickmalcolm" width="32" />
 
 ## Who uses ViewComponent?
 

--- a/lib/view_component/system_test_helpers.rb
+++ b/lib/view_component/system_test_helpers.rb
@@ -10,10 +10,10 @@ module ViewComponent
     # @param layout [String] The (optional) layout to use.
     # @return [Proc] A block that can be used to visit the path of the inline rendered component.
     def with_rendered_component_path(fragment, layout: false, &block)
-      # Add './tmp/view_components/' directory if it doesn't exist to store the rendered component HTML
-      FileUtils.mkdir_p("./tmp/view_components/") unless Dir.exist?("./tmp/view_components/")
-
-      file = Tempfile.new(["rendered_#{fragment.class.name}", ".html"], "tmp/view_components/")
+      file = Tempfile.new(
+        ["rendered_#{fragment.class.name}", ".html"],
+        ViewComponentsSystemTestController::TEMP_DIR
+      )
       begin
         file.write(__vc_test_helpers_controller.render_to_string(html: fragment.to_html.html_safe, layout: layout))
         file.rewind

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -663,4 +663,12 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       config_entrypoints.rotate!
     end
   end
+
+  def test_path_traversal_raises_error
+    path = "../../README.md"
+
+    assert_raises ArgumentError do
+      get "/_system_test_entrypoint?file=#{path}"
+    end
+  end
 end

--- a/test/sandbox/test/view_component_system_test.rb
+++ b/test/sandbox/test/view_component_system_test.rb
@@ -53,12 +53,4 @@ class ViewComponentSystemTest < ViewComponent::SystemTestCase
       assert_no_selector "body > title", visible: false
     end
   end
-
-  def test_path_traversal_raises_error
-    # Use a valid example path that the rails app has permission to read.
-    path = "../../README.md"
-    assert_raises ArgumentError do
-      visit "/_system_test_entrypoint?file=#{path}"
-    end
-  end
 end

--- a/test/sandbox/test/view_component_system_test.rb
+++ b/test/sandbox/test/view_component_system_test.rb
@@ -53,4 +53,12 @@ class ViewComponentSystemTest < ViewComponent::SystemTestCase
       assert_no_selector "body > title", visible: false
     end
   end
+
+  def test_path_traversal_raises_error
+    # Use a valid example path that the rails app has permission to read.
+    path = "../../README.md"
+    assert_raises ArgumentError do
+      visit "/_system_test_entrypoint?file=#{path}"
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Resolves https://github.com/ViewComponent/view_component/issues/1663. When a file path is passed to `ViewComponentsSystemTestController` it will ensure that the path exists and is within `/tmp/view_components/`. It will also raise an error if run outside of a test environment.

One thing I can't quickly figure out is how to get the test to pass properly 😅 It raises the error as expected, but I think the Rails App is catching the error instead of passing it to Minitest. It says nothing was raised ... then says the test failed because an error was raised.

```
Failure:
ViewComponentSystemTest#test_path_traversal_raises_error:
ArgumentError expected but nothing was raised.

Error:
ViewComponentSystemTest#test_path_traversal_raises_error:
ArgumentError: Invalid file path
```

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

See https://github.com/ViewComponent/view_component/issues/1663 for discussion.

### Anything you want to highlight for special attention from reviewers?

Assistance with getting the test to pass, please.