### PR TITLE
Docs: Add `html_safe` example to testing->slots section

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ nav_order: 5
 
     *Cameron Dutro*
 
+* Minor testing documentation improvement.
+
+    *Travis Gaff*
+
 ## 3.5.0
 
 * Add Skroutz to users list.

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -33,6 +33,7 @@ def test_render_component
   component = ListComponent.new(title: "Fruits").tap do |c|
     c.with_item { "Apple" }
     c.with_item { "Orange" }
+    c.with_extra { "<div><span>rendered html</span></div>".html_safe }
   end
 
   render_inline(component)


### PR DESCRIPTION
### What are you trying to accomplish?

I'm trying to make a (small) testing bump in the road easy to resolve.

I ran into an issue where a tested component was rendering the passed slot as plain text.  I thought a doc example with `html_safe` might help others with testing.

```rb
    component.tap do |c|
      c.with_buttons { "<div><button>bigger</button><a href='smaller'>smaller</a></div>" }
    end
    render_inline(component)
```

Results in the following `page.find('.some-class').native.inner_html`

```html
<div class=\"flex justify-end gap-3 bg-secondary-50 px-6 py-3\">&lt;div&gt;&lt;button&gt;bigger&lt;/button&gt;&lt;a href='smaller'&gt;smaller&lt;/a&gt;&lt;/div&gt;</div>"
```


### What approach did you choose and why?

It's not really worth it to do templating in tests.  This seems like an easy compromise.

### Anything you want to highlight for special attention from reviewers?

Nah, this is straightforward I think.