### PR TITLE
Use custom error classes instead of generic errors

### DIFF
--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -15,7 +15,7 @@ class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
   private
 
   def validate_test_env
-    raise "ViewComponentsSystemTestController must only be called in a test environment" unless Rails.env.test?
+    raise ViewComponent::SystemTestControllerOnlyAllowedInTestError unless Rails.env.test?
   end
 
   # Ensure that the file path is valid and doesn't target files outside
@@ -24,7 +24,7 @@ class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
     base_path = ::File.realpath(self.class.temp_dir)
     @path = ::File.realpath(params.permit(:file)[:file], base_path)
     unless @path.start_with?(base_path)
-      raise ArgumentError, "Invalid file path"
+      raise ViewComponent::SystemTestControllerNefariousPathError
     end
   end
 end

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -31,10 +31,8 @@ module PreviewHelper
         path =~ /#{template_identifier}*.(html)/
       end
 
-      # In-case of a conflict due to multiple template files with
-      # the same name
-      raise "found 0 matches for templates for #{template_identifier}." if matching_templates.empty?
-      raise "found multiple templates for #{template_identifier}." if matching_templates.size > 1
+      raise ViewComponent::NoMatchingTemplatesForPreviewError.new(template_identifier) if matching_templates.empty?
+      raise ViewComponent::MultipleTemplatesForPreviewError.new(template_identifier) if matching_templates.size > 1
 
       template_file_path = matching_templates.first
       template_source = File.read(template_file_path)

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -32,7 +32,7 @@ module PreviewHelper
       end
 
       raise ViewComponent::NoMatchingTemplatesForPreviewError.new(template_identifier) if matching_templates.empty?
-      raise ViewComponent::MultipleTemplatesForPreviewError.new(template_identifier) if matching_templates.size > 1
+      raise ViewComponent::MultipleMatchingTemplatesForPreviewError.new(template_identifier) if matching_templates.size > 1
 
       template_file_path = matching_templates.first
       template_source = File.read(template_file_path)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError` or `NilWithContentError` instead of generic error classes.
+* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError`, `EmptyOrInvalidInitializerError`, `MissingCollectionArgumentError` or `NilWithContentError` instead of generic error classes.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ nav_order: 5
 
     *Joel Hawksley*
 
+* Allow `.with_content` to be redefined by components.
+
+    *Joel Hawksley*
+
 * Run `standardrb` against markdown in docs.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: Raise `ViewComponent::ReservedPluralSlotNameError` instead of `ArgumentError`.
+
+    *Joel Hawksley*
+
 * BREAKING: Raise `NilWithContentError` instead of `ArgumentError`.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: Use `TranslateCalledBeforeRenderError` in place of `ViewContextCalledBeforeRenderError`, removing `ViewContextCalledBeforeRenderError`.
+
+    *Joel Hawksley*
+
 * BREAKING: Use `HelpersCalledBeforeRenderError` in place of `ViewContextCalledBeforeRenderError`.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError`, `EmptyOrInvalidInitializerError`, `MissingCollectionArgumentError`, `ReservedParameterError`, `InvalidCollectionArgumentError`, `MultipleInlineTemplatesError`, `MissingPreviewTemplateError` or `NilWithContentError` instead of generic error classes.
+* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError`, `EmptyOrInvalidInitializerError`, `MissingCollectionArgumentError`, `ReservedParameterError`, `InvalidCollectionArgumentError`, `MultipleInlineTemplatesError`, `MissingPreviewTemplateError`, `DuplicateSlotContentError` or `NilWithContentError` instead of generic error classes.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: Raise `ViewComponent::ContentSlotNameError` instead of `ArgumentError`.
+
+    *Joel Hawksley*
+
 * BREAKING: Raise `ViewComponent::InvalidSlotDefinitionError` instead of `ArgumentError`.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: Raise `ViewComponent::ReservedSingularSlotNameError` instead of `ArgumentError`.
+
+    *Joel Hawksley*
+
 * BREAKING: Raise `ViewComponent::ContentSlotNameError` instead of `ArgumentError`.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError`, `EmptyOrInvalidInitializerError`, `MissingCollectionArgumentError`, `ReservedParameterError`, `InvalidCollectionArgumentError` or `NilWithContentError` instead of generic error classes.
+* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError`, `EmptyOrInvalidInitializerError`, `MissingCollectionArgumentError`, `ReservedParameterError`, `InvalidCollectionArgumentError`, `MultipleInlineTemplatesError` or `NilWithContentError` instead of generic error classes.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError` or `NilWithContentError` instead of generic error classes.
+* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError` or `NilWithContentError` instead of generic error classes.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,47 +10,15 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Raise `ViewComponent::RedefinedSlotError` instead of `ArgumentError`.
+* BREAKING: Raise `SlotPredicateNameError`, `ViewComponent::RedefinedSlotError`, `ViewComponent::ReservedSingularSlotNameError`, `ViewComponent::ContentSlotNameError`, `ViewComponent::InvalidSlotDefinitionError`, `ViewComponent::ReservedPluralSlotNameError`, or `NilWithContentError` instead of `ArgumentError`.
 
     *Joel Hawksley*
 
-* BREAKING: Raise `ViewComponent::ReservedSingularSlotNameError` instead of `ArgumentError`.
-
-    *Joel Hawksley*
-
-* BREAKING: Raise `ViewComponent::ContentSlotNameError` instead of `ArgumentError`.
-
-    *Joel Hawksley*
-
-* BREAKING: Raise `ViewComponent::InvalidSlotDefinitionError` instead of `ArgumentError`.
-
-    *Joel Hawksley*
-
-* BREAKING: Raise `ViewComponent::ReservedPluralSlotNameError` instead of `ArgumentError`.
-
-    *Joel Hawksley*
-
-* BREAKING: Raise `NilWithContentError` instead of `ArgumentError`.
-
-    *Joel Hawksley*
-
-* BREAKING: Raise `TranslateCalledBeforeRenderError` instead of `ViewContextCalledBeforeRenderError`, removing `ViewContextCalledBeforeRenderError`.
-
-    *Joel Hawksley*
-
-* BREAKING: Raise `HelpersCalledBeforeRenderError` instead of `ViewContextCalledBeforeRenderError`.
+* BREAKING: Raise `TranslateCalledBeforeRenderError`, `ControllerCalledBeforeRenderError`, or `HelpersCalledBeforeRenderError` instead of `ViewContextCalledBeforeRenderError`.
 
     *Joel Hawksley*
 
 * Run `standardrb` against markdown in docs.
-
-    *Joel Hawksley*
-
-* BREAKING: Raise `ControllerCalledBeforeRenderError` instead of `ViewContextCalledBeforeRenderError`. Rename `Base::ViewContextCalledBeforeRenderError` to `ViewContextCalledBeforeRenderError`.
-
-    *Joel Hawksley*
-
-* Add docs for `ControllerCalledBeforeRenderError` to website.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,11 +10,15 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Use `TranslateCalledBeforeRenderError` in place of `ViewContextCalledBeforeRenderError`, removing `ViewContextCalledBeforeRenderError`.
+* BREAKING: Raise `NilWithContentError` instead of `ArgumentError`.
 
     *Joel Hawksley*
 
-* BREAKING: Use `HelpersCalledBeforeRenderError` in place of `ViewContextCalledBeforeRenderError`.
+* BREAKING: Raise `TranslateCalledBeforeRenderError` instead of `ViewContextCalledBeforeRenderError`, removing `ViewContextCalledBeforeRenderError`.
+
+    *Joel Hawksley*
+
+* BREAKING: Raise `HelpersCalledBeforeRenderError` instead of `ViewContextCalledBeforeRenderError`.
 
     *Joel Hawksley*
 
@@ -22,7 +26,7 @@ nav_order: 5
 
     *Joel Hawksley*
 
-* BREAKING: Use `ControllerCalledBeforeRenderError` in place of `ViewContextCalledBeforeRenderError`. Rename `Base::ViewContextCalledBeforeRenderError` to `ViewContextCalledBeforeRenderError`.
+* BREAKING: Raise `ControllerCalledBeforeRenderError` instead of `ViewContextCalledBeforeRenderError`. Rename `Base::ViewContextCalledBeforeRenderError` to `ViewContextCalledBeforeRenderError`.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError`, `EmptyOrInvalidInitializerError`, `MissingCollectionArgumentError` or `NilWithContentError` instead of generic error classes.
+* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError`, `EmptyOrInvalidInitializerError`, `MissingCollectionArgumentError`, `ReservedParameterError` or `NilWithContentError` instead of generic error classes.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: Use `HelpersCalledBeforeRenderError` in place of `ViewContextCalledBeforeRenderError`.
+
+    *Joel Hawksley*
+
 * Run `standardrb` against markdown in docs.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError`, `EmptyOrInvalidInitializerError`, `MissingCollectionArgumentError`, `ReservedParameterError`, `InvalidCollectionArgumentError`, `MultipleInlineTemplatesError` or `NilWithContentError` instead of generic error classes.
+* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError`, `EmptyOrInvalidInitializerError`, `MissingCollectionArgumentError`, `ReservedParameterError`, `InvalidCollectionArgumentError`, `MultipleInlineTemplatesError`, `MissingPreviewTemplateError` or `NilWithContentError` instead of generic error classes.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: Raise `ViewComponent::InvalidSlotDefinitionError` instead of `ArgumentError`.
+
+    *Joel Hawksley*
+
 * BREAKING: Raise `ViewComponent::ReservedPluralSlotNameError` instead of `ArgumentError`.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError` or `NilWithContentError` instead of generic error classes.
+* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError` or `NilWithContentError` instead of generic error classes.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,7 +48,7 @@ nav_order: 5
 
     *Joel Hawksley*
 
