### PR TITLE
detect closest match preview path when namespaced previews exist

### DIFF
--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -59,7 +59,7 @@ module ViewComponent
     def find_preview
       candidates = []
       params[:path].to_s.scan(%r{/|$}) { candidates << Regexp.last_match.pre_match }
-      preview = candidates.sort_by { |candidate| -candidate.length }.detect { |candidate| ViewComponent::Preview.exists?(candidate) }
+      preview = candidates.sort_by(&:length).reverse_each.detect { |candidate| ViewComponent::Preview.exists?(candidate) }
 
       if preview
         @preview = ViewComponent::Preview.find(preview)

--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -59,7 +59,7 @@ module ViewComponent
     def find_preview
       candidates = []
       params[:path].to_s.scan(%r{/|$}) { candidates << Regexp.last_match.pre_match }
-      preview = candidates.detect { |candidate| ViewComponent::Preview.exists?(candidate) }
+      preview = candidates.sort_by { |candidate| -candidate.length }.detect { |candidate| ViewComponent::Preview.exists?(candidate) }
 
       if preview
         @preview = ViewComponent::Preview.find(preview)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,10 @@ nav_order: 5
 * Allow Setting host when using the `with_request_url` test helper.
 
      *Daniel Alfaro*
+ 
+* Resolve ambiguous preview paths when using components without the Component suffix.
+
+     *Reed Law*
 
 ## 3.2.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ nav_order: 5
 * Allow Setting host when using the `with_request_url` test helper.
 
      *Daniel Alfaro*
- 
+
 * Resolve ambiguous preview paths when using components without the Component suffix.
 
      *Reed Law*

--- a/test/sandbox/app/components/unsuffixed.html.erb
+++ b/test/sandbox/app/components/unsuffixed.html.erb
@@ -1,0 +1,2 @@
+<div>hello,world!</div>
+<%= content %>

--- a/test/sandbox/app/components/unsuffixed.rb
+++ b/test/sandbox/app/components/unsuffixed.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Unsuffixed < ViewComponent::Base
+end

--- a/test/sandbox/app/components/unsuffixed/other.html.erb
+++ b/test/sandbox/app/components/unsuffixed/other.html.erb
@@ -1,0 +1,2 @@
+<div>subclass</div>
+<%= content %>

--- a/test/sandbox/app/components/unsuffixed/other.rb
+++ b/test/sandbox/app/components/unsuffixed/other.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Unsuffixed::Other < ViewComponent::Base
+end

--- a/test/sandbox/test/components/previews/unsuffixed/other_preview.rb
+++ b/test/sandbox/test/components/previews/unsuffixed/other_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Unsuffixed::OtherPreview < ViewComponent::Preview
+  def other
+    render(Unsuffixed::Other.new)
+  end
+end

--- a/test/sandbox/test/components/previews/unsuffixed_preview.rb
+++ b/test/sandbox/test/components/previews/unsuffixed_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UnsuffixedPreview < ViewComponent::Preview
+  def default
+    render(Unsuffixed.new)
+  end
+end

--- a/test/sandbox/test/components/render_preview_test.rb
+++ b/test/sandbox/test/components/render_preview_test.rb
@@ -18,4 +18,10 @@ class RenderPreviewTest < ViewComponent::TestCase
 
     assert_selector("a[href='/']", text: "root")
   end
+
+  def test_render_preview_unsuffixed
+    render_preview(:other, from: Unsuffixed::OtherPreview)
+
+    assert_selector("div", text: "subclass")
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

When using components without the `Component` suffix there can be ambiguous preview paths. For instance, if there is a [`milestone`](https://github.com/reedrolemodel/view_component-bug-replica/blob/master/app/components/milestone.rb) and [`milestone/card`](https://github.com/reedrolemodel/view_component-bug-replica/blob/master/app/components/milestone/card.rb), both are candidates when rendering a [`:with_default_title`](https://github.com/reedrolemodel/view_component-bug-replica/blob/master/test/components/previews/milestone/card_preview.rb) preview. [app/controllers/concerns/view_component/preview_actions.rb#62](https://github.com/ViewComponent/view_component/blob/72b4f7de53d0834f5b9bf1ee83bee5ff79e2a09b/app/controllers/concerns/view_component/preview_actions.rb#L62) always detects the first candidate, `milestone`, which is the wrong one when testing `milestone/card`.

### What approach did you choose and why?

Reverse sorting the candidate paths by length results in the longest match which means we get the most specific one.

### Anything you want to highlight for special attention from reviewers?

Depending on the project, this bug can result in `NameError` if the preview method doesn't exist in the other preview class. In [this reproduction](https://github.com/reedrolemodel/view_component-bug-replica/) the test renders the wrong preview text:

```
Failure:
Milestone::CardTest#test_render_preview [/home/reed/src/view_component-bug-replica/test/components/milestone/card_test.rb:7]:
expected to find text "Milestone card component default" in "\n  \n    ViewComponentBugReplica\n    \n    \n    \n\n    \n  \n\n  \n        Milestone component default\n\n\n\n\n  \n"
```