### PR TITLE
Add Skroutz engineering to the list of users

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add Skroutz to users list.
+
+    *Chris Nitsas*
+
 ## 3.4.0
 
 * Avoid including Rails `url_helpers` into `Preview` class when they're not defined.

--- a/docs/index.md
+++ b/docs/index.md
@@ -248,6 +248,7 @@ ViewComponent is built by over a hundred members of the community, including:
 * [Project Blacklight](http://projectblacklight.org/)
 * [QuickNode](https://www.quicknode.com/)
 * [Room AI](https://roomai.com/)
+* [Skroutz](https://engineering.skroutz.gr/blog/)
 * [Shogun](https://getshogun.com/)
 * [Spina CMS](https://spinacms.com/)
 * [Startup Jobs](https://startup.jobs/)


### PR DESCRIPTION
We've started using ViewComponent since March 2023 and we are extremely satisfied with the experience!

### What are you trying to accomplish?

Added Skroutz to the list of ViewComponent users, with a link to our [engineering blog](https://engineering.skroutz.gr/blog/). 🙂

### What approach did you choose and why?

Hi, I read CONTRIBUTING.md but didn't add myself in the list of contributors because I only added a new entry in the list of users of the library. I didn't actually contribute anything else. I'll check the issues and try to help in the future. 🙂

### Anything you want to highlight for special attention from reviewers?