### PR TITLE
Protect against SystemStackError if CaptureCompatibility module is included more than once

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Protect against `SystemStackError` if `CaptureCompatibility` module is included more than once.
+
+    *Cameron Dutro*
+
 ## v3.0.0.rc4
 
 Run into an issue with this release candidate? [Let us know](https://github.com/ViewComponent/view_component/issues/1629).

--- a/lib/view_component/capture_compatibility.rb
+++ b/lib/view_component/capture_compatibility.rb
@@ -17,6 +17,8 @@ module ViewComponent
   # the `capture` logic to the ViewComponent that created the block.
   module CaptureCompatibility
     def self.included(base)
+      return if base < InstanceMethods
+
       base.class_eval do
         alias_method :original_capture, :capture
       end

--- a/test/sandbox/test/action_view_compatibility_test.rb
+++ b/test/sandbox/test/action_view_compatibility_test.rb
@@ -40,4 +40,12 @@ class ViewComponent::ActionViewCompatibilityTest < ViewComponent::TestCase
     render_inline(ContentTagComponent.new)
     assert_selector("div > p")
   end
+
+  def test_including_compat_module_twice_does_not_blow_the_stack
+    skip unless ENV["CAPTURE_PATCH_ENABLED"] == "true"
+    ActionView::Base.include(ViewComponent::CaptureCompatibility)
+    render_inline(FormForComponent.new)
+    assert_selector("form > div > label > input")
+    refute_selector("form > div > input")
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

I tried setting `config.view_component.capture_compatibility_patch_enabled = true` in GitHub's monolith today and ran into a `SystemStackError` indicating infinite recursion. After digging in I discovered the `CaptureCompatibility` module is getting `include`d more than once, which causes `alias_method :original_capture, :capture` to be evaluated multiple times. The second time around, the alias makes both `#capture` and `#original_capture` point to the same method (`CaptureCompatibility::InstanceMethods#capture`). This means that when `#capture` calls `#original_capture`, it ends up calling itself 🤦 

### What approach did you choose and why?

I added a single-line `return` statement to bail out if `InstanceMethods` has already been prepended to `ActionView::Base`.

### Anything you want to highlight for special attention from reviewers?

I think the above covers it.