### PR TITLE
Add TestHelpers#vc_test_request

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add `TestHelpers#vc_test_request`.
+
+    *Joel Hawksley*
+
 ## v3.0.0.rc3
 
 Run into an issue with this release candidate? [Let us know](https://github.com/ViewComponent/view_component/issues/1629).

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -841,7 +841,7 @@ class RenderingTest < ViewComponent::TestCase
     end
 
     with_request_url "/products" do
-      assert_equal "/products", __vc_test_helpers_request.path
+      assert_equal "/products", vc_test_request.path
     end
   end
 
@@ -862,13 +862,13 @@ class RenderingTest < ViewComponent::TestCase
     end
 
     with_request_url "/products?mykey=myvalue&otherkey=othervalue" do
-      assert_equal "/products", __vc_test_helpers_request.path
-      assert_equal "mykey=myvalue&otherkey=othervalue", __vc_test_helpers_request.query_string
-      assert_equal "/products?mykey=myvalue&otherkey=othervalue", __vc_test_helpers_request.fullpath
+      assert_equal "/products", vc_test_request.path
+      assert_equal "mykey=myvalue&otherkey=othervalue", vc_test_request.query_string
+      assert_equal "/products?mykey=myvalue&otherkey=othervalue", vc_test_request.fullpath
     end
 
     with_request_url "/products?mykey[mynestedkey]=myvalue" do
-      assert_equal({"mynestedkey" => "myvalue"}, __vc_test_helpers_request.parameters["mykey"])
+      assert_equal({"mynestedkey" => "myvalue"}, vc_test_request.parameters["mykey"])
     end
   end
 

--- a/test/sandbox/test/test_helper_test.rb
+++ b/test/sandbox/test/test_helper_test.rb
@@ -23,7 +23,7 @@ class TestHelperTest < ViewComponent::TestCase
     warden = Minitest::Mock.new
     warden.expect(:authenticate!, true)
 
-    __vc_test_helpers_request.env["warden"] = warden
+    vc_test_request.env["warden"] = warden
 
     with_request_url "/constraints_with_env" do
       render_inline(ControllerInlineComponent.new(message: "request.env is valid"))


### PR DESCRIPTION
In #1661, I renamed several private TestHelper methods to indicate that they should not be used by consumers.

However, we depended on the request method in the GitHub.com test suite. I've chosen to reintroduce this method with a new name, as we originally made it private due to it conflicting with folks setting a request method name in tests.