### PR TITLE
bug: Slots with the name prefix `call` cause rendering to fail

### DIFF
--- a/test/sandbox/app/components/empty_slot_component.rb
+++ b/test/sandbox/app/components/empty_slot_component.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class EmptySlotComponent < ViewComponent::Base
-  renders_one :title
+  renders_one :callout_title
 end

--- a/test/sandbox/app/views/integration_examples/empty_slot.slim
+++ b/test/sandbox/app/views/integration_examples/empty_slot.slim
@@ -1,3 +1,3 @@
 = render(EmptySlotComponent.new) do |component|
-  - component.title
+  - component.callout_title
     - nil

--- a/test/sandbox/test/components/empty_slot_component_test.rb
+++ b/test/sandbox/test/components/empty_slot_component_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MyComponentTest < ViewComponent::TestCase
+  def setup
+    ViewComponent::Preview.load_previews
+  end
+
+  def test_render_without_slot
+    render_preview(:default, from: EmptySlotComponent)
+
+    assert_selector("span", text: "Hello")
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

This is a bug report. When a component defines a `render_one` with a slot name starting with `call`, the app will crash when attempting to render.

This started as of v3.5.0 and does not occur with v3.4.0.

[This is the specific line](https://github.com/ViewComponent/view_component/commit/425338ffc99d59c335ccd82f95ba17135ab18be9#diff-fa28fa6e2d5f267384e7793b855281451a46b8437431867871a298fc52fe4940R99) where the app crashes, but the root cause appears to be the slot name being caught by [the logic to find "inline calls"](https://github.com/ViewComponent/view_component/blob/425338ffc99d59c335ccd82f95ba17135ab18be9/lib/view_component/compiler.rb#L222).

### What approach did you choose and why?

This is a minimal reproduction of the error within the existing codebase. Per the bug report Issue template guidance, I am opening a PR with a failing test to demonstrate the issue.

I also have a full repo version of a minimal reproduction of the bug: https://github.com/wenley/ViewComponent-3.5.0-bug

### Anything you want to highlight for special attention from reviewers?

I'll admit that the problematic case is a bit niche, but even changing the prefix matching to look for `call_` might be an improvement.