### PR TITLE
Attempt to fix Ferrum timeout errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Vale
-        uses: errata-ai/vale-action@d074f98809cbae059386851971544a281fd9f593
+        uses: errata-ai/vale-action@c99f2dfd2aeaedb3d4bb16f385841830b9164d31
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   markdown:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,9 +18,13 @@ nav_order: 5
 
     *Alexandre Ignjatovic*
 
-* Improve docs about inline templates interpolation
+* Improve docs about inline templates interpolation.
 
     *Hans Lemuet*
+
+* Attempt to fix Ferrum timeout errors by creating driver with unique name.
+
+    *Cameron Dutro*
 
 ## 3.6.0
 

--- a/test/sandbox/test/view_component_system_test.rb
+++ b/test/sandbox/test/view_component_system_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class ViewComponentSystemTest < ViewComponent::SystemTestCase
-  driven_by :cuprite
+  driven_by :vc_cuprite
 
   def test_simple_js_interaction_in_browser_without_layout
     with_rendered_component_path(render_inline(SimpleJavascriptInteractionWithJsIncludedComponent.new)) do |path|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,14 +40,16 @@ require "rails/test_help"
 
 require "capybara/cuprite"
 
-Capybara.register_driver(:cuprite) do |app|
+# Rails registers its own driver named "cuprite" which will overwrite the one we
+# register here. Avoid the problem by registering the driver with a distinct name.
+Capybara.register_driver(:vc_cuprite) do |app|
   # Add the process_timeout option to prevent failures due to the browser
   # taking too long to start up.
-  Capybara::Cuprite::Driver.new(app, {process_timeout: 60, timeout: 30})
+  Capybara::Cuprite::Driver.new(app, { process_timeout: 60, timeout: 30 })
 end
 
 # Reduce extra logs produced by puma booting up
-Capybara.server = :puma, {Silent: true}
+Capybara.server = :puma, { Silent: true }
 # Increase the max wait time to appease test failures due to timeouts.
 Capybara.default_max_wait_time = 30
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,11 +45,11 @@ require "capybara/cuprite"
 Capybara.register_driver(:vc_cuprite) do |app|
   # Add the process_timeout option to prevent failures due to the browser
   # taking too long to start up.
-  Capybara::Cuprite::Driver.new(app, { process_timeout: 60, timeout: 30 })
+  Capybara::Cuprite::Driver.new(app, {process_timeout: 60, timeout: 30})
 end
 
 # Reduce extra logs produced by puma booting up
-Capybara.server = :puma, { Silent: true }
+Capybara.server = :puma, {Silent: true}
 # Increase the max wait time to appease test failures due to timeouts.
 Capybara.default_max_wait_time = 30
 


### PR DESCRIPTION
### What are you trying to accomplish?

We're seeing quite a few `Ferrum::ProcessTimeoutError: Browser did not produce websocket url within 10 seconds` errors in CI jobs. I did a little digging and discovered the Cuprite driver we're registering in test_helper.rb is getting overwritten by Rails, so it's not using any of the config options we're passing in.

### What approach did you choose and why?

primer/view_components solved this a while ago by registering a driver with a unique name, so that's what I did here.