### PR TITLE
Fix `#with_request_url` to ensure `request.query_parameters` is an instance of ActiveSupport::HashWithIndifferentAccess

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,10 @@ nav_order: 5
 
     *Sebastjan Prachovskij*
 
+* Fix `#with_request_url` to ensure `request.query_parameters` is an instance of ActiveSupport::HashWithIndifferentAccess.
+
+    *milk1000cc*
+
 ## 3.5.0
 
 * Add Skroutz to users list.

--- a/docs/index.md
+++ b/docs/index.md
@@ -209,6 +209,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/nickmalcolm?s=64" alt="nickmalcolm" width="32" />
 <img src="https://avatars.githubusercontent.com/reeganviljoen?s=64" alt="reeganviljoen" width="32" />
 <img src="https://avatars.githubusercontent.com/thomascchen?s=64" alt="thomascchen" width="32" />
+<img src="https://avatars.githubusercontent.com/milk1000cc?s=64" alt="milk1000cc" width="32" />
 
 ## Who uses ViewComponent?
 

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -177,7 +177,8 @@ module ViewComponent
       vc_test_request.host = host if host
       vc_test_request.path_info = path
       vc_test_request.path_parameters = Rails.application.routes.recognize_path_with_request(vc_test_request, path, {})
-      vc_test_request.set_header("action_dispatch.request.query_parameters", Rack::Utils.parse_nested_query(query))
+      vc_test_request.set_header("action_dispatch.request.query_parameters",
+        Rack::Utils.parse_nested_query(query).with_indifferent_access)
       vc_test_request.set_header(Rack::QUERY_STRING, query)
       yield
     ensure

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -855,6 +855,7 @@ class RenderingTest < ViewComponent::TestCase
       assert_equal "/products", vc_test_request.path
       assert_equal "mykey=myvalue&otherkey=othervalue", vc_test_request.query_string
       assert_equal "/products?mykey=myvalue&otherkey=othervalue", vc_test_request.fullpath
+      assert_instance_of ActiveSupport::HashWithIndifferentAccess, vc_test_request.query_parameters
     end
 
     with_request_url "/products?mykey[mynestedkey]=myvalue" do


### PR DESCRIPTION
### What are you trying to accomplish?

When using the `#with_request_url` test helper, `request.query_parameters` returns `Hash`, while Rails' `request.query_parameters` returns `ActiveSupport::HashWithIndifferentAccess`.

So I changed the `request.query_parameters` in the `#with_request_url` test helper to also return `ActiveSupport::HashWithIndifferentAccess`.