### PR TITLE
Support devise using ViewComponent::TestCase

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add support for `Devise::Test::ControllerHelpers` by resolving `NoMethodError: undefined method env for nil:NilClass`
+
+    *fugufish*
+
 * Refer to `helpers` in `NameError` message in development and test environments.
 
     *Simon Fish*

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -164,17 +164,6 @@ class ExampleComponentTest < ViewComponent::TestCase
 end
 ```
 
-## Testing with Devise
-
-Testing with Devise requires you include `Devise::Test::ControllerHelpers` in the `ViewComponent::TestCase` class. This
-is typically done by adding the following to `test/test_helper.rb`:
-
-```ruby
-class ViewComponent::TestCase
-  include Devise::Test::ControllerHelpers
-end
-```
-
 ## Setting `request.path_parameters`
 
 Since 2.31.0

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -164,6 +164,17 @@ class ExampleComponentTest < ViewComponent::TestCase
 end
 ```
 
+## Testing with Devise
+
+Testing with Devise reqiures you include `Devise::Test::ControllerHelpers` in the `ViewComponent::TestCase` class. This
+is typically done by adding the following to `test/test_helper.rb`:
+
+```ruby
+class ViewComponent::TestCase
+  include Devise::Test::ControllerHelpers
+end
+```
+
 ## Setting `request.path_parameters`
 
 Since 2.31.0

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -166,7 +166,7 @@ end
 
 ## Testing with Devise
 
-Testing with Devise reqiures you include `Devise::Test::ControllerHelpers` in the `ViewComponent::TestCase` class. This
+Testing with Devise requires you include `Devise::Test::ControllerHelpers` in the `ViewComponent::TestCase` class. This
 is typically done by adding the following to `test/test_helper.rb`:
 
 ```ruby

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -230,6 +230,11 @@ module ViewComponent
       super
     end
 
+    def teardown
+      super
+      @vc_render_preview_controller = nil
+    end
+
     # Note: We prefix private methods here to prevent collisions in consumer's tests.
     private
 

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -103,9 +103,9 @@ module ViewComponent
     #
     # assert_text("Hello, World!")
     # ```
-    def render_in_view_context(*, &block)
+    def render_in_view_context(*args, &block)
       @page = nil
-      @rendered_content = vc_test_controller.view_context.instance_exec(*, &block)
+      @rendered_content = vc_test_controller.view_context.instance_exec(*args, &block)
       Nokogiri::HTML.fragment(@rendered_content)
     end
     ruby2_keywords(:render_in_view_context) if respond_to?(:ruby2_keywords, true)

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -37,8 +37,6 @@ module ViewComponent
             @request = __vc_render_preview_controller.request
           end
         end
-
-        base.include(Devise::Test::ControllerHelpers)
       end
     end
 

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -117,9 +117,9 @@ module ViewComponent
     #
     # assert_text("Hello, World!")
     # ```
-    def render_in_view_context(*args, &block)
+    def render_in_view_context(*, &block)
       @page = nil
-      @rendered_content = vc_test_controller.view_context.instance_exec(*args, &block)
+      @rendered_content = vc_test_controller.view_context.instance_exec(*, &block)
       Nokogiri::HTML.fragment(@rendered_content)
     end
 
@@ -193,7 +193,7 @@ module ViewComponent
       vc_test_request.path_info = path
       vc_test_request.path_parameters = Rails.application.routes.recognize_path_with_request(vc_test_request, path, {})
       vc_test_request.set_header("action_dispatch.request.query_parameters",
-                                 Rack::Utils.parse_nested_query(query).with_indifferent_access)
+        Rack::Utils.parse_nested_query(query).with_indifferent_access)
       vc_test_request.set_header(Rack::QUERY_STRING, query)
       yield
     ensure
@@ -250,12 +250,12 @@ module ViewComponent
 
     def __vc_test_helpers_preview_class
       result = if respond_to?(:described_class)
-                 raise "`render_preview` expected a described_class, but it is nil." if described_class.nil?
+        raise "`render_preview` expected a described_class, but it is nil." if described_class.nil?
 
-                 "#{described_class}Preview"
-               else
-                 self.class.name.gsub("Test", "Preview")
-               end
+        "#{described_class}Preview"
+      else
+        self.class.name.gsub("Test", "Preview")
+      end
       result = result.constantize
     rescue NameError
       raise NameError, "`render_preview` expected to find #{result}, but it does not exist."

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -75,7 +75,7 @@ module ViewComponent
     # @param params [Hash] Parameters to be passed to the preview.
     # @return [Nokogiri::HTML]
     def render_preview(name, from: __vc_test_helpers_preview_class, params: {})
