### PR TITLE
Add Url helpers to previews 

### DIFF
--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -4,6 +4,7 @@ require "active_support/descendants_tracker"
 
 module ViewComponent # :nodoc:
   class Preview
+    include Rails.application.routes.url_helpers
     include ActionView::Helpers::TagHelper
     include ActionView::Helpers::AssetTagHelper
     extend ActiveSupport::DescendantsTracker

--- a/test/sandbox/app/components/url_helper_component.html.erb
+++ b/test/sandbox/app/components/url_helper_component.html.erb
@@ -1,0 +1,1 @@
+<a href=<%=@url%> target="_blank">root</a>

--- a/test/sandbox/app/components/url_helper_component.rb
+++ b/test/sandbox/app/components/url_helper_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UrlHelperComponent < ViewComponent::Base
+  def initialize(url: root_path)
+    @url = url
+  end
+end

--- a/test/sandbox/test/components/previews/url_helper_component_preview.rb
+++ b/test/sandbox/test/components/previews/url_helper_component_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UrlHelperComponentPreview < ViewComponent::Preview
+  def default
+    render(UrlHelperComponent.new(url: root_path))
+  end
+end

--- a/test/sandbox/test/components/render_preview_test.rb
+++ b/test/sandbox/test/components/render_preview_test.rb
@@ -12,4 +12,10 @@ class RenderPreviewTest < ViewComponent::TestCase
 
     assert_selector("div", text: "hello,world!")
   end
+
+  def test_render_preview_with_url_helper
+    render_preview(:default, from: UrlHelperComponentPreview)
+    
+    assert_selector("a[href='/']", text: "root")
+  end
 end


### PR DESCRIPTION
closes https://github.com/ViewComponent/view_component/issues/1764
### What are you trying to accomplish?
Add Rails Url helpers to previews, for instance, if resources :items is defined in routes.rb, I may want to use items_path in the component preview method
<!-- Provide a description of the changes. Link to any related issues or projects. -->

### What approach did you choose and why?
I added `include Rails.application.routes.url_helpers` to `preview.rb` to add the helpers to the previews class 

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->
A similar way to achieve this is by using the preview template which will have the URL helpers loaded but that seems like overkill just to get access to a helper
### Anything you want to highlight for special attention from reviewers?