### PR TITLE
Adding example for 3.x migration in the docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -237,6 +237,17 @@ This release makes the following breaking changes, many of which have long been 
 
     *Joel Hawksley*
 
+For example:
+
+```diff
+<%= render BlogComponent.new do |component| %>
+-  <% component.header do %>
++  <% component.with_header do %>
+    <%= link_to "My blog", root_path %>
+  <% end %>
+<% end %>
+```
+
 * BREAKING: Remove deprecated SlotsV1 in favor of current SlotsV2.
 
     *Joel Hawksley*


### PR DESCRIPTION
### What are you trying to accomplish?

I would like to help developers to upgrade their app with the current changelog with examples and how to do it without having to compare their code and the new docs.

This is just an example here that make our life much easier I guess. I saw that in other gems and packages and found it really helpful.

Here is the result: https://github.com/ViewComponent/view_component/blob/adb07c8d949b6f71d4c5d8e3fd50855b4544934e/docs/CHANGELOG.md#v300