### PR TITLE
Fix generate configuration

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Fix typos in generator docs.
+
+    *Sascha Karnatz*
+
 * Add support for experimental inline templates.
 
     *Blake Williams*

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -102,7 +102,7 @@ bin/rails generate component Example title --stimulus
       create    app/components/example_component.html.erb
 ```
 
-To always generate a Stimulus controller, set `config.view_component.generate_stimulus_controller = true`.
+To always generate a Stimulus controller, set `config.view_component.generate.stimulus_controller = true`.
 
 ### Generate [locale files](/guide/translations.html)
 
@@ -121,9 +121,9 @@ bin/rails generate component Example title --locale
       create    app/components/example_component.html.erb
 ```
 
-To always generate locale files, set `config.view_component.generate_locale = true`.
+To always generate locale files, set `config.view_component.generate.locale = true`.
 
-To generate translations in distinct locale files, set `config.view_component.generate_distinct_locale_files = true` to generate as many files as configured in `I18n.available_locales`.
+To generate translations in distinct locale files, set `config.view_component.generate.distinct_locale_files = true` to generate as many files as configured in `I18n.available_locales`.
 
 ### Place the view in a sidecar directory
 


### PR DESCRIPTION
The previous configurations are not working any more. The `generate_....` notation was replaced with a `generate. ...` object.

### What are you trying to accomplish?

Fixing the shown configurations.

### What approach did you choose and why?

Only replacing the not working configurations with working ones.

### Anything you want to highlight for special attention from reviewers?

nope