-* Check for inline `erb_template` calls when deciding whether or not to compile a component's superclass.
+* Check for inline `erb_template` calls when deciding whether to compile a component's superclass.
 
     *Justin Kenyon*
 
@@ -104,7 +104,7 @@ Run into an issue with this release? [Let us know](https://github.com/ViewCompon
 
     *Joel Hawksley*
 
-* BREAKING: Rename private TestHelpers#controller, #build_controller, #request, and #preview_class to avoid conflicts. Note: While these methods were undocumented and marked as private, they was easily accessible in tests. As such, we're cautiously considering this to be a breaking change.
+* BREAKING: Rename private TestHelpers#controller, #build_controller, #request, and #preview_class to avoid conflicts. Note: While these methods were undocumented and marked as private, they were accessible in tests. As such, we're considering this to be a breaking change.
 
     *Joel Hawksley*
 
@@ -144,7 +144,7 @@ Run into an issue with this release? [Let us know](https://github.com/ViewCompon
 
 1,000+ days and 100+ releases later, the 200+ contributors to ViewComponent are proud to ship v3.0.0!
 
-We're so grateful for all of the work of community members to get us to this release. Whether it’s filing bug reports, designing APIs in long-winded discussion threads, or writing code itself, ViewComponent is built by the community, for the community. We couldn’t be more proud of what we’re building together :heart:
+We're so grateful for all the work of community members to get us to this release. Whether it’s filing bug reports, designing APIs in long-winded discussion threads, or writing code itself, ViewComponent is built by the community, for the community. We couldn’t be more proud of what we’re building together :heart:
 
 This release makes the following breaking changes, many of which have long been deprecated:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Raise `SlotPredicateNameError`, `ViewComponent::RedefinedSlotError`, `ViewComponent::ReservedSingularSlotNameError`, `ViewComponent::ContentSlotNameError`, `ViewComponent::InvalidSlotDefinitionError`, `ViewComponent::ReservedPluralSlotNameError`, or `NilWithContentError` instead of `ArgumentError`.
+* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror` or `NilWithContentError` instead of `ArgumentError`.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* BREAKING: Raise `ViewComponent::RedefinedSlotError` instead of `ArgumentError`.
+
+    *Joel Hawksley*
+
 * BREAKING: Raise `ViewComponent::ReservedSingularSlotNameError` instead of `ArgumentError`.
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror` or `NilWithContentError` instead of `ArgumentError`.
+* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError` or `NilWithContentError` instead of generic error classes.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError`, `EmptyOrInvalidInitializerError`, `MissingCollectionArgumentError`, `ReservedParameterError` or `NilWithContentError` instead of generic error classes.
+* BREAKING: Raise `SlotPredicateNameError`, `RedefinedSlotError`, `ReservedSingularSlotNameError`, `ContentSlotNameError`, `InvalidSlotDefinitionError`, `ReservedPluralSlotNameError`, `ContentAlreadySetForPolymorphicSlotErrror`, `SystemTestControllerOnlyAllowedInTestError`, `SystemTestControllerNefariousPathError`, `NoMatchingTemplatesForPreviewError`, `MultipleMatchingTemplatesForPreviewError`, `DuplicateContentError`, `EmptyOrInvalidInitializerError`, `MissingCollectionArgumentError`, `ReservedParameterError`, `InvalidCollectionArgumentError` or `NilWithContentError` instead of generic error classes.
 
     *Joel Hawksley*
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -423,6 +423,10 @@ This is not allowed because the ViewComponent framework already provides predica
 
 To fix this issue, choose a different name.
 
+### `SystemTestControllerOnlyAllowedInTestError`
+
+ViewComponent System Test Controller must only be called in a test environment for security reasons.
+
 ### `TranslateCalledBeforeRenderError`
 
 `#translate` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.

--- a/docs/api.md
+++ b/docs/api.md
@@ -363,6 +363,14 @@ end
 
 ## Errors
 
+### `ContentSlotNameError`
+
+COMPONENT_CLASS_NAME declares a slot named content, which is a reserved word in ViewComponent.
+
+Content passed to a ViewComponent as a block is captured and assigned to the `content` accessor without having to create an explicit slot.
+
+To fix this issue, either use the `content` accessor directly or choose a different slot name.
+
 ### `ControllerCalledBeforeRenderError`
 
 `#controller` can't be used during initialization, as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
@@ -377,7 +385,7 @@ It's sometimes possible to fix this issue by moving code dependent on `#helpers`
 
 ### `InvalidSlotDefinitionError`
 
-invalid slot definition. Please pass a class, string, or callable (i.e. proc, lambda, etc)
+Invalid slot definition. Please pass a class, string, or callable (i.e. proc, lambda, etc)
 
 ### `NilWithContentError`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -363,6 +363,10 @@ end
 
 ## Errors
 
+### `ContentAlreadySetForPolymorphicSlotError`
+
+Content for slot SLOT_NAME has already been provided.
+
 ### `ContentSlotNameError`
 
 COMPONENT declares a slot named content, which is a reserved word in ViewComponent.

--- a/docs/api.md
+++ b/docs/api.md
@@ -381,6 +381,12 @@ To fix this issue, either use the `content` accessor directly or choose a differ
 
 It's sometimes possible to fix this issue by moving code dependent on `#controller` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void).
 
+### `DuplicateContentError`
+
+It looks like a block was provided after calling `with_content` on COMPONENT, which means that ViewComponent doesn't know which content to use.
+
+To fix this issue, use either `with_content` or a block.
+
 ### `HelpersCalledBeforeRenderError`
 
 `#helpers` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.

--- a/docs/api.md
+++ b/docs/api.md
@@ -268,7 +268,7 @@ Internally sets `page` to be a `Capybara::Node::Simple`, allowing for
 Capybara assertions to be used. All arguments are forwarded to the block.
 
 ```ruby
-render_in_view_context(arg1, arg2:) do |arg1, arg2:|
+render_in_view_context(arg1, arg2: nil) do |arg1, arg2:|
   render(MyComponent.new(arg1, arg2))
 end
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -417,6 +417,12 @@ To fix this issue, update the initializer to accept `PARAMETER`.
 
 See https://viewcomponent.org/guide/collections.html for more information on rendering collections.
 
+### `MissingPreviewTemplateError`
+
+A preview template for example EXAMPLE doesn't exist.
+
+To fix this issue, create a template for the example.
+
 ### `MultipleInlineTemplatesError`
 
 Inline templates can only be defined once per-component.

--- a/docs/api.md
+++ b/docs/api.md
@@ -375,6 +375,12 @@ It's sometimes possible to fix this issue by moving code dependent on `#controll
 
 It's sometimes possible to fix this issue by moving code dependent on `#helpers` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void.
 
+### `NilWithContentError`
+
+No content provided to `#with_content` for ViewComponent::NilWithContentError.
+
+To fix this issue, pass a value.
+
 ### `TranslateCalledBeforeRenderError`
 
 `#translate` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.

--- a/docs/api.md
+++ b/docs/api.md
@@ -411,6 +411,14 @@ COMPONENT declares a slot named SLOT_NAME, which is a reserved word in the ViewC
 
 To fix this issue, choose a different name.
 
+### `SlotPredicateNameError`
+
+COMPONENT declares a slot named SLOT_NAME, which ends with a question mark.
+
+This is not allowed because the ViewComponent framework already provides predicate methods ending in `?`.
+
+To fix this issue, choose a different name.
+
 ### `TranslateCalledBeforeRenderError`
 
 `#translate` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.

--- a/docs/api.md
+++ b/docs/api.md
@@ -375,6 +375,10 @@ It's sometimes possible to fix this issue by moving code dependent on `#controll
 
 It's sometimes possible to fix this issue by moving code dependent on `#helpers` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void.
 
+### `InvalidSlotDefinitionError`
+
+invalid slot definition. Please pass a class, string, or callable (i.e. proc, lambda, etc)
+
 ### `NilWithContentError`
 
 No content provided to `#with_content` for ViewComponent::NilWithContentError.

--- a/docs/api.md
+++ b/docs/api.md
@@ -387,6 +387,14 @@ It looks like a block was provided after calling `with_content` on COMPONENT, wh
 
 To fix this issue, use either `with_content` or a block.
 
+### `EmptyOrInvalidInitializerError`
+
+The COMPONENT initializer is empty or invalid.It must accept the parameter `PARAMETER` to render it as a collection.
+
+To fix this issue, update the initializer to accept `PARAMETER`.
+
+See https://viewcomponent.org/guide/collections.html for more information on rendering collections.
+
 ### `HelpersCalledBeforeRenderError`
 
 `#helpers` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
@@ -396,6 +404,14 @@ It's sometimes possible to fix this issue by moving code dependent on `#helpers`
 ### `InvalidSlotDefinitionError`
 
 Invalid slot definition. Please pass a class, string, or callable (i.e. proc, lambda, etc)
+
+### `MissingCollectionArgumentError`
+
+The initializer for COMPONENT doesn't accept the parameter `PARAMETER`, which is required in order to render it as a collection.
+
+To fix this issue, update the initializer to accept `PARAMETER`.
+
+See https://viewcomponent.org/guide/collections.html for more information on rendering collections.
 
 ### `MultipleMatchingTemplatesForPreviewError`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -401,6 +401,10 @@ See https://viewcomponent.org/guide/collections.html for more information on ren
 
 It's sometimes possible to fix this issue by moving code dependent on `#helpers` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void.
 
+### `InvalidCollectionArgumentError`
+
+The value of the first argument passed to `with_collection` isn't a valid collection. Make sure it responds to `to_ary`.
+
 ### `InvalidSlotDefinitionError`
 
 Invalid slot definition. Please pass a class, string, or callable (i.e. proc, lambda, etc)

--- a/docs/api.md
+++ b/docs/api.md
@@ -365,7 +365,7 @@ end
 
 ### `ContentSlotNameError`
 
-COMPONENT_CLASS_NAME declares a slot named content, which is a reserved word in ViewComponent.
+COMPONENT declares a slot named content, which is a reserved word in ViewComponent.
 
 Content passed to a ViewComponent as a block is captured and assigned to the `content` accessor without having to create an explicit slot.
 
@@ -395,7 +395,13 @@ To fix this issue, pass a value.
 
 ### `ReservedPluralSlotNameError`
 
-COMPONENT_CLASS_NAME declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.
+COMPONENT declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.
+
+To fix this issue, choose a different name.
+
+### `ReservedSingularSlotNameError`
+
+COMPONENT declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.
 
 To fix this issue, choose a different name.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -393,6 +393,12 @@ No content provided to `#with_content` for ViewComponent::NilWithContentError.
 
 To fix this issue, pass a value.
 
+### `RedefinedSlotError`
+
+COMPONENT declares the SLOT_NAME slot multiple times.
+
+To fix this issue, choose a different slot name.
+
 ### `ReservedPluralSlotNameError`
 
 COMPONENT declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.

--- a/docs/api.md
+++ b/docs/api.md
@@ -395,17 +395,17 @@ To fix this issue, use either `with_content` or a block.
 
 ### `EmptyOrInvalidInitializerError`
 
-The COMPONENT initializer is empty or invalid.It must accept the parameter `PARAMETER` to render it as a collection.
+The COMPONENT initializer is empty or invalid. It must accept the parameter `PARAMETER` to render it as a collection.
 
 To fix this issue, update the initializer to accept `PARAMETER`.
 
-See https://viewcomponent.org/guide/collections.html for more information on rendering collections.
+See [the collections docs](https://viewcomponent.org/guide/collections.html) for more information on rendering collections.
 
 ### `HelpersCalledBeforeRenderError`
 
 `#helpers` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
 
-It's sometimes possible to fix this issue by moving code dependent on `#helpers` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void.
+It's sometimes possible to fix this issue by moving code dependent on `#helpers` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void).
 
 ### `InvalidCollectionArgumentError`
 
@@ -413,15 +413,15 @@ The value of the first argument passed to `with_collection` isn't a valid collec
 
 ### `InvalidSlotDefinitionError`
 
-Invalid slot definition. Please pass a class, string, or callable (i.e. proc, lambda, etc)
+Invalid slot definition. Please pass a class, string, or callable (that is proc, lambda, etc)
 
 ### `MissingCollectionArgumentError`
 
-The initializer for COMPONENT doesn't accept the parameter `PARAMETER`, which is required in order to render it as a collection.
+The initializer for COMPONENT doesn't accept the parameter `PARAMETER`, which is required to render it as a collection.
 
 To fix this issue, update the initializer to accept `PARAMETER`.
 
-See https://viewcomponent.org/guide/collections.html for more information on rendering collections.
+See [the collections docs](https://viewcomponent.org/guide/collections.html) for more information on rendering collections.
 
 ### `MissingPreviewTemplateError`
 
@@ -473,7 +473,7 @@ To fix this issue, choose a different name.
 
 COMPONENT declares a slot named SLOT_NAME, which ends with a question mark.
 
-This is not allowed because the ViewComponent framework already provides predicate methods ending in `?`.
+This isn't allowed because the ViewComponent framework already provides predicate methods ending in `?`.
 
 To fix this issue, choose a different name.
 
@@ -489,4 +489,4 @@ ViewComponent SystemTest controller must only be called in a test environment fo
 
 `#translate` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
 
-It's sometimes possible to fix this issue by moving code dependent on `#translate` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void.
+It's sometimes possible to fix this issue by moving code dependent on `#translate` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void).

--- a/docs/api.md
+++ b/docs/api.md
@@ -433,6 +433,10 @@ COMPONENT declares the SLOT_NAME slot multiple times.
 
 To fix this issue, choose a different slot name.
 
+### `ReservedParameterError`
+
+COMPONENT initializer can't accept the parameter `PARAMETER`, as it will override a public ViewComponent method. To fix this issue, rename the parameter.
+
 ### `ReservedPluralSlotNameError`
 
 COMPONENT declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.

--- a/docs/api.md
+++ b/docs/api.md
@@ -381,6 +381,12 @@ No content provided to `#with_content` for ViewComponent::NilWithContentError.
 
 To fix this issue, pass a value.
 
+### `ReservedPluralSlotNameError`
+
+COMPONENT_CLASS_NAME declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.
+
+To fix this issue, choose a different name.
+
 ### `TranslateCalledBeforeRenderError`
 
 `#translate` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.

--- a/docs/api.md
+++ b/docs/api.md
@@ -268,7 +268,7 @@ Internally sets `page` to be a `Capybara::Node::Simple`, allowing for
 Capybara assertions to be used. All arguments are forwarded to the block.
 
 ```ruby
-render_in_view_context(arg1, arg2: "foo") do |arg1, arg2:|
+render_in_view_context(arg1, arg2:) do |arg1, arg2:|
   render(MyComponent.new(arg1, arg2))
 end
 
@@ -368,3 +368,9 @@ end
 `#controller` can't be used during initialization, as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
 
 It's sometimes possible to fix this issue by moving code dependent on `#controller` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void).
+
+### `HelpersCalledBeforeRenderError`
+
+`#helpers` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
+
+It's sometimes possible to fix this issue by moving code dependent on `#helpers` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void.

--- a/docs/api.md
+++ b/docs/api.md
@@ -391,11 +391,19 @@ It's sometimes possible to fix this issue by moving code dependent on `#helpers`
 
 Invalid slot definition. Please pass a class, string, or callable (i.e. proc, lambda, etc)
 
+### `MultipleMatchingTemplatesForPreviewError`
+
+Found multiple templates for TEMPLATE_IDENTIFIER.
+
 ### `NilWithContentError`
 
 No content provided to `#with_content` for ViewComponent::NilWithContentError.
 
 To fix this issue, pass a value.
+
+### `NoMatchingTemplatesForPreviewError`
+
+Found 0 matches for templates for TEMPLATE_IDENTIFIER.
 
 ### `RedefinedSlotError`
 
@@ -423,9 +431,13 @@ This is not allowed because the ViewComponent framework already provides predica
 
 To fix this issue, choose a different name.
 
+### `SystemTestControllerNefariousPathError`
+
+ViewComponent SystemTest controller attempted to load a file outside of the expected directory.
+
 ### `SystemTestControllerOnlyAllowedInTestError`
 
-ViewComponent System Test Controller must only be called in a test environment for security reasons.
+ViewComponent SystemTest controller must only be called in a test environment for security reasons.
 
 ### `TranslateCalledBeforeRenderError`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -417,6 +417,10 @@ To fix this issue, update the initializer to accept `PARAMETER`.
 
 See https://viewcomponent.org/guide/collections.html for more information on rendering collections.
 
+### `MultipleInlineTemplatesError`
+
+Inline templates can only be defined once per-component.
+
 ### `MultipleMatchingTemplatesForPreviewError`
 
 Found multiple templates for TEMPLATE_IDENTIFIER.

--- a/docs/api.md
+++ b/docs/api.md
@@ -387,6 +387,12 @@ It looks like a block was provided after calling `with_content` on COMPONENT, wh
 
 To fix this issue, use either `with_content` or a block.
 
+### `DuplicateSlotContentError`
+
+It looks like a block was provided after calling `with_content` on COMPONENT, which means that ViewComponent doesn't know which content to use.
+
+To fix this issue, use either `with_content` or a block.
+
 ### `EmptyOrInvalidInitializerError`
 
 The COMPONENT initializer is empty or invalid.It must accept the parameter `PARAMETER` to render it as a collection.

--- a/docs/api.md
+++ b/docs/api.md
@@ -374,3 +374,9 @@ It's sometimes possible to fix this issue by moving code dependent on `#controll
 `#helpers` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
 
 It's sometimes possible to fix this issue by moving code dependent on `#helpers` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void.
+
+### `TranslateCalledBeforeRenderError`
+
+`#translate` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
+
+It's sometimes possible to fix this issue by moving code dependent on `#translate` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void.

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -16,7 +16,6 @@ module ViewComponent
   autoload :InlineTemplate
   autoload :Instrumentation
   autoload :Preview
-  autoload :PreviewTemplateError
   autoload :TestHelpers
   autoload :SystemTestHelpers
   autoload :TestCase

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -20,7 +20,6 @@ module ViewComponent
   autoload :SystemTestHelpers
   autoload :TestCase
   autoload :SystemTestCase
-  autoload :TemplateError
   autoload :Translatable
 end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -93,9 +93,7 @@ module ViewComponent
       @current_template = self
 
       if block && defined?(@__vc_content_set_by_with_content)
-        raise ArgumentError, "It looks like a block was provided after calling `with_content` on #{self.class.name}, " \
-          "which means that ViewComponent doesn't know which content to use.\n\n" \
-          "To fix this issue, use either `with_content` or a block."
+        raise DuplicateContentError.new(self.class.name)
       end
 
       @__vc_content_evaluated = false

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -555,8 +555,7 @@ module ViewComponent
       def validate_initialization_parameters!
         return unless initialize_parameter_names.include?(RESERVED_PARAMETER)
 
-        raise ViewComponent::ComponentError, "#{self} initializer can't accept the parameter `#{RESERVED_PARAMETER}`, as it will override a " \
-          "public ViewComponent method. To fix this issue, rename the parameter."
+        raise ReservedParameterError.new(self.name, RESERVED_PARAMETER)
       end
 
       # @private

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -172,7 +172,7 @@ module ViewComponent
     #
     # @return [ActionController::Base]
     def controller
-      raise(ControllerCalledBeforeRenderError) if view_context.nil?
+      raise ControllerCalledBeforeRenderError if view_context.nil?
 
       @__vc_controller ||= view_context.controller
     end
@@ -182,7 +182,7 @@ module ViewComponent
     #
     # @return [ActionView::Base]
     def helpers
-      raise(HelpersCalledBeforeRenderError) if view_context.nil?
+      raise HelpersCalledBeforeRenderError if view_context.nil?
 
       # Attempt to re-use the original view_context passed to the first
       # component rendered in the rendering pipeline. This prevents the
@@ -538,20 +538,14 @@ module ViewComponent
         return unless parameter
         return if initialize_parameter_names.include?(parameter) || splatted_keyword_argument_present?
 
-        # If Ruby can't parse the component class, then the initalize
+        # If Ruby can't parse the component class, then the initialize
         # parameters will be empty and ViewComponent will not be able to render
         # the component.
         if initialize_parameters.empty?
-          raise ArgumentError, "The #{self} initializer is empty or invalid." \
-            "It must accept the parameter `#{parameter}` to render it as a collection.\n\n" \
-            "To fix this issue, update the initializer to accept `#{parameter}`.\n\n" \
-            "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
+          raise EmptyOrInvalidInitializerError.new(self.name, parameter)
         end
 
-        raise ArgumentError, "The initializer for #{self} doesn't accept the parameter `#{parameter}`, " \
-          "which is required in order to render it as a collection.\n\n" \
-          "To fix this issue, update the initializer to accept `#{parameter}`.\n\n" \
-          "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
+        raise MissingCollectionArgumentError.new(self.name, parameter)
       end
 
       # Ensure the component initializer doesn't define

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -514,7 +514,7 @@ module ViewComponent
       # end
       # ```
       #
-      # @param value [Boolean] Whether or not to strip newlines.
+      # @param value [Boolean] Whether to strip newlines.
       def strip_trailing_whitespace(value = true)
         self.__vc_strip_trailing_whitespace = value
       end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -542,10 +542,10 @@ module ViewComponent
         # parameters will be empty and ViewComponent will not be able to render
         # the component.
         if initialize_parameters.empty?
-          raise EmptyOrInvalidInitializerError.new(self.name, parameter)
+          raise EmptyOrInvalidInitializerError.new(name, parameter)
         end
 
-        raise MissingCollectionArgumentError.new(self.name, parameter)
+        raise MissingCollectionArgumentError.new(name, parameter)
       end
 
       # Ensure the component initializer doesn't define
@@ -555,7 +555,7 @@ module ViewComponent
       def validate_initialization_parameters!
         return unless initialize_parameter_names.include?(RESERVED_PARAMETER)
 
-        raise ReservedParameterError.new(self.name, RESERVED_PARAMETER)
+        raise ReservedParameterError.new(name, RESERVED_PARAMETER)
       end
 
       # @private

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -184,16 +184,7 @@ module ViewComponent
     #
     # @return [ActionView::Base]
     def helpers
-      if view_context.nil?
-        raise(
-          ViewComponent::ViewContextCalledBeforeRenderError,
-          "`#helpers` can't be used during initialization as it depends " \
-          "on the view context that only exists once a ViewComponent is passed to " \
-          "the Rails render pipeline.\n\n" \
-          "It's sometimes possible to fix this issue by moving code dependent on " \
-          "`#helpers` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void."
-        )
-      end
+      raise(HelpersCalledBeforeRenderError) if view_context.nil?
 
       # Attempt to re-use the original view_context passed to the first
       # component rendered in the rendering pipeline. This prevents the

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -53,10 +53,7 @@ module ViewComponent
       if object.respond_to?(:to_ary)
         object.to_ary
       else
-        raise ArgumentError.new(
-          "The value of the first argument passed to `with_collection` isn't a valid collection. " \
-          "Make sure it responds to `to_ary`."
-        )
+        raise InvalidCollectionArgumentError
       end
     end
 

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -33,7 +33,7 @@ module ViewComponent
       component_class.superclass.compile(raise_errors: raise_errors) if should_compile_superclass?
 
       if template_errors.present?
-        raise ViewComponent::TemplateError.new(template_errors) if raise_errors
+        raise TemplateError.new(template_errors) if raise_errors
 
         return false
       end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -31,7 +31,6 @@ module ViewComponent
       return if component_class == ViewComponent::Base
 
       component_class.superclass.compile(raise_errors: raise_errors) if should_compile_superclass?
-      subclass_instance_methods = component_class.instance_methods(false)
 
       if template_errors.present?
         raise ViewComponent::TemplateError.new(template_errors) if raise_errors

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -33,13 +33,6 @@ module ViewComponent
       component_class.superclass.compile(raise_errors: raise_errors) if should_compile_superclass?
       subclass_instance_methods = component_class.instance_methods(false)
 
-      if subclass_instance_methods.include?(:with_content) && raise_errors
-        raise ViewComponent::ComponentError.new(
-          "#{component_class} implements a reserved method, `#with_content`.\n\n" \
-          "To fix this issue, change the name of the method."
-        )
-      end
-
       if template_errors.present?
         raise ViewComponent::TemplateError.new(template_errors) if raise_errors
 

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -22,6 +22,18 @@ module ViewComponent
       "string, or callable (i.e. proc, lambda, etc)"
   end
 
+  class SlotPredicateNameError < StandardError
+    MESSAGE =
+      "COMPONENT declares a slot named SLOT_NAME, which ends with a question mark.\n\n" \
+      "This is not allowed because the ViewComponent framework already provides predicate " \
+      "methods ending in `?`.\n\n" \
+      "To fix this issue, choose a different name."
+
+    def initialize(klass_name, slot_name)
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("SLOT_NAME", slot_name.to_s))
+    end
+  end
+
   class RedefinedSlotError < StandardError
     MESSAGE =
       "COMPONENT declares the SLOT_NAME slot multiple times.\n\n" \

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -5,6 +5,17 @@ module ViewComponent
     end
   end
 
+  class ContentSlotNameError < StandardError
+    MESSAGE =
+      "COMPONENT_CLASS_NAME declares a slot named content, which is a reserved word in ViewComponent.\n\n" \
+      "Content passed to a ViewComponent as a block is captured and assigned to the `content` accessor without having to create an explicit slot.\n\n" \
+      "To fix this issue, either use the `content` accessor directly or choose a different slot name."
+
+    def initialize(klass_name)
+      super(MESSAGE.gsub("COMPONENT_CLASS_NAME", klass_name.to_s))
+    end
+  end
+
   class InvalidSlotDefinitionError < BaseError
     MESSAGE =
       "Invalid slot definition. Please pass a class, " \

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -5,6 +5,17 @@ module ViewComponent
     end
   end
 
+  class DuplicateSlotContentError < StandardError
+    MESSAGE =
+      "It looks like a block was provided after calling `with_content` on COMPONENT, " \
+      "which means that ViewComponent doesn't know which content to use.\n\n" \
+      "To fix this issue, use either `with_content` or a block."
+
+    def initialize(klass_name)
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s))
+    end
+  end
+
   class TemplateError < StandardError
     def initialize(errors)
       super(errors.join(", "))

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -104,4 +104,12 @@ module ViewComponent
       "It's sometimes possible to fix this issue by moving code dependent on " \
       "`#controller` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void)."
   end
+
+  class SystemTestControllerOnlyAllowedInTestError < BaseError
+    MESSAGE = "ViewComponent SystemTest controller must only be called in a test environment for security reasons."
+  end
+
+  class SystemTestControllerNefariousPathError < BaseError
+    MESSAGE = "ViewComponent SystemTest controller attempted to load a file outside of the expected directory."
+  end
 end

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -22,6 +22,15 @@ module ViewComponent
       "string, or callable (i.e. proc, lambda, etc)"
   end
 
+  class RedefinedSlotError < StandardError
+    MESSAGE =
+      "COMPONENT declares the SLOT_NAME slot multiple times.\n\n" \
+      "To fix this issue, choose a different slot name."
+
+    def initialize(klass_name, slot_name)
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("SLOT_NAME", slot_name.to_s))
+    end
+  end
 
   class ReservedSingularSlotNameError < StandardError
     MESSAGE =

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -40,6 +40,16 @@ module ViewComponent
     end
   end
 
