### PR TITLE
Fix inline template error in development

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,8 +10,7 @@ nav_order: 5
 
 ## main
 
-* Check for `inline_calls` and inline `erb_template` calls when deciding whether
-or not to compile a component's superclass.
+* Check for inline `erb_template` calls when deciding whether or not to compile a component's superclass.
 
     *Justin Kenyon*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,11 @@ nav_order: 5
 
 ## main
 
+* Check for `inline_calls` and inline `erb_template` calls when deciding whether
+or not to compile a component's superclass.
+
+    *Justin Kenyon*
+
 * Protect against `SystemStackError` if `CaptureCompatibility` module is included more than once.
 
     *Cameron Dutro*

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -134,7 +134,7 @@ module ViewComponent
         begin
           errors = []
 
-          if (templates + inline_calls).empty? && !has_inline_template?
+          if !has_valid_template?
             errors << "Couldn't find a template file or inline render method for #{component_class}."
           end
 
@@ -285,12 +285,15 @@ module ViewComponent
     end
 
     def should_compile_superclass?
-      development? &&
-        templates.empty? && !has_inline_template? &&
+      development? && !has_valid_template? &&
         !(
           component_class.instance_methods(false).include?(:call) ||
             component_class.private_instance_methods(false).include?(:call)
         )
+    end
+
+    def has_valid_template?
+      templates.any? || inline_calls.any? || has_inline_template?
     end
   end
 end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -134,7 +134,7 @@ module ViewComponent
         begin
           errors = []
 
-          if !has_valid_template?
+          if (templates + inline_calls).empty? && !has_inline_template?
             errors << "Couldn't find a template file or inline render method for #{component_class}."
           end
 
@@ -285,15 +285,11 @@ module ViewComponent
     end
 
     def should_compile_superclass?
-      development? && !has_valid_template? &&
+      development? && templates.empty? && !has_inline_template? &&
         !(
           component_class.instance_methods(false).include?(:call) ||
             component_class.private_instance_methods(false).include?(:call)
         )
-    end
-
-    def has_valid_template?
-      templates.any? || inline_calls.any? || has_inline_template?
     end
   end
 end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -286,7 +286,7 @@ module ViewComponent
 
     def should_compile_superclass?
       development? &&
-        templates.empty? &&
+        templates.empty? && !has_inline_template? &&
         !(
           component_class.instance_methods(false).include?(:call) ||
             component_class.private_instance_methods(false).include?(:call)

--- a/test/sandbox/test/inline_template_test.rb
+++ b/test/sandbox/test/inline_template_test.rb
@@ -18,6 +18,7 @@ class InlineErbTest < ViewComponent::TestCase
   end
 
   class ParentBaseComponent < ViewComponent::Base; end
+
   class InlineErbChildComponent < ParentBaseComponent
     include ViewComponent::InlineTemplate
 

--- a/test/sandbox/test/inline_template_test.rb
+++ b/test/sandbox/test/inline_template_test.rb
@@ -17,6 +17,21 @@ class InlineErbTest < ViewComponent::TestCase
     end
   end
 
+  class ParentBaseComponent < ViewComponent::Base; end
+  class InlineErbChildComponent < ParentBaseComponent
+    include ViewComponent::InlineTemplate
+
+    attr_reader :name
+
+    erb_template <<~ERB
+      <h1>Hello, <%= name %>!</h1>
+    ERB
+
+    def initialize(name)
+      @name = name
+    end
+  end
+
   class InlineRaiseErbComponent < ViewComponent::Base
     include ViewComponent::InlineTemplate
 
@@ -71,6 +86,12 @@ class InlineErbTest < ViewComponent::TestCase
 
   test "renders inline templates" do
     render_inline(InlineErbComponent.new("Fox Mulder"))
+
+    assert_selector("h1", text: "Hello, Fox Mulder!")
+  end
+
+  test "renders inline templates when inheriting base component" do
+    render_inline(InlineErbChildComponent.new("Fox Mulder"))
 
     assert_selector("h1", text: "Hello, Fox Mulder!")
   end

--- a/test/sandbox/test/inline_template_test.rb
+++ b/test/sandbox/test/inline_template_test.rb
@@ -17,22 +17,6 @@ class InlineErbTest < ViewComponent::TestCase
     end
   end
 
-  class ParentBaseComponent < ViewComponent::Base; end
-
-  class InlineErbChildComponent < ParentBaseComponent
-    include ViewComponent::InlineTemplate
-
-    attr_reader :name
-
-    erb_template <<~ERB
-      <h1>Hello, <%= name %>!</h1>
-    ERB
-
-    def initialize(name)
-      @name = name
-    end
-  end
-
   class InlineRaiseErbComponent < ViewComponent::Base
     include ViewComponent::InlineTemplate
 
@@ -83,6 +67,23 @@ class InlineErbTest < ViewComponent::TestCase
         <%= greeting %>
       </div>
     ERB
+  end
+
+  class ParentBaseComponent < ViewComponent::Base
+  end
+
+  class InlineErbChildComponent < ParentBaseComponent
+    include ViewComponent::InlineTemplate
+
+    attr_reader :name
+
+    erb_template <<~ERB
+      <h1>Hello, <%= name %>!</h1>
+    ERB
+
+    def initialize(name)
+      @name = name
+    end
   end
 
   test "renders inline templates" do


### PR DESCRIPTION
### What are you trying to accomplish?

When using inline templates in development we try to compile the superclass of the component when there are no sidecar templates available. When your component inherits from `ViewComponent::Base` this is not a problem. However, when you have another base component that inherits from `ViewComponent::Base` (e.g. `class ApplicationComponent < ViewComponent::Base`) we fail to compile the superclass, `ApplicationComponent`.

However, in the case of `inline_calls` or inline `erb_template` usage, we don't actually want to try and compile the super class.

### What approach did you choose and why?

This PR:
  - Adds a failing test to exercise this problem
  - Modifies the `should_compile_superclass?` method to not only check for sidecar erb files, but also inline `erb_template` usage.

### Anything you want to highlight for special attention from reviewers?

n/a