### PR TITLE
Support `required: true` for renders_one slots

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add `required` option to `renders_one` to indicate that there is a default slot to be rendered, which automatically applies lambda options. This only works with lambda or Component slots (and not for passthrough slots). It can be used with polymorphic slots but exactly one specific option can be required, otherwise an error is shown.
+
+    *Jalyna Schröder*
+
 * Add Simundia to list of companies using ViewComponent.
 
     *Alexandre Ignjatovic*

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -349,3 +349,44 @@ end
 ```
 
 The setters are now `#with_icon_visual` and `#with_avatar_visual` instead of the default `#with_visual_icon` and `#with_visual_avatar`. The slot getter remains `#visual`.
+
+## Required `renders_one` slots
+
+Since 3.x.x
+{: .label }
+
+When using [Component](#component-slots) or [lambda slots](#lambda-slots), it's possible to define a required slot by passing `required: true`:
+
+```ruby
+class ListItemComponent < ViewComponent::Base
+  renders_one :line_item_icon, types: {
+    disc: LineItemIconDiscComponent,
+    square: { renders: LineItemIconSquareComponent, required: true }
+  }
+end
+
+class LayoutComponent < ViewComponent::Base
+  renders_one :head, HeadComponent, required: true
+  renders_one :logo, ->(**system_arguments) do
+    LogoComponent.new(main_color: :purple, **system_arguments)
+  end, required: true
+end
+```
+
+```erb
+<%= render LayoutComponent.new %>
+<%= render ListItemComponent.new %>
+```
+
+will do the same as as it will set defaults for required slots or types:
+
+```erb
+<%= render LayoutComponent.new do |component| %>
+  <% component.with_head %>
+  <% component.with_logo %>
+<% end %>
+
+<%= render ListItemComponent.new do |component| %>
+  <% component.with_line_item_icon_square %>
+<% end %>
+```

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -361,7 +361,7 @@ When using [Component](#component-slots) or [lambda slots](#lambda-slots), it's 
 class ListItemComponent < ViewComponent::Base
   renders_one :line_item_icon, types: {
     disc: LineItemIconDiscComponent,
-    square: { renders: LineItemIconSquareComponent, required: true }
+    square: {renders: LineItemIconSquareComponent, required: true}
   }
 end
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -210,6 +210,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/reeganviljoen?s=64" alt="reeganviljoen" width="32" />
 <img src="https://avatars.githubusercontent.com/thomascchen?s=64" alt="thomascchen" width="32" />
 <img src="https://avatars.githubusercontent.com/milk1000cc?s=64" alt="milk1000cc" width="32" />
+<img src="https://avatars.githubusercontent.com/jalyna?s=64" alt="jalyna" width="32" />
 
 ## Who uses ViewComponent?
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -100,6 +100,8 @@ module ViewComponent
       @__vc_content_evaluated = false
       @__vc_render_in_block = block
 
+      __vc_before_render
+
       before_render
 
       if render?
@@ -294,6 +296,10 @@ module ViewComponent
 
     def __vc_content_set_by_with_content_defined?
       defined?(@__vc_content_set_by_with_content)
+    end
+
+    def __vc_before_render
+      __vc_initialize_required_slots if respond_to?(:__vc_initialize_required_slots, true)
     end
 
     def content_evaluated?

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -126,6 +126,26 @@ module ViewComponent
     end
   end
 
+  class MultipleRequiredSlotError < StandardError
+    MESSAGE =
+      "COMPONENT with polymorphic SLOT_NAME requires multiple types.\n\n" \
+      "To fix this issue, please only `required: true` for 1 type."
+
+    def initialize(klass_name, slot_name)
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("SLOT_NAME", slot_name.to_s))
+    end
+  end
+
+  class RequiredSlotsOnPassthroughSlotError < StandardError
+    MESSAGE =
+      "COMPONENT with SLOT_NAME can not be set to `required: true`.\n\n" \
+      "To fix this issue, please use component or lambda slot instead of a passthrough slot."
+
+    def initialize(klass_name, slot_name)
+      super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("SLOT_NAME", slot_name.to_s))
+    end
+  end
+
   class ReservedSingularSlotNameError < StandardError
     MESSAGE =
       "COMPONENT declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.\n\n" \

--- a/test/sandbox/app/components/slots_required_component.html.erb
+++ b/test/sandbox/app/components/slots_required_component.html.erb
@@ -1,0 +1,9 @@
+<div id="child1"><%= child1 %></div>
+
+<div id="child2"><%= child2 %></div>
+
+<div id="child3"><%= child3 %></div>
+
+<% if child4? %>
+  <div id="child4"><%= child4 %></div>
+<% end %>

