### PR TITLE
Update testing slots example

### DIFF
--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -90,8 +90,8 @@ To test components that use Slots:
 ```ruby
 def test_renders_slots_with_content
   render_inline(SlotsComponent.new(footer: "Bye!")) do |component|
-    component.title { "Hello!" }
-    component.body { "Have a nice day." }
+    component.with_title { "Hello!" }
+    component.with_body { "Have a nice day." }
   end
 
   assert_selector(".title", text: "Hello!")


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide a description of the changes. Link to any related issues or projects. -->

It looks like the API for slots has changed since the test examples were written. This updates the calls to `component` to use the `with_{slot_name}` method.

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?

We're using RSpec for testing, so I'm not 100% certain that the api for slots is the same in MiniTest, but I assume these examples are just using the component API.