-      previews_controller = __vc_test_helpers_build_controller(Rails.application.config.view_component.preview_controller.constantize)
+      previews_controller = __vc_render_preview_controller
 
       # From what I can tell, it's not possible to overwrite all request parameters
       # at once, so we set them individually here.
@@ -103,9 +103,9 @@ module ViewComponent
     #
     # assert_text("Hello, World!")
     # ```
-    def render_in_view_context(*args, &block)
+    def render_in_view_context(*, &block)
       @page = nil
-      @rendered_content = vc_test_controller.view_context.instance_exec(*args, &block)
+      @rendered_content = vc_test_controller.view_context.instance_exec(*, &block)
       Nokogiri::HTML.fragment(@rendered_content)
     end
     ruby2_keywords(:render_in_view_context) if respond_to?(:ruby2_keywords, true)
@@ -225,6 +225,11 @@ module ViewComponent
         end
     end
 
+    def before_setup
+      @request = __vc_render_preview_controller.request
+      super
+    end
+
     # Note: We prefix private methods here to prevent collisions in consumer's tests.
     private
 
@@ -243,6 +248,10 @@ module ViewComponent
       result = result.constantize
     rescue NameError
       raise NameError, "`render_preview` expected to find #{result}, but it does not exist."
+    end
+
+    def __vc_render_preview_controller
+      @vc_render_preview_controller ||= __vc_test_helpers_build_controller(Rails.application.config.view_component.preview_controller.constantize)
     end
   end
 end

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -117,9 +117,9 @@ module ViewComponent
     #
     # assert_text("Hello, World!")
     # ```
-    def render_in_view_context(*, &block)
+    def render_in_view_context(*args, &block)
       @page = nil
-      @rendered_content = vc_test_controller.view_context.instance_exec(*, &block)
+      @rendered_content = vc_test_controller.view_context.instance_exec(*args, &block)
       Nokogiri::HTML.fragment(@rendered_content)
     end
 

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -21,23 +21,11 @@ module ViewComponent
       if ENV["DEBUG"]
         warn(
           "WARNING in `ViewComponent::TestHelpers`: Add `capybara` " \
-            "to Gemfile to use Capybara assertions."
+          "to Gemfile to use Capybara assertions."
         )
       end
 
       # :nocov:
-    end
-
-    def self.included(base)
-      if defined?(Devise::Test::ControllerHelpers)
-        # the `@request` instance variable is used by Devise::Test::ControllerHelpers and must
-        # be in a `setup` block before including `Devise::Test::ControllerHelpers`
-        base.instance_eval do
-          setup do
-            @request = __vc_render_preview_controller.request
-          end
-        end
-      end
     end
 
     # Returns the result of a render_inline call.
@@ -87,7 +75,7 @@ module ViewComponent
     # @param params [Hash] Parameters to be passed to the preview.
     # @return [Nokogiri::HTML]
     def render_preview(name, from: __vc_test_helpers_preview_class, params: {})
-      previews_controller = __vc_render_preview_controller
+      previews_controller = __vc_test_helpers_build_controller(Rails.application.config.view_component.preview_controller.constantize)
 
       # From what I can tell, it's not possible to overwrite all request parameters
       # at once, so we set them individually here.
@@ -120,7 +108,6 @@ module ViewComponent
       @rendered_content = vc_test_controller.view_context.instance_exec(*args, &block)
       Nokogiri::HTML.fragment(@rendered_content)
     end
-
     ruby2_keywords(:render_in_view_context) if respond_to?(:ruby2_keywords, true)
 
     # Set the Action Pack request variant for the given block:
@@ -239,7 +226,6 @@ module ViewComponent
     end
 
     # Note: We prefix private methods here to prevent collisions in consumer's tests.
-
     private
 
     def __vc_test_helpers_build_controller(klass)
@@ -257,10 +243,6 @@ module ViewComponent
       result = result.constantize
     rescue NameError
       raise NameError, "`render_preview` expected to find #{result}, but it does not exist."
-    end
-
-    def __vc_render_preview_controller
-      @vc_render_preview_controller ||= __vc_test_helpers_build_controller(Rails.application.config.view_component.preview_controller.constantize)
     end
   end
 end


### PR DESCRIPTION

### What are you trying to accomplish?

This updates ViewComponent::TestHelpers to better detect and support Devise. It resolves the issue described in this discussion https://github.com/ViewComponent/view_component/discussions/371.

### What approach did you choose and why?

Detect whether or not `Devise::Test::ControllerHelpers`, and if so, set up the `@request` instance variable and include `Devise::Test::ControllerHelpers`. The `@request` variable MUST be present before Devise's own setup hook is called, the only way to ensure this is to create setup initializing the controller and setting the `@request` instance variable before inclusion.

### Anything you want to highlight for special attention from reviewers?

I'd like not to have to add janky `included` callbacks, but this is the only way that seems to work with Devise.