### PR TITLE
use correct syntax for assert_select

### DIFF
--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -208,7 +208,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     get "/partial"
     assert_response :success
 
-    assert_select("div", { text: "hello,partial world!", count: 4 })
+    assert_select("div", {text: "hello,partial world!", count: 4})
   end
 
   def test_rendering_component_without_variant

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -208,7 +208,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     get "/partial"
     assert_response :success
 
-    assert_select("div", "hello,partial world!", count: 2)
+    assert_select("div", { text: "hello,partial world!", count: 4 })
   end
 
   def test_rendering_component_without_variant


### PR DESCRIPTION
### What are you trying to accomplish?

This PR updates a test to use the correct syntax for `assert_select`. This has likely been an issue for a while but only recently caused CI to fail due to changes to `rails-dom-testing` to not accept invalid arguments.