+  class ReservedParameterError < StandardError
+    MESSAGE =
+      "COMPONENT initializer can't accept the parameter `PARAMETER`, as it will override a " \
+      "public ViewComponent method. To fix this issue, rename the parameter."
+
+    def initialize(klass_name, parameter)
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("PARAMETER", parameter.to_s))
+    end
+  end
+
   class ContentSlotNameError < StandardError
     MESSAGE =
       "COMPONENT declares a slot named content, which is a reserved word in ViewComponent.\n\n" \

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -49,7 +49,7 @@ module ViewComponent
 
   class EmptyOrInvalidInitializerError < StandardError
     MESSAGE =
-      "The COMPONENT initializer is empty or invalid." \
+      "The COMPONENT initializer is empty or invalid. " \
       "It must accept the parameter `PARAMETER` to render it as a collection.\n\n" \
       "To fix this issue, update the initializer to accept `PARAMETER`.\n\n" \
       "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
@@ -62,7 +62,7 @@ module ViewComponent
   class MissingCollectionArgumentError < StandardError
     MESSAGE =
       "The initializer for COMPONENT doesn't accept the parameter `PARAMETER`, " \
-      "which is required in order to render it as a collection.\n\n" \
+      "which is required to render it as a collection.\n\n" \
       "To fix this issue, update the initializer to accept `PARAMETER`.\n\n" \
       "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
 
