### PR TITLE
Added support for CSP nonces with `javascript_tag` 

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -38,6 +38,9 @@ module ViewComponent
     # For CSRF authenticity tokens in forms
     delegate :form_authenticity_token, :protect_against_forgery?, :config, to: :helpers
 
+    #For Content Security Policy nonces
+    delegate :content_security_policy_nonce, to: :helpers
+
     # Config option that strips trailing whitespace in templates before compiling them.
     class_attribute :__vc_strip_trailing_whitespace, instance_accessor: false, instance_predicate: false
     self.__vc_strip_trailing_whitespace = false # class_attribute:default doesn't work until Rails 5.2


### PR DESCRIPTION
### What are you trying to accomplish?

This allows `javascript_tag` to work with the nonce parameter without throwing this error `undefined local variable or method `content_security_policy_nonce' for #<NonceComponent:0x00007fdee2bc2f50 @_routes=nil, @view_context=#<ActionView::Base:0x0000000000ea60>`

### What approach did you choose and why?

I used an aproach similar to adding the CSRF token helper to components to make sure the added code fits the style of the codebase. The primary trade of with this aproach is that it couples the requests global state into the component but I believe this is an acceptable use case as their would be no way to pull in a nonce value without coupling global state somewhat 

### Anything you want to highlight for special attention from reviewers?