--- a/test/sandbox/app/components/slots_required_component.rb
+++ b/test/sandbox/app/components/slots_required_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class SlotsRequiredComponent < ViewComponent::Base
+  renders_one :child1, "SlotsRequiredChildComponent", required: true
+  renders_one :child2, ->(**system_arguments) do
+    SlotsRequiredChildComponent.new(class_names: "child2", **system_arguments)
+  end, required: true
+  renders_one :child3, types: {
+    icon: { renders: "SlotsRequiredChildComponent" },
+    avatar: {
+      renders: lambda { |**system_arguments| SlotsRequiredChildComponent.new(class_names: "child3", **system_arguments) },
+      required: true
+    }
+  }
+  renders_one :child4, "SlotsRequiredChildComponent", required: false
+
+  class SlotsRequiredChildComponent < ViewComponent::Base
+    def initialize(class_names: "")
+      @class_names = class_names
+    end
+
+    def call
+      content_tag(:div, "Child", class: "child #{@class_names}")
+    end
+  end
+end

--- a/test/sandbox/app/components/slots_required_component.rb
+++ b/test/sandbox/app/components/slots_required_component.rb
@@ -6,7 +6,7 @@ class SlotsRequiredComponent < ViewComponent::Base
     SlotsRequiredChildComponent.new(class_names: "child2", **system_arguments)
   end, required: true
   renders_one :child3, types: {
-    icon: { renders: "SlotsRequiredChildComponent" },
+    icon: {renders: "SlotsRequiredChildComponent"},
     avatar: {
       renders: lambda { |**system_arguments| SlotsRequiredChildComponent.new(class_names: "child3", **system_arguments) },
       required: true

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -719,4 +719,49 @@ class SlotableTest < ViewComponent::TestCase
 
     assert component.title.content?
   end
+
+  def test_required_slot_with_defaults
+    render_inline(SlotsRequiredComponent.new)
+
+    assert_selector("#child1 .child")
+    assert_no_selector("#child1 .child.child1")
+    assert_selector("#child2 .child.child2")
+    assert_selector("#child3 .child.child3")
+    assert_no_selector("#child4 .child")
+  end
+
+  def test_required_slot_with_overwrites
+    render_inline(SlotsRequiredComponent.new) do |component|
+      component.with_child1(class_names: "overwrite")
+      component.with_child2(class_names: "overwrite")
+      component.with_child3_icon(class_names: "overwrite")
+      component.with_child4(class_names: "overwrite")
+    end
+
+    assert_selector("#child1 .child.overwrite")
+    assert_selector("#child2 .child.overwrite")
+    assert_selector("#child3 .child.overwrite")
+    assert_selector("#child4 .child.overwrite")
+  end
+
+  def test_required_slot_raise_when_multiple_on_polymorphic_slots
+    exception =
+      assert_raises ViewComponent::MultipleRequiredSlotError do
+        SlotsRequiredComponent.renders_one :child5, types: {
+          icon: { renders: SlotsRequiredComponent::SlotsRequiredChildComponent, required: true },
+          avatar: { renders: SlotsRequiredComponent::SlotsRequiredChildComponent, required: true }
+        }
+      end
+
+    assert_includes exception.message, "requires multiple types"
+  end
+
+  def test_required_slot_raise_when_used_on_passthrough_slot
+    exception =
+      assert_raises ViewComponent::RequiredSlotsOnPassthroughSlotError do
+        SlotsRequiredComponent.renders_one :child5, required: true
+      end
+
+    assert_includes exception.message, "can not be set to"
+  end
 end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -748,8 +748,8 @@ class SlotableTest < ViewComponent::TestCase
     exception =
       assert_raises ViewComponent::MultipleRequiredSlotError do
         SlotsRequiredComponent.renders_one :child5, types: {
-          icon: { renders: SlotsRequiredComponent::SlotsRequiredChildComponent, required: true },
-          avatar: { renders: SlotsRequiredComponent::SlotsRequiredChildComponent, required: true }
+          icon: {renders: SlotsRequiredComponent::SlotsRequiredChildComponent, required: true},
+          avatar: {renders: SlotsRequiredComponent::SlotsRequiredChildComponent, required: true}
         }
       end
 


### PR DESCRIPTION
Hi everyone, first of all thanks for the amazing work! I really love working with view_component!

I'm very new to the project and hope I can contribute to this project. Looking forward to any feedback.

### What are you trying to accomplish?

Trying to solve the issue described in #614

### What approach did you choose and why?

Add `required` option to `renders_one` to indicate that there is a default slot to be rendered, which automatically applies lambda options. This only works with lambda or Component slots (and not for passthrough slots). It can be used with polymorphic slots but exactly one specific option can be required, otherwise an error is shown.

This is just my first attempt and probably a lot of fine tuning is needed as this project is used by many people.

### Anything you want to highlight for special attention from reviewers?

I added a new method `__vc_before_render` to the `Base` class in order to register a method called from the `Slotable` module. This way I was able to add defaults to the slots before `before_render` is called. I'm not sure if this is the best approach yet, but I'm happy to get any feedback.