@@ -101,13 +101,13 @@ module ViewComponent
   class InvalidSlotDefinitionError < BaseError
     MESSAGE =
       "Invalid slot definition. Please pass a class, " \
-      "string, or callable (i.e. proc, lambda, etc)"
+      "string, or callable (that is proc, lambda, etc)"
   end
 
   class SlotPredicateNameError < StandardError
     MESSAGE =
       "COMPONENT declares a slot named SLOT_NAME, which ends with a question mark.\n\n" \
-      "This is not allowed because the ViewComponent framework already provides predicate " \
+      "This isn't allowed because the ViewComponent framework already provides predicate " \
       "methods ending in `?`.\n\n" \
       "To fix this issue, choose a different name."
 

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -52,7 +52,7 @@ module ViewComponent
       "The COMPONENT initializer is empty or invalid. " \
       "It must accept the parameter `PARAMETER` to render it as a collection.\n\n" \
       "To fix this issue, update the initializer to accept `PARAMETER`.\n\n" \
-      "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
+      "See [the collections docs](https://viewcomponent.org/guide/collections.html) for more information on rendering collections."
 
     def initialize(klass_name, parameter)
       super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("PARAMETER", parameter.to_s))
@@ -64,7 +64,7 @@ module ViewComponent
       "The initializer for COMPONENT doesn't accept the parameter `PARAMETER`, " \
       "which is required to render it as a collection.\n\n" \
       "To fix this issue, update the initializer to accept `PARAMETER`.\n\n" \
