### PR TITLE
Fix duplication in configuration docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Fix duplication in configuration docs.
+
+    *Tom Chen*
+
 * Fix helpers not reloading in development.
 
     *Jonathan del Strother*

--- a/docs/api.md
+++ b/docs/api.md
@@ -130,10 +130,6 @@ so helpers, etc work as expected.
 
 ### `.capture_compatibility_patch_enabled`
 
-A custom default layout used for the previews index page and individual
-previews.
-Defaults to `nil`. If this is falsy, `"component_preview"` is used.
-
 Enables the experimental capture compatibility patch that makes ViewComponent
 compatible with forms, capture, and other built-ins.
 previews.
@@ -154,11 +150,6 @@ Returns the value of attribute config.
 A custom default layout used for the previews index page and individual
 previews.
 Defaults to `nil`. If this is falsy, `"component_preview"` is used.
-
-Enables the experimental capture compatibility patch that makes ViewComponent
-compatible with forms, capture, and other built-ins.
-previews.
-Defaults to `false`.
 
 ### `.generate`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,7 @@ nav_order: 3
 
 ## Class methods
 
-### `.config` → [ViewComponent::Config]
+### `.config` → [ActiveSupport::OrderedOptions]
 
 Returns the current config.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -210,6 +210,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/svetlins?s=64" alt="svetlins" width="32" />
 <img src="https://avatars.githubusercontent.com/nickmalcolm?s=64" alt="nickmalcolm" width="32" />
 <img src="https://avatars.githubusercontent.com/reeganviljoen?s=64" alt="reeganviljoen" width="32" />
+<img src="https://avatars.githubusercontent.com/thomascchen?s=64" alt="thomascchen" width="32" />
 
 ## Who uses ViewComponent?
 

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -138,7 +138,7 @@ module ViewComponent
       # A custom default layout used for the previews index page and individual
       # previews.
       # Defaults to `nil`. If this is falsy, `"component_preview"` is used.
-      #
+
       # @!attribute capture_compatibility_patch_enabled
       # @return [Boolean]
       # Enables the experimental capture compatibility patch that makes ViewComponent


### PR DESCRIPTION
### What are you trying to accomplish?

This fixes some incorrect duplication in the configuration docs for `.capture_compatibility_patch_enabled` and `.default_preview_layout`. The descriptions for both config options were included under both headings. This seems to have been introduced in this commit: https://github.com/ViewComponent/view_component/commit/72830c8cf4aa034570fb2cc3167dedbd69cf7f4b.