### PR TITLE
Update integration test to use valid HTML5

### DIFF
--- a/test/sandbox/app/components/partial_haml_component.html.haml
+++ b/test/sandbox/app/components/partial_haml_component.html.haml
@@ -1,2 +1,2 @@
-%span.bar
+%div.bar
   = render "haml_partial"

--- a/test/sandbox/app/views/integration_examples/nested_haml.html.haml
+++ b/test/sandbox/app/views/integration_examples/nested_haml.html.haml
@@ -1,3 +1,3 @@
-%p.foo
+%div.foo
   = "Hello, world!"
   = render(PartialHamlComponent.new)

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -616,7 +616,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
 
     get "/nested_haml"
     assert_response :success
-    assert_select "p.foo > span.bar > div.baz > article.quux > div.haml-div"
+    assert_select ".foo > .bar > .baz > .quux > .haml-div"
   end
 
   def test_raises_an_error_if_the_template_is_not_present_and_the_render_with_template_method_is_used_in_the_example


### PR DESCRIPTION
This change fixes a test in our suite broken by
https://github.com/rails/rails/pull/48523.

Before the upstream change, invalid the invalid HTML5 in this test case was parsed without issue. The upstream change switched the Nokogiri parsing mode to HTML5, leading to parsing issues with our test case.

I've converted all of the DOM nodes in this case into divs, preserving the intention of the test case but making it valid HTML5.