-      "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
+      "See [the collections docs](https://viewcomponent.org/guide/collections.html) for more information on rendering collections."
 
     def initialize(klass_name, parameter)
       super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("PARAMETER", parameter.to_s))
@@ -166,7 +166,7 @@ module ViewComponent
       "on the view context that only exists once a ViewComponent is passed to " \
       "the Rails render pipeline.\n\n" \
       "It's sometimes possible to fix this issue by moving code dependent on " \
-      "`#translate` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void."
+      "`#translate` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void)."
   end
 
   class HelpersCalledBeforeRenderError < BaseError
@@ -175,7 +175,7 @@ module ViewComponent
       "on the view context that only exists once a ViewComponent is passed to " \
       "the Rails render pipeline.\n\n" \
       "It's sometimes possible to fix this issue by moving code dependent on " \
-      "`#helpers` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void."
+      "`#helpers` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void)."
   end
 
   class ControllerCalledBeforeRenderError < BaseError

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -5,6 +5,17 @@ module ViewComponent
     end
   end
 
+  class DuplicateContentError < StandardError
+    MESSAGE =
+      "It looks like a block was provided after calling `with_content` on COMPONENT, " \
+      "which means that ViewComponent doesn't know which content to use.\n\n" \
+      "To fix this issue, use either `with_content` or a block."
+
+    def initialize(klass_name)
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s))
+    end
+  end
+
   class ContentSlotNameError < StandardError
     MESSAGE =
       "COMPONENT declares a slot named content, which is a reserved word in ViewComponent.\n\n" \

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -5,6 +5,12 @@ module ViewComponent
     end
   end
 
+  class InvalidSlotDefinitionError < BaseError
+    MESSAGE =
+      "Invalid slot definition. Please pass a class, " \
+      "string, or callable (i.e. proc, lambda, etc)"
+  end
+
   class ReservedPluralSlotNameError < StandardError
     MESSAGE =
       "COMPONENT_CLASS_NAME declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.\n\n" \

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -1,6 +1,19 @@
 module ViewComponent
   class ViewContextCalledBeforeRenderError < StandardError; end
 
+  class HelpersCalledBeforeRenderError < StandardError
+    MESSAGE =
+      "`#helpers` can't be used during initialization as it depends " \
+      "on the view context that only exists once a ViewComponent is passed to " \
+      "the Rails render pipeline.\n\n" \
+      "It's sometimes possible to fix this issue by moving code dependent on " \
+      "`#helpers` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void."
+
+    def initialize
+      super(MESSAGE)
+    end
+  end
+
   class ControllerCalledBeforeRenderError < StandardError
     MESSAGE =
       "`#controller` can't be used during initialization, as it depends " \

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -7,12 +7,12 @@ module ViewComponent
 
   class ContentSlotNameError < StandardError
     MESSAGE =
-      "COMPONENT_CLASS_NAME declares a slot named content, which is a reserved word in ViewComponent.\n\n" \
+      "COMPONENT declares a slot named content, which is a reserved word in ViewComponent.\n\n" \
       "Content passed to a ViewComponent as a block is captured and assigned to the `content` accessor without having to create an explicit slot.\n\n" \
       "To fix this issue, either use the `content` accessor directly or choose a different slot name."
 
     def initialize(klass_name)
-      super(MESSAGE.gsub("COMPONENT_CLASS_NAME", klass_name.to_s))
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s))
     end
   end
 
@@ -22,13 +22,24 @@ module ViewComponent
       "string, or callable (i.e. proc, lambda, etc)"
   end
 
-  class ReservedPluralSlotNameError < StandardError
+
+  class ReservedSingularSlotNameError < StandardError
     MESSAGE =
-      "COMPONENT_CLASS_NAME declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.\n\n" \
+      "COMPONENT declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.\n\n" \
       "To fix this issue, choose a different name."
 
     def initialize(klass_name, slot_name)
-      super(MESSAGE.gsub("COMPONENT_CLASS_NAME", klass_name.to_s).gsub("SLOT_NAME", slot_name.to_s))
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("SLOT_NAME", slot_name.to_s))
+    end
+  end
+
+  class ReservedPluralSlotNameError < StandardError
+    MESSAGE =
+      "COMPONENT declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.\n\n" \
+      "To fix this issue, choose a different name."
+
+    def initialize(klass_name, slot_name)
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("SLOT_NAME", slot_name.to_s))
     end
   end
 

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -1,5 +1,16 @@
 module ViewComponent
-  class ViewContextCalledBeforeRenderError < StandardError; end
+  class TranslateCalledBeforeRenderError < StandardError
+    MESSAGE =
+      "`#translate` can't be used during initialization as it depends " \
+      "on the view context that only exists once a ViewComponent is passed to " \
+      "the Rails render pipeline.\n\n" \
+      "It's sometimes possible to fix this issue by moving code dependent on " \
+      "`#translate` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void."
+
+    def initialize
+      super(MESSAGE)
+    end
+  end
 
   class HelpersCalledBeforeRenderError < StandardError
     MESSAGE =

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -16,6 +16,30 @@ module ViewComponent
     end
   end
 
+  class EmptyOrInvalidInitializerError < StandardError
+    MESSAGE =
+      "The COMPONENT initializer is empty or invalid." \
+      "It must accept the parameter `PARAMETER` to render it as a collection.\n\n" \
+      "To fix this issue, update the initializer to accept `PARAMETER`.\n\n" \
+      "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
+
+    def initialize(klass_name, parameter)
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("PARAMETER", parameter.to_s))
+    end
+  end
+
+  class MissingCollectionArgumentError < StandardError
+    MESSAGE =
+      "The initializer for COMPONENT doesn't accept the parameter `PARAMETER`, " \
+      "which is required in order to render it as a collection.\n\n" \
+      "To fix this issue, update the initializer to accept `PARAMETER`.\n\n" \
+      "See https://viewcomponent.org/guide/collections.html for more information on rendering collections."
+
+    def initialize(klass_name, parameter)
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("PARAMETER", parameter.to_s))
+    end
+  end
+
   class ContentSlotNameError < StandardError
     MESSAGE =
       "COMPONENT declares a slot named content, which is a reserved word in ViewComponent.\n\n" \

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -64,6 +64,14 @@ module ViewComponent
     end
   end
 
+  class ContentAlreadySetForPolymorphicSlotError < StandardError
+    MESSAGE = "Content for slot SLOT_NAME has already been provided."
+
+    def initialize(slot_name)
+      super(MESSAGE.gsub("SLOT_NAME", slot_name.to_s))
+    end
+  end
+
   class NilWithContentError < BaseError
     MESSAGE =
       "No content provided to `#with_content` for #{self}.\n\n" \

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -1,40 +1,39 @@
 module ViewComponent
-  class TranslateCalledBeforeRenderError < StandardError
+  class BaseError < StandardError
+    def initialize
+      super(self.class::MESSAGE)
+    end
+  end
+  class NilWithContentError < BaseError
+    MESSAGE =
+      "No content provided to `#with_content` for #{self}.\n\n" \
+      "To fix this issue, pass a value."
+  end
+
+  class TranslateCalledBeforeRenderError < BaseError
     MESSAGE =
       "`#translate` can't be used during initialization as it depends " \
       "on the view context that only exists once a ViewComponent is passed to " \
       "the Rails render pipeline.\n\n" \
       "It's sometimes possible to fix this issue by moving code dependent on " \
       "`#translate` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void."
-
-    def initialize
-      super(MESSAGE)
-    end
   end
 
