### PR TITLE
Refer to helpers in `NameError` response in development/test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Refer to `helpers` in `NameError` message in development and test environments.
+
+    *Simon Fish*
+
 * Fix API documentation and revert unnecessary change in `preview.rb`.
 
     *Richard Macklin*

--- a/test/sandbox/app/components/references_method_on_helpers_component.html.erb
+++ b/test/sandbox/app/components/references_method_on_helpers_component.html.erb
@@ -1,0 +1,1 @@
+<%= current_user %>

--- a/test/sandbox/app/components/references_method_on_helpers_component.rb
+++ b/test/sandbox/app/components/references_method_on_helpers_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ReferencesMethodOnHelpersComponent < ViewComponent::Base
+end

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -119,7 +119,11 @@ class ViewComponent::Base::UnitTest < Minitest::Test
 
   def test_no_method_error_references_helper_if_view_context_present
     view_context = ActionController::Base.new.view_context
-    view_context.instance_eval { def current_user; "a user"; end }
+    view_context.instance_eval {
+      def current_user
+        "a user"
+      end
+    }
     exception = assert_raises(NameError) { ReferencesMethodOnHelpersComponent.new.render_in(view_context) }
     exception_advice = "You may be trying to call a method provided as a view helper. Did you mean `helpers.current_user'?"
     assert exception.message.include?(exception_advice)

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -122,7 +122,7 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     view_context.instance_eval { def current_user; "a user"; end }
     exception = assert_raises(NameError) { ReferencesMethodOnHelpersComponent.new.render_in(view_context) }
     exception_advice = "You may be trying to call a method provided as a view helper. Did you mean `helpers.current_user'?"
-    assert exception.message.ends_with?(exception_advice)
+    assert exception.message.include?(exception_advice)
   end
 
   def test_no_method_error_does_not_reference_missing_helper

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -106,4 +106,14 @@ class ViewComponent::Base::UnitTest < Minitest::Test
 
     eval(source) # rubocop:disable Security/Eval
   end
+
+  def test_no_method_error_references_helper_if_available
+    exception = assert_raises(NoMethodError) { Class.new(ViewComponent::Base).new.current_user }
+    exception_message_regex = Regexp.new <<~MESSAGE.chomp #, Regexp::MULTILINE
+      undefined method `current_user' for .*
+
+      You may be trying to call a method provided as a view helper. Did you mean `helpers.current_user'?
+    MESSAGE
+    assert exception_message_regex.match?(exception.message)
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

We identified in #1836 that some things might influence whether the developer is aware of methods provided by the helper layer, particularly in the case where they may have used the help of libraries like Devise and Kaminari to get going. In order to make things easier when you're getting started like this, this PR adds extra context to `NameError`s raised by method calls that mirror something the view context already responds to.

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->
`method_missing` seemed like a natural fit here, but as suggested by @camertron, I've conditionally defined this behaviour for development and test environments only.

Additionally, the source location is removed from the backtrace – this was causing another test to fail.

### Anything you want to highlight for special attention from reviewers?

Worth noting that I needed to `define_instance_method` in order to stub in the test, since calling MiniTest's `stub` would raise an error because view contexts don't naturally define `current_user`.

I wonder if there's anything more we can add here? A link to some docs, perhaps?

Also, it's worth noting that for older versions of Ruby, `DidYouMean` appends its suggestion a couple of times (notice `Did you mean?   current_page?` showing up twice in the below logs):

```rb
[1] pry(#<ViewComponent::Base::UnitTest>)> exception.message
=> "undefined local variable or method `current_user' for #<ReferencesMethodOnHelpersComponent:0x0000000151a98560>\nDid you mean?  current_page?\n\nYou may be trying to call a method provided as a view helper. Did you mean `helpers.current_user'?\nDid you mean?  current_page?"
```