### PR TITLE
Failing test for request formats

### DIFF
--- a/test/sandbox/app/components/request_formats_component.html.erb
+++ b/test/sandbox/app/components/request_formats_component.html.erb
@@ -1,0 +1,1 @@
+<p>Hello, HTML World!</p>

--- a/test/sandbox/app/components/request_formats_component.rb
+++ b/test/sandbox/app/components/request_formats_component.rb
@@ -1,0 +1,2 @@
+class RequestFormatsComponent < ViewComponent::Base
+end

--- a/test/sandbox/app/components/request_formats_component.text.erb
+++ b/test/sandbox/app/components/request_formats_component.text.erb
@@ -1,0 +1,1 @@
+Hello, Text World!

--- a/test/sandbox/app/controllers/integration_examples_controller.rb
+++ b/test/sandbox/app/controllers/integration_examples_controller.rb
@@ -55,4 +55,8 @@ class IntegrationExamplesController < ActionController::Base
   def inherited_from_uncompilable_component
     render(InheritedFromUncompilableComponent.new)
   end
+
+  def request_formats
+    render(RequestFormatsComponent.new)
+  end
 end

--- a/test/sandbox/config/routes.rb
+++ b/test/sandbox/config/routes.rb
@@ -18,6 +18,7 @@ Sandbox::Application.routes.draw do
   get :render_component, to: "integration_examples#render_component"
   get :controller_inline_render_component, to: "integration_examples#controller_inline_render_component"
   get :controller_to_string_render_component, to: "integration_examples#controller_to_string_render_component"
+  get :request_formats, to: "integration_examples#request_formats"
   get :layout_default, to: "layouts#default"
   get :layout_global_for_action, to: "layouts#global_for_action"
   get :layout_explicit_in_action, to: "layouts#explicit_in_action"

--- a/test/sandbox/test/request_formats_test.rb
+++ b/test/sandbox/test/request_formats_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class RequestFormatsTest < ActionDispatch::IntegrationTest
+  def test_rendering_component_with_multiple_formats
+    get "/request_formats"
+    assert_response :success
+
+    assert_select("p", "Hello, HTML World")
+  end
+
+  def test_rendering_text_format
+    get "/request_formats.txt"
+    assert_response :success
+
+    assert_text("Hello, Text World")
+  end
+end


### PR DESCRIPTION
An initial stab at a failing test for #1670 - multipart emails are one part of this, multiple templates per request format may be a more generic case? If not, multiple formats is also a compelling feature for me.