-  class HelpersCalledBeforeRenderError < StandardError
+  class HelpersCalledBeforeRenderError < BaseError
     MESSAGE =
       "`#helpers` can't be used during initialization as it depends " \
       "on the view context that only exists once a ViewComponent is passed to " \
       "the Rails render pipeline.\n\n" \
       "It's sometimes possible to fix this issue by moving code dependent on " \
       "`#helpers` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void."
-
-    def initialize
-      super(MESSAGE)
-    end
   end
 
-  class ControllerCalledBeforeRenderError < StandardError
+  class ControllerCalledBeforeRenderError < BaseError
     MESSAGE =
       "`#controller` can't be used during initialization, as it depends " \
       "on the view context that only exists once a ViewComponent is passed to " \
       "the Rails render pipeline.\n\n" \
       "It's sometimes possible to fix this issue by moving code dependent on " \
       "`#controller` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void)."
-
-    def initialize
-      super(MESSAGE)
-    end
   end
 end

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -4,6 +4,17 @@ module ViewComponent
       super(self.class::MESSAGE)
     end
   end
+
+  class ReservedPluralSlotNameError < StandardError
+    MESSAGE =
+      "COMPONENT_CLASS_NAME declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.\n\n" \
+      "To fix this issue, choose a different name."
+
+    def initialize(klass_name, slot_name)
+      super(MESSAGE.gsub("COMPONENT_CLASS_NAME", klass_name.to_s).gsub("SLOT_NAME", slot_name.to_s))
+    end
+  end
+
   class NilWithContentError < BaseError
     MESSAGE =
       "No content provided to `#with_content` for #{self}.\n\n" \

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -105,6 +105,22 @@ module ViewComponent
       "`#controller` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void)."
   end
 
+  class NoMatchingTemplatesForPreviewError < StandardError
+    MESSAGE = "Found 0 matches for templates for TEMPLATE_IDENTIFIER."
+
+    def initialize(template_identifier)
+      super(MESSAGE.gsub("TEMPLATE_IDENTIFIER", template_identifier))
+    end
+  end
+
+  class MultipleMatchingTemplatesForPreviewError < StandardError
+    MESSAGE = "Found multiple templates for TEMPLATE_IDENTIFIER."
+
+    def initialize(template_identifier)
+      super(MESSAGE.gsub("TEMPLATE_IDENTIFIER", template_identifier))
+    end
+  end
+
   class SystemTestControllerOnlyAllowedInTestError < BaseError
     MESSAGE = "ViewComponent SystemTest controller must only be called in a test environment for security reasons."
   end

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -5,6 +5,10 @@ module ViewComponent
     end
   end
 
+  class MultipleInlineTemplatesError < BaseError
+    MESSAGE = "Inline templates can only be defined once per-component."
+  end
+
   class DuplicateContentError < StandardError
     MESSAGE =
       "It looks like a block was provided after calling `with_content` on COMPONENT, " \

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -5,6 +5,12 @@ module ViewComponent
     end
   end
 
+  class TemplateError < StandardError
+    def initialize(errors)
+      super(errors.join(", "))
+    end
+  end
+
   class MultipleInlineTemplatesError < BaseError
     MESSAGE = "Inline templates can only be defined once per-component."
   end

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -9,6 +9,16 @@ module ViewComponent
     MESSAGE = "Inline templates can only be defined once per-component."
   end
 
+  class MissingPreviewTemplateError < StandardError
+    MESSAGE =
+      "A preview template for example EXAMPLE doesn't exist.\n\n" \
+      "To fix this issue, create a template for the example."
+
+    def initialize(example)
+      super(MESSAGE.gsub("EXAMPLE", example))
+    end
+  end
+
   class DuplicateContentError < StandardError
     MESSAGE =
       "It looks like a block was provided after calling `with_content` on COMPONENT, " \

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -50,6 +50,12 @@ module ViewComponent
     end
   end
 
+  class InvalidCollectionArgumentError < BaseError
+    MESSAGE =
+      "The value of the first argument passed to `with_collection` isn't a valid collection. " \
+      "Make sure it responds to `to_ary`."
+  end
+
   class ContentSlotNameError < StandardError
     MESSAGE =
       "COMPONENT declares a slot named content, which is a reserved word in ViewComponent.\n\n" \

--- a/lib/view_component/inline_template.rb
+++ b/lib/view_component/inline_template.rb
@@ -10,7 +10,7 @@ module ViewComponent # :nodoc:
         return super if !method.end_with?("_template")
 
         if defined?(@__vc_inline_template_defined) && @__vc_inline_template_defined
-          raise ViewComponent::ComponentError, "inline templates can only be defined once per-component"
+          raise MultipleInlineTemplatesError
         end
 
         if args.size != 1

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -80,13 +80,7 @@ module ViewComponent # :nodoc:
             Dir["#{path}/#{preview_name}_preview/#{example}.html.*"].first
           end
 
-        if preview_path.nil?
-          raise(
-            PreviewTemplateError,
-            "A preview template for example #{example} doesn't exist.\n\n" \
-            "To fix this issue, create a template for the example."
-          )
-        end
+        raise MissingPreviewTemplateError.new(example) if preview_path.nil?
 
         path = Dir["#{preview_path}/#{preview_name}_preview/#{example}.html.*"].first
         Pathname.new(path)

--- a/lib/view_component/preview_template_error.rb
+++ b/lib/view_component/preview_template_error.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module ViewComponent
-  class PreviewTemplateError < StandardError
-  end
-end

--- a/lib/view_component/slot.rb
+++ b/lib/view_component/slot.rb
@@ -31,11 +31,7 @@ module ViewComponent
       view_context = @parent.send(:view_context)
 
       if defined?(@__vc_content_block) && defined?(@__vc_content_set_by_with_content)
-        raise ArgumentError.new(
-          "It looks like a block was provided after calling `with_content` on #{self.class.name}, " \
-          "which means that ViewComponent doesn't know which content to use.\n\n" \
-          "To fix this issue, use either `with_content` or a block."
-        )
+        raise DuplicateSlotContentError.new(self.class.name)
       end
 
       @content =

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -279,14 +279,7 @@ module ViewComponent
       end
 
       def raise_if_slot_ends_with_question_mark(slot_name)
-        if slot_name.to_s.ends_with?("?")
-          raise ArgumentError.new(
-            "#{self} declares a slot named #{slot_name}, which ends with a question mark.\n\n" \
-            "This is not allowed because the ViewComponent framework already provides predicate " \
-            "methods ending in `?`.\n\n" \
-            "To fix this issue, choose a different name."
-          )
-        end
+        raise SlotPredicateNameError.new(self.name, slot_name) if slot_name.to_s.ends_with?("?")
       end
     end
 

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -251,7 +251,7 @@ module ViewComponent
 
       def validate_plural_slot_name(slot_name)
         if RESERVED_NAMES[:plural].include?(slot_name.to_sym)
-          raise ReservedPluralSlotNameError.new(self.name, slot_name)
+          raise ReservedPluralSlotNameError.new(name, slot_name)
         end
 
         raise_if_slot_ends_with_question_mark(slot_name)
@@ -260,11 +260,11 @@ module ViewComponent
 
       def validate_singular_slot_name(slot_name)
         if slot_name.to_sym == :content
-          raise ContentSlotNameError.new(self.name)
+          raise ContentSlotNameError.new(name)
         end
 
         if RESERVED_NAMES[:singular].include?(slot_name.to_sym)
-          raise ReservedSingularSlotNameError.new(self.name, slot_name)
+          raise ReservedSingularSlotNameError.new(name, slot_name)
         end
 
         raise_if_slot_ends_with_question_mark(slot_name)
@@ -274,12 +274,12 @@ module ViewComponent
       def raise_if_slot_registered(slot_name)
         if registered_slots.key?(slot_name)
           # TODO remove? This breaks overriding slots when slots are inherited
-          raise RedefinedSlotError.new(self.name, slot_name)
+          raise RedefinedSlotError.new(name, slot_name)
         end
       end
 
       def raise_if_slot_ends_with_question_mark(slot_name)
-        raise SlotPredicateNameError.new(self.name, slot_name) if slot_name.to_s.ends_with?("?")
+        raise SlotPredicateNameError.new(name, slot_name) if slot_name.to_s.ends_with?("?")
       end
     end
 

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -264,10 +264,7 @@ module ViewComponent
         end
 
         if RESERVED_NAMES[:singular].include?(slot_name.to_sym)
-          raise ArgumentError.new(
-            "#{self} declares a slot named #{slot_name}, which is a reserved word in the ViewComponent framework.\n\n" \
-            "To fix this issue, choose a different name."
-          )
+          raise ReservedSingularSlotNameError.new(self.name, slot_name)
         end
 
         raise_if_slot_ends_with_question_mark(slot_name)

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -260,11 +260,7 @@ module ViewComponent
 
       def validate_singular_slot_name(slot_name)
         if slot_name.to_sym == :content
-          raise ArgumentError.new(
-            "#{self} declares a slot named content, which is a reserved word in ViewComponent.\n\n" \
-            "Content passed to a ViewComponent as a block is captured and assigned to the `content` accessor without having to create an explicit slot.\n\n" \
-            "To fix this issue, either use the `content` accessor directly or choose a different slot name."
-          )
+          raise ContentSlotNameError.new(self.name)
         end
 
         if RESERVED_NAMES[:singular].include?(slot_name.to_sym)

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -254,10 +254,7 @@ module ViewComponent
 
       def validate_plural_slot_name(slot_name)
         if RESERVED_NAMES[:plural].include?(slot_name.to_sym)
