### PR TITLE
[Docs]Update document for changing view_component_path

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ nav_order: 5
 
     *Alexandre Ignjatovic*
 
+* Update generators.md to clarify the way of changing `config.view_component.view_component_path`.
+
+    *Shozo Hatta*
+
 ## 3.6.0
 
 * Refer to `helpers` in `NameError` message in development and test environments.

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -38,7 +38,13 @@ bin/rails generate component Sections::Example title content
 
 You can specify options when running the generator. To alter the default values project-wide, define the configuration settings described in [API docs](/api.html#configuration).
 
-Generated ViewComponents are added to `app/components` by default. Set `config.view_component.view_component_path` to use a different path.
+Generated ViewComponents are added to `app/components` by default. Set `config.view_component.view_component_path` to use a different path. Note that you need to add the same path to `config.eager_load_paths` as well.
+
+```ruby
+# config/application.rb
+    config.view_component.view_component_path = "app/views/components"
+    config.eager_load_paths << Rails.root.join("app/views/components")
+```
 
 ### Override template engine
 

--- a/docs/guide/generators.md
+++ b/docs/guide/generators.md
@@ -42,8 +42,8 @@ Generated ViewComponents are added to `app/components` by default. Set `config.v
 
 ```ruby
 # config/application.rb
-    config.view_component.view_component_path = "app/views/components"
-    config.eager_load_paths << Rails.root.join("app/views/components")
+config.view_component.view_component_path = "app/views/components"
+config.eager_load_paths << Rails.root.join("app/views/components")
 ```
 
 ### Override template engine


### PR DESCRIPTION
### What are you trying to accomplish?

I'm trying to update the document so that users can change the `view_component_path`.

### What approach did you choose and why?

I got stuck when I tried to introduce ViewComponent to Rails 7.1 app because changing just `config.view_component.view_component_path` did not work.

Finally I found that `config.eager_load_paths` should also be changed with the same path to get this change work.

I checked the fact with the newly generated Rails 7.1/7.0/6.1 apps.