### PR TITLE
docs: Improve contrast for `::selection` style of code blocks

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -203,3 +203,6 @@
 .highlight {
   background-color: #f8f8f8;
 }
+.highlight ::selection {
+  background-color: #0366D6;
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Improve the text selection contrast when selecting text in code blocks in the docs.

| **Before** | **After** |
| --- | --- |
| ![Screenshot 2023-03-15 at 21 22 51](https://user-images.githubusercontent.com/6411752/225433398-1bfe4475-04ba-4703-ac64-78e4adfefb7a.png) | ![Screenshot 2023-03-15 at 21 23 02](https://user-images.githubusercontent.com/6411752/225433429-aa4a81e2-aeee-48db-a0ab-13e420d616eb.png) |


### What approach did you choose and why?

I added a new CSS rule for the `.highlight ::selection` selector with the color `#0366D6` which is currently also being used for selecting regular text on the page.

### Anything you want to highlight for special attention from reviewers?
\- 