-          raise ArgumentError.new(
-            "#{self} declares a slot named #{slot_name}, which is a reserved word in the ViewComponent framework.\n\n" \
-            "To fix this issue, choose a different name."
-          )
+          raise ReservedPluralSlotNameError.new(self.name, slot_name)
         end
 
         raise_if_slot_ends_with_question_mark(slot_name)

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -360,7 +360,7 @@ module ViewComponent
       slot_definition = self.class.registered_slots[slot_name]
 
       if !slot_definition[:collection] && (defined?(@__vc_set_slots) && @__vc_set_slots[slot_name])
-        raise ArgumentError, "content for slot '#{slot_name}' has already been provided"
+        raise ContentAlreadySetForPolymorphicSlotError.new(slot_name)
       end
 
       poly_def = slot_definition[:renderable_hash][poly_type]

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -243,10 +243,7 @@ module ViewComponent
           define_method method_name, &callable
           slot[:renderable_function] = instance_method(method_name)
         else
-          raise(
-            ArgumentError,
-            "invalid slot definition. Please pass a class, string, or callable (i.e. proc, lambda, etc)"
-          )
+          raise(InvalidSlotDefinitionError)
         end
 
         slot

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -274,10 +274,7 @@ module ViewComponent
       def raise_if_slot_registered(slot_name)
         if registered_slots.key?(slot_name)
           # TODO remove? This breaks overriding slots when slots are inherited
-          raise ArgumentError.new(
-            "#{self} declares the #{slot_name} slot multiple times.\n\n" \
-            "To fix this issue, choose a different slot name."
-          )
+          raise RedefinedSlotError.new(self.name, slot_name)
         end
       end
 

--- a/lib/view_component/template_error.rb
+++ b/lib/view_component/template_error.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module ViewComponent
-  class TemplateError < StandardError
-    def initialize(errors)
-      super(errors.join(", "))
-    end
-  end
-end

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -221,8 +221,6 @@ module ViewComponent
 
     def __vc_test_helpers_preview_class
       result = if respond_to?(:described_class)
-        raise "`render_preview` expected a described_class, but it is nil." if described_class.nil?
-
         "#{described_class}Preview"
       else
         self.class.name.gsub("Test", "Preview")

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -97,7 +97,7 @@ module ViewComponent
     # Capybara assertions to be used. All arguments are forwarded to the block.
     #
     # ```ruby
-    # render_in_view_context(arg1, arg2:) do |arg1, arg2:|
+    # render_in_view_context(arg1, arg2: nil) do |arg1, arg2:|
     #   render(MyComponent.new(arg1, arg2))
     # end
     #

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -221,6 +221,8 @@ module ViewComponent
 
     def __vc_test_helpers_preview_class
       result = if respond_to?(:described_class)
+        raise "`render_preview` expected a described_class, but it is nil." if described_class.nil?
+
         "#{described_class}Preview"
       else
         self.class.name.gsub("Test", "Preview")

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -81,7 +81,7 @@ module ViewComponent
     end
 
     def translate(key = nil, **options)
-      raise(ViewComponent::TranslateCalledBeforeRenderError) if view_context.nil?
+      raise ViewComponent::TranslateCalledBeforeRenderError if view_context.nil?
 
       return super unless i18n_backend
       return key.map { |k| translate(k, **options) } if key.is_a?(Array)

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -81,16 +81,7 @@ module ViewComponent
     end
 
     def translate(key = nil, **options)
-      if view_context.nil?
-        raise(
-          ViewComponent::ViewContextCalledBeforeRenderError,
-          "`#translate` can't be used during initialization as it depends " \
-          "on the view context that only exists once a ViewComponent is passed to " \
-          "the Rails render pipeline.\n\n" \
-          "It's sometimes possible to fix this issue by moving code dependent on " \
-          "`#translate` to a `#before_render` method: https://viewcomponent.org/api.html#before_render--void."
-        )
-      end
+      raise(ViewComponent::TranslateCalledBeforeRenderError) if view_context.nil?
 
       return super unless i18n_backend
       return key.map { |k| translate(k, **options) } if key.is_a?(Array)

--- a/lib/view_component/with_content_helper.rb
+++ b/lib/view_component/with_content_helper.rb
@@ -3,14 +3,9 @@
 module ViewComponent
   module WithContentHelper
     def with_content(value)
-      if value.nil?
-        raise ArgumentError.new(
-          "No content provided to `#with_content` for #{self}.\n\n" \
-          "To fix this issue, pass a value."
-        )
-      else
-        @__vc_content_set_by_with_content = value
-      end
+      raise NilWithContentError if value.nil?
+
+      @__vc_content_set_by_with_content = value
 
       self
     end

--- a/test/sandbox/app/components/invalid_with_render_component.rb
+++ b/test/sandbox/app/components/invalid_with_render_component.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class InvalidWithRenderComponent < ViewComponent::Base
-  # You aren't permitted to implement this method.
-  def with_content
-  end
-end

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -31,7 +31,7 @@ class ViewComponent::Base::UnitTest < Minitest::Test
   def test_calling_helpers_outside_render_raises
     component = ViewComponent::Base.new
     err =
-      assert_raises ViewComponent::ViewContextCalledBeforeRenderError do
+      assert_raises ViewComponent::HelpersCalledBeforeRenderError do
         component.helpers
       end
     assert_includes err.message, "can't be used during initialization"

--- a/test/sandbox/test/inline_template_test.rb
+++ b/test/sandbox/test/inline_template_test.rb
@@ -123,14 +123,14 @@ class InlineErbTest < ViewComponent::TestCase
   end
 
   test "calling template methods multiple times raises an exception" do
-    error = assert_raises ViewComponent::ComponentError do
+    error = assert_raises ViewComponent::MultipleInlineTemplatesError do
       Class.new(InlineErbComponent) do
         erb_template "foo"
         erb_template "bar"
       end
     end
 
-    assert_equal "inline templates can only be defined once per-component", error.message
+    assert_equal "Inline templates can only be defined once per-component.", error.message
   end
 
   test "calling template methods with more or less than 1 argument raises" do

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -569,7 +569,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
 
   def test_raises_an_error_if_the_template_is_not_present_and_the_render_with_template_method_is_used_in_the_example
     error =
-      assert_raises ViewComponent::PreviewTemplateError do
+      assert_raises ViewComponent::MissingPreviewTemplateError do
         get "/rails/view_components/inline_component/without_template"
       end
     assert_match(/preview template for example without_template doesn't exist/, error.message)

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -667,7 +667,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   def test_path_traversal_raises_error
     path = "../../README.md"
 
-    assert_raises ArgumentError do
+    assert_raises ViewComponent::SystemTestControllerNefariousPathError do
       get "/_system_test_entrypoint?file=#{path}"
     end
   end

--- a/test/sandbox/test/preview_helper_test.rb
+++ b/test/sandbox/test/preview_helper_test.rb
@@ -128,7 +128,7 @@ class PreviewHelperTest < ActiveSupport::TestCase
           )
         end
 
-        assert_equal("found 0 matches for templates for #{template_identifier}.", exception.message)
+        assert_equal("Found 0 matches for templates for #{template_identifier}.", exception.message)
       end
     end
 
@@ -152,7 +152,7 @@ class PreviewHelperTest < ActiveSupport::TestCase
           )
         end
 
-        assert_equal("found multiple templates for #{template_identifier}.", exception.message)
+        assert_equal("Found multiple templates for #{template_identifier}.", exception.message)
       end
     end
   end

--- a/test/sandbox/test/preview_helper_test.rb
+++ b/test/sandbox/test/preview_helper_test.rb
@@ -121,7 +121,7 @@ class PreviewHelperTest < ActiveSupport::TestCase
       mock = Minitest::Mock.new
       mock.expect :map, []
       Rails.application.config.view_component.stub :preview_paths, mock do
