### PR TITLE
Two small cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,8 @@ jobs:
       with:
         name: simplecov-resultset-rails${{matrix.rails_version}}-ruby${{matrix.ruby_version}}
         path: coverage
-  pvc:
+  primer_view_components_compatibility:
+    name: Test compatibility with Primer ViewComponents (main)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: `#SLOT_NAME` getter no longer accepts arguments. This change was missed as part of the earlier deprecation in `3.0.0.rc1`.
+
+    *Joel Hawksley*
+
 * Raise error if translations are used in initializer.
 
     *Joel Hawksley*

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -84,7 +84,6 @@ module ViewComponent
           define_method slot_name do
             get_slot(slot_name)
           end
-          ruby2_keywords(slot_name.to_sym) if respond_to?(:ruby2_keywords, true)
 
           define_method "#{slot_name}?" do
             get_slot(slot_name).present?

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -81,7 +81,7 @@ module ViewComponent
           end
           ruby2_keywords(:"with_#{slot_name}") if respond_to?(:ruby2_keywords, true)
 
-          define_method slot_name do |*args, &block|
+          define_method slot_name do
             get_slot(slot_name)
           end
           ruby2_keywords(slot_name.to_sym) if respond_to?(:ruby2_keywords, true)
@@ -151,7 +151,7 @@ module ViewComponent
             end
           end
 
-          define_method slot_name do |collection_args = nil, &block|
+          define_method slot_name do
             get_slot(slot_name)
           end
 


### PR DESCRIPTION
1) Remove unused block arguments in `Slotable`
2) Rename `pvc` build to clarify why the build exists, as folks ask about it on occaision.