### PR TITLE
fix: reduce UnboundMethod objects by memoizing initialize_parameters

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ nav_order: 5
 
     *Alexandre Ignjatovic*
 
+* Reduce UnboundMethod objects by memoizing initialize_parameters
+
+    Rainer Borene
+
 ## 3.6.0
 
 * Refer to `helpers` in `NameError` message in development and test environments.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -553,6 +553,7 @@ module ViewComponent
       # @param parameter [Symbol] The parameter name used when rendering elements of a collection.
       def with_collection_parameter(parameter)
         @provided_collection_parameter = parameter
+        @initialize_parameters = nil
       end
 
       # Strips trailing whitespace from templates before compiling them.
@@ -648,7 +649,7 @@ module ViewComponent
       end
 
       def initialize_parameters
-        instance_method(:initialize).parameters
+        @initialize_parameters ||= instance_method(:initialize).parameters
       end
 
       def provided_collection_parameter


### PR DESCRIPTION
I have just discovered a simple optimization on `ViewComponent::Base` that can reduce `UnboundMethod` objects allocation. I have removed other objects from this memory allocation report comparison to keep things simple and clear. These are the results in one of our main Rails endpoints.

Before:
```
allocated memory by class
-------------------------
4080  UnboundMethod
```

After:
```
allocated memory by class
-------------------------
1280  UnboundMethod
```

If you want to test this patch yourself, just do this on your `ApplicationComponent`:

```ruby
class ApplicationComponent < ViewComponent::Base
  private
    def self.initialize_parameters
      @initialize_parameters ||= super
    end
end
```