### PR TITLE
Stop running PVC's 'docs:preview' rake task in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,6 @@ jobs:
         cd demo && npm ci && cd ..
         bundle config path vendor/bundle
         bundle install
-        bundle exec rake docs:preview
         bundle exec rake
       env:
         VIEW_COMPONENT_PATH: ../view_component

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Stop running PVC's `docs:preview` rake task in CI, as the old docsite has been removed.
+
+    *Cameron Dutro*
+
 ## 3.5.0
 
 * Add Skroutz to users list.


### PR DESCRIPTION
### What are you trying to accomplish?

A [recent PR](https://github.com/primer/view_components/pull/2193) removed the legacy docsite from the PVC repo, which included the `docs:preview` rake task. We should stop running it in our CI.

### What approach did you choose and why?

I removed the line that runs the offending rake task.