### PR TITLE
Add TestHelpers#vc_test_controller

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add `TestHelpers#vc_test_controller`.
+
+    *Joel Hawksley*
+
 * Add support for experimental inline templates.
 
     *Blake Williams*

--- a/lib/view_component/system_test_helpers.rb
+++ b/lib/view_component/system_test_helpers.rb
@@ -15,7 +15,7 @@ module ViewComponent
         ViewComponentsSystemTestController::TEMP_DIR
       )
       begin
-        file.write(__vc_test_helpers_controller.render_to_string(html: fragment.to_html.html_safe, layout: layout))
+        file.write(vc_test_controller.render_to_string(html: fragment.to_html.html_safe, layout: layout))
         file.rewind
 
         block.call("/_system_test_entrypoint?file=#{file.path.split("/").last}")

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -47,9 +47,9 @@ module ViewComponent
       @page = nil
       @rendered_content =
         if Rails.version.to_f >= 6.1
-          __vc_test_helpers_controller.view_context.render(component, args, &block)
+          vc_test_controller.view_context.render(component, args, &block)
         else
-          __vc_test_helpers_controller.view_context.render_component(component, &block)
+          vc_test_controller.view_context.render_component(component, &block)
         end
 
       Nokogiri::HTML.fragment(@rendered_content)
@@ -105,7 +105,7 @@ module ViewComponent
     # ```
     def render_in_view_context(*args, &block)
       @page = nil
-      @rendered_content = __vc_test_helpers_controller.view_context.instance_exec(*args, &block)
+      @rendered_content = vc_test_controller.view_context.instance_exec(*args, &block)
       Nokogiri::HTML.fragment(@rendered_content)
     end
     ruby2_keywords(:render_in_view_context) if respond_to?(:ruby2_keywords, true)
@@ -120,12 +120,12 @@ module ViewComponent
     #
     # @param variant [Symbol] The variant to be set for the provided block.
     def with_variant(variant)
-      old_variants = __vc_test_helpers_controller.view_context.lookup_context.variants
+      old_variants = vc_test_controller.view_context.lookup_context.variants
 
-      __vc_test_helpers_controller.view_context.lookup_context.variants = variant
+      vc_test_controller.view_context.lookup_context.variants = variant
       yield
     ensure
-      __vc_test_helpers_controller.view_context.lookup_context.variants = old_variants
+      vc_test_controller.view_context.lookup_context.variants = old_variants
     end
 
     # Set the controller to be used while executing the given block,
@@ -139,12 +139,12 @@ module ViewComponent
     #
     # @param klass [ActionController::Base] The controller to be used.
     def with_controller_class(klass)
-      old_controller = defined?(@__vc_test_helpers_controller) && @__vc_test_helpers_controller
+      old_controller = defined?(@vc_test_controller) && @vc_test_controller
 
-      @__vc_test_helpers_controller = __vc_test_helpers_build_controller(klass)
+      @vc_test_controller = __vc_test_helpers_build_controller(klass)
       yield
     ensure
-      @__vc_test_helpers_controller = old_controller
+      @vc_test_controller = old_controller
     end
 
     # Set the URL of the current request (such as when using request-dependent path helpers):
@@ -161,7 +161,7 @@ module ViewComponent
       old_request_path_parameters = __vc_test_helpers_request.path_parameters
       old_request_query_parameters = __vc_test_helpers_request.query_parameters
       old_request_query_string = __vc_test_helpers_request.query_string
-      old_controller = defined?(@__vc_test_helpers_controller) && @__vc_test_helpers_controller
+      old_controller = defined?(@vc_test_controller) && @vc_test_controller
 
       path, query = path.split("?", 2)
       __vc_test_helpers_request.path_info = path
@@ -174,15 +174,26 @@ module ViewComponent
       __vc_test_helpers_request.path_parameters = old_request_path_parameters
       __vc_test_helpers_request.set_header("action_dispatch.request.query_parameters", old_request_query_parameters)
       __vc_test_helpers_request.set_header(Rack::QUERY_STRING, old_request_query_string)
-      @__vc_test_helpers_controller = old_controller
+      @vc_test_controller = old_controller
+    end
+
+    # Access the controller used by `render_inline`:
+    #
+    # ```ruby
+    # test "logged out user sees login link" do
+    #   vc_test_controller.expects(:logged_in?).at_least_once.returns(false)
+    #   render_inline(LoginComponent.new)
+    #   assert_selector("[aria-label='You must be signed in']")
+    # end
+    # ```
+    #
+    # @return [ActionController::Base]
+    def vc_test_controller
+      @vc_test_controller ||= __vc_test_helpers_build_controller(Base.test_controller.constantize)
     end
 
     # Note: We prefix private methods here to prevent collisions in consumer's tests.
     private
-
-    def __vc_test_helpers_controller
-      @__vc_test_helpers_controller ||= __vc_test_helpers_build_controller(Base.test_controller.constantize)
-    end
 
     def __vc_test_helpers_request
       @__vc_test_helpers_request ||=

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -415,7 +415,7 @@ class RenderingTest < ViewComponent::TestCase
         render_inline(ValidationsComponent.new)
       end
 
-    assert_equal "Validation failed: Content can't be blank", exception.message
+    assert_includes exception.message, "Validation failed: Content"
   end
 
   def test_compiles_unrendered_component

--- a/test/sandbox/test/test_helper_test.rb
+++ b/test/sandbox/test/test_helper_test.rb
@@ -31,4 +31,8 @@ class TestHelperTest < ViewComponent::TestCase
 
     assert_selector("div", text: "request.env is valid")
   end
+
+  def test_vc_test_controller_exists
+    assert vc_test_controller.is_a?(ActionController::Base)
+  end
 end


### PR DESCRIPTION
In https://github.com/ViewComponent/view_component/pull/1661, I renamed several private TestHelper methods to indicate that they should not be used by consumers.

However, we depended on the `controller` method in the GitHub.com test suite. I've chosen to reintroduce this method with new name, as we originally made it private due to it conflicting with folks setting a `controller` method name in tests.