-        exception = assert_raises RuntimeError do
+        exception = assert_raises ViewComponent::NoMatchingTemplatesForPreviewError do
           PreviewHelper.find_template_data(
             lookup_context: lookup_context,
             template_identifier: template_identifier
@@ -145,7 +145,7 @@ class PreviewHelperTest < ActiveSupport::TestCase
       mock = Minitest::Mock.new
       mock.expect :map, [template_identifier + ".html.haml", template_identifier + ".html.erb"]
       Rails.application.config.view_component.stub :preview_paths, mock do
-        exception = assert_raises RuntimeError do
+        exception = assert_raises ViewComponent::MultipleTemplatesForPreviewError do
           PreviewHelper.find_template_data(
             lookup_context: lookup_context,
             template_identifier: template_identifier

--- a/test/sandbox/test/preview_helper_test.rb
+++ b/test/sandbox/test/preview_helper_test.rb
@@ -145,7 +145,7 @@ class PreviewHelperTest < ActiveSupport::TestCase
       mock = Minitest::Mock.new
       mock.expect :map, [template_identifier + ".html.haml", template_identifier + ".html.erb"]
       Rails.application.config.view_component.stub :preview_paths, mock do
-        exception = assert_raises ViewComponent::MultipleTemplatesForPreviewError do
+        exception = assert_raises ViewComponent::MultipleMatchingTemplatesForPreviewError do
           PreviewHelper.find_template_data(
             lookup_context: lookup_context,
             template_identifier: template_identifier

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -652,7 +652,7 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_render_collection_missing_collection_object
     exception =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::InvalidCollectionArgumentError do
         render_inline(ProductComponent.with_collection("foo"))
       end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -681,7 +681,7 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_collection_component_missing_parameter_name
     exception =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::MissingCollectionArgumentError do
         render_inline(MissingCollectionParameterNameComponent.with_collection([]))
       end
 
@@ -692,7 +692,7 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_collection_component_missing_default_parameter_name
     exception =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::MissingCollectionArgumentError do
         render_inline(
           MissingDefaultCollectionParameterComponent.with_collection([OpenStruct.new(name: "Mints")])
         )
@@ -702,7 +702,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_collection_component_missing_custom_parameter_name_with_activemodel
-    exception = assert_raises ArgumentError do
+    exception = assert_raises ViewComponent::MissingCollectionArgumentError do
       render_inline(
         MissingCollectionParameterWithActiveModelComponent.with_collection([OpenStruct.new(name: "Mints")])
       )
@@ -758,7 +758,7 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_collection_component_with_trailing_comma_attr_reader
     exception =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::EmptyOrInvalidInitializerError do
         render_inline(
           ProductReaderOopsComponent.with_collection(["foo"])
         )

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -61,15 +61,6 @@ class RenderingTest < ViewComponent::TestCase
     assert_includes error.message, "It looks like a block was provided after calling"
   end
 
-  def test_raise_error_when_component_implements_with_content
-    exception =
-      assert_raises ViewComponent::ComponentError do
-        render_inline(InvalidWithRenderComponent.new)
-      end
-
-    assert_includes exception.message, "InvalidWithRenderComponent implements a reserved method, `#with_content`"
-  end
-
   def test_renders_content_given_as_argument
     render_inline(WrapperComponent.new.with_content("from arg"))
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -701,7 +701,7 @@ class RenderingTest < ViewComponent::TestCase
 
     assert_match(
       "The initializer for MissingCollectionParameterWithActiveModelComponent doesn't accept the parameter `name`, " \
-      "which is required in order to render it as a collection.\n\n" \
+      "which is required to render it as a collection.\n\n" \
       "To fix this issue, update the initializer to accept `name`.\n\n" \
       "See https://viewcomponent.org/guide/collections.html for more information on rendering collections.",
       exception.message

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -52,7 +52,7 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_raise_error_when_content_already_set
     error =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::DuplicateContentError do
         render_inline(WrapperComponent.new.with_content("setter content")) do
           "block content"
         end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -671,41 +671,25 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_collection_component_missing_parameter_name
-    exception =
-      assert_raises ViewComponent::MissingCollectionArgumentError do
-        render_inline(MissingCollectionParameterNameComponent.with_collection([]))
-      end
-
-    assert_match(
-      /The initializer for MissingCollectionParameterNameComponent doesn't accept the parameter/, exception.message
-    )
+    assert_raises ViewComponent::MissingCollectionArgumentError do
+      render_inline(MissingCollectionParameterNameComponent.with_collection([]))
+    end
   end
 
   def test_collection_component_missing_default_parameter_name
-    exception =
-      assert_raises ViewComponent::MissingCollectionArgumentError do
-        render_inline(
-          MissingDefaultCollectionParameterComponent.with_collection([OpenStruct.new(name: "Mints")])
-        )
-      end
-
-    assert_match(/MissingDefaultCollectionParameterComponent doesn't accept the parameter/, exception.message)
+    assert_raises ViewComponent::MissingCollectionArgumentError do
+      render_inline(
+        MissingDefaultCollectionParameterComponent.with_collection([OpenStruct.new(name: "Mints")])
+      )
+    end
   end
 
   def test_collection_component_missing_custom_parameter_name_with_activemodel
-    exception = assert_raises ViewComponent::MissingCollectionArgumentError do
+    assert_raises ViewComponent::MissingCollectionArgumentError do
       render_inline(
         MissingCollectionParameterWithActiveModelComponent.with_collection([OpenStruct.new(name: "Mints")])
       )
     end
-
-    assert_match(
-      "The initializer for MissingCollectionParameterWithActiveModelComponent doesn't accept the parameter `name`, " \
-      "which is required to render it as a collection.\n\n" \
-      "To fix this issue, update the initializer to accept `name`.\n\n" \
-      "See https://viewcomponent.org/guide/collections.html for more information on rendering collections.",
-      exception.message
-    )
   end
 
   def test_collection_component_present_custom_parameter_name_with_activemodel

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -76,9 +76,9 @@ class RenderingTest < ViewComponent::TestCase
     assert_selector("span", text: "from arg")
   end
 
-  def test_raises_error_when_with_content_is_called_withot_any_values
+  def test_raises_error_when_with_content_is_called_without_any_values
     exception =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::NilWithContentError do
         WrapperComponent.new.with_content(nil)
       end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -730,7 +730,7 @@ class RenderingTest < ViewComponent::TestCase
     ViewComponent::CompileCache.cache = Set.new
 
     exception =
-      assert_raises ViewComponent::ComponentError do
+      assert_raises ViewComponent::ReservedParameterError do
         InvalidParametersComponent.compile(raise_errors: true)
       end
 
@@ -744,7 +744,7 @@ class RenderingTest < ViewComponent::TestCase
     ViewComponent::CompileCache.cache = Set.new
 
     exception =
-      assert_raises ViewComponent::ComponentError do
+      assert_raises ViewComponent::ReservedParameterError do
         InvalidNamedParametersComponent.compile(raise_errors: true)
       end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -377,7 +377,7 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_renders_component_with_initializer_translations
     err =
-      assert_raises ViewComponent::ViewContextCalledBeforeRenderError do
+      assert_raises ViewComponent::TranslateCalledBeforeRenderError do
         render_inline(InitializerTranslationsComponent.new)
       end
     assert_includes err.message, "can't be used during initialization"

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -568,7 +568,7 @@ class SlotableTest < ViewComponent::TestCase
   end
 
   def test_invalid_slot_definition_raises_error
-    error = assert_raises ArgumentError do
+    error = assert_raises ViewComponent::InvalidSlotDefinitionError do
       Class.new(ViewComponent::Base) do
         renders_many :items, :foo
       end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -335,7 +335,7 @@ class SlotableTest < ViewComponent::TestCase
 
   def test_component_raises_when_given_content_slot_name
     exception =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::ContentSlotNameError do
         Class.new(ViewComponent::Base) do
           renders_one :content
         end
@@ -574,7 +574,7 @@ class SlotableTest < ViewComponent::TestCase
       end
     end
 
-    assert_includes error.message, "invalid slot definition"
+    assert_includes error.message, "Invalid slot definition"
   end
 
   def test_component_delegation_slots_work_with_helpers

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -368,7 +368,7 @@ class SlotableTest < ViewComponent::TestCase
   end
 
   def test_component_raises_when_given_invalid_slot_name_for_has_many
-    exception = assert_raises ArgumentError do
+    exception = assert_raises ViewComponent::ReservedPluralSlotNameError do
       Class.new(ViewComponent::Base) do
         renders_many :contents
       end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -557,7 +557,7 @@ class SlotableTest < ViewComponent::TestCase
   end
 
   def test_singular_polymorphic_slot_raises_on_redefinition
-    error = assert_raises ArgumentError do
+    error = assert_raises ViewComponent::ContentAlreadySetForPolymorphicSlotError do
       render_inline(PolymorphicSlotComponent.new) do |component|
         component.with_header_standard { "standard" }
         component.with_header_special { "special" }

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -126,7 +126,7 @@ class SlotableTest < ViewComponent::TestCase
 
   def test_sub_component_raise_with_duplicate_slot_name
     exception =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::RedefinedSlotError do
         SlotsComponent.renders_one :title
       end
 
@@ -602,7 +602,7 @@ class SlotableTest < ViewComponent::TestCase
   end
 
   def test_raises_error_on_conflicting_slot_names
-    error = assert_raises ArgumentError do
+    error = assert_raises ViewComponent::RedefinedSlotError do
       Class.new(ViewComponent::Base) do
         renders_one :conflicting_item
         renders_many :conflicting_items
@@ -613,7 +613,7 @@ class SlotableTest < ViewComponent::TestCase
   end
 
   def test_raises_error_on_conflicting_slot_names_in_reverse_order
-    error = assert_raises ArgumentError do
+    error = assert_raises ViewComponent::RedefinedSlotError do
       Class.new(ViewComponent::Base) do
         renders_many :conflicting_items
         renders_one :conflicting_item

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -417,7 +417,7 @@ class SlotableTest < ViewComponent::TestCase
 
   def test_raises_if_using_both_block_content_and_with_content
     error =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::DuplicateSlotContentError do
         component = SlotsComponent.new
         slot = component.with_title("some_argument")
         slot.with_content("This is my title!")

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -347,7 +347,7 @@ class SlotableTest < ViewComponent::TestCase
 
   def test_component_raises_when_given_invalid_slot_name
     exception =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::ReservedSingularSlotNameError do
         Class.new(ViewComponent::Base) do
           renders_one :render
         end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -358,7 +358,7 @@ class SlotableTest < ViewComponent::TestCase
 
   def test_component_raises_when_given_one_slot_name_ending_with_question_mark
     exception =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::SlotPredicateNameError do
         Class.new(ViewComponent::Base) do
           renders_one :item?
         end
@@ -379,7 +379,7 @@ class SlotableTest < ViewComponent::TestCase
 
   def test_component_raises_when_given_many_slot_name_ending_with_question_mark
     exception =
-      assert_raises ArgumentError do
+      assert_raises ViewComponent::SlotPredicateNameError do
         Class.new(ViewComponent::Base) do
           renders_many :items?
         end


### PR DESCRIPTION
### What are you trying to accomplish?

The goal of this PR is to add all of our error messages to our docs. In order to do so, I moved all of our errors to an `Errors` module and had YARD look for classes ending in `Error` that have a `MESSAGE` constant.

I also cleaned up a few errors that should have been removed previously. I'll follow up with a review of our error messages themselves.

What do y'all think of the names for these errors?