### PR TITLE
Restore API documentation example for with_request_url's `host` param

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -349,6 +349,14 @@ with_request_url("/users/42") do
 end
 ```
 
+To use a specific host, pass the host param:
+
+```ruby
+with_request_url("/users/42", host: "app.example.com") do
+  render_inline(MyComponent.new)
+end
+```
+
 ### `#with_variant(variant)`
 
 Set the Action Pack request variant for the given block:

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -155,6 +155,14 @@ module ViewComponent
     # end
     # ```
     #
+    # To use a specific host, pass the host param:
+    #
+    # ```ruby
+    # with_request_url("/users/42", host: "app.example.com") do
+    #   render_inline(MyComponent.new)
+    # end
+    # ```
+    #
     # @param path [String] The path to set for the current request.
     # @param host [String] The host to set for the current request.
     def with_request_url(path, host: nil)


### PR DESCRIPTION
### What are you trying to accomplish?

Addresses https://github.com/ViewComponent/view_component/pull/1771#pullrequestreview-1519743265

It looks like this may have been inadvertently deleted by regenerating the API docs. That happened because this example was manually added directly in `api.md` in https://github.com/ViewComponent/view_component/pull/1773, rather than in the corresponding YARD comment. To fix this, we've added the example to the YARD comment and regenerated the API docs.

I did not include a changelog entry since this is just basically just reverting an inadvertent change from the most recent PR.