### PR TITLE
Allow setting method when using the  test helper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,10 @@ nav_order: 5
 
     *Nachiket Pusalkar*
 
+* Allow setting method when using the `with_request_url` test helper.
+
+    *Andrew Duthie*
+
 ## 3.7.0
 
 * Support Rails 7.1 in CI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,6 +211,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/reeganviljoen?s=64" alt="reeganviljoen" width="32" />
 <img src="https://avatars.githubusercontent.com/thomascchen?s=64" alt="thomascchen" width="32" />
 <img src="https://avatars.githubusercontent.com/milk1000cc?s=64" alt="milk1000cc" width="32" />
+<img src="https://avatars.githubusercontent.com/aduth?s=64" alt="aduth" width="32" />
 
 ## Who uses ViewComponent?
 

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -163,10 +163,20 @@ module ViewComponent
     # end
     # ```
     #
+    # To specify a request method, pass the method param:
+    #
+    # ```ruby
+    # with_request_url("/users/42", method: "POST") do
+    #   render_inline(MyComponent.new)
+    # end
+    # ```
+    #
     # @param path [String] The path to set for the current request.
     # @param host [String] The host to set for the current request.
-    def with_request_url(full_path, host: nil)
+    # @param method [String] The request method to set for the current request.
+    def with_request_url(full_path, host: nil, method: nil)
       old_request_host = vc_test_request.host
+      old_request_method = vc_test_request.request_method
       old_request_path_info = vc_test_request.path_info
       old_request_path_parameters = vc_test_request.path_parameters
       old_request_query_parameters = vc_test_request.query_parameters
@@ -177,6 +187,7 @@ module ViewComponent
       vc_test_request.instance_variable_set(:@fullpath, full_path)
       vc_test_request.instance_variable_set(:@original_fullpath, full_path)
       vc_test_request.host = host if host
+      vc_test_request.request_method = method if method
       vc_test_request.path_info = path
       vc_test_request.path_parameters = Rails.application.routes.recognize_path_with_request(vc_test_request, path, {})
       vc_test_request.set_header("action_dispatch.request.query_parameters",
@@ -185,6 +196,7 @@ module ViewComponent
       yield
     ensure
       vc_test_request.host = old_request_host
+      vc_test_request.request_method = old_request_method
       vc_test_request.path_info = old_request_path_info
       vc_test_request.path_parameters = old_request_path_parameters
       vc_test_request.set_header("action_dispatch.request.query_parameters", old_request_query_parameters)

--- a/test/sandbox/app/components/current_page_component.rb
+++ b/test/sandbox/app/components/current_page_component.rb
@@ -2,10 +2,6 @@
 
 class CurrentPageComponent < ViewComponent::Base
   def text
-    if current_page?("/slots")
-      "Inside /slots"
-    else
-      "Outside /slots"
-    end
+    "#{current_page?("/slots") ? "Inside" : "Outside"} /slots (#{request.method} #{request.path})"
   end
 end

--- a/test/sandbox/config/routes.rb
+++ b/test/sandbox/config/routes.rb
@@ -29,6 +29,7 @@ Sandbox::Application.routes.draw do
   get :cached_partial, to: "integration_examples#cached_partial"
   get :inherited_sidecar, to: "integration_examples#inherited_sidecar"
   get :inherited_from_uncompilable_component, to: "integration_examples#inherited_from_uncompilable_component"
+  post :create, to: "integration_examples#create"
 
   constraints(lambda { |request| request.env["warden"].authenticate! }) do
     get :constraints_with_env, to: "integration_examples#index"

--- a/test/sandbox/test/test_helper_test.rb
+++ b/test/sandbox/test/test_helper_test.rb
@@ -8,7 +8,7 @@ class TestHelperTest < ViewComponent::TestCase
       render_inline(CurrentPageComponent.new)
     end
 
-    assert_selector("div", text: "Inside /slots")
+    assert_selector("div", text: "Inside /slots (GET /slots)")
   end
 
   def test_with_request_url_outside_slots_path
@@ -16,7 +16,15 @@ class TestHelperTest < ViewComponent::TestCase
       render_inline(CurrentPageComponent.new)
     end
 
-    assert_selector("div", text: "Outside /slots")
+    assert_selector("div", text: "Outside /slots (GET /)")
+  end
+
+  def test_with_request_url_specifying_method
+    with_request_url "/create", method: "POST" do
+      render_inline(CurrentPageComponent.new)
+    end
+
+    assert_selector("div", text: "Outside /slots (POST /create)")
   end
 
   def test_with_request_url_under_constraint


### PR DESCRIPTION
### What are you trying to accomplish?

We have components whose logic varies depending based on the request method, which is not easy to test with the current `with_request_url` helper.

### What approach did you choose and why?

This adds a new `method` option to `with_request_url`. This follows the pattern previously established with the `host` option which exists to similarly specify the `host` associated with the test request.
