### PR TITLE
Set request full path with request url

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Fix bug where `#with_request_url`, set the incorrect `request.fullpath`.
+
+    *Nachiket Pusalkar*
+
 ## 3.7.0
 
 * Support Rails 7.1 in CI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,7 @@ ViewComponents are Ruby objects, making it easy to follow (and enforce) code qua
 
 ViewComponent is built by over a hundred members of the community, including:
 
+<img src="https://avatars.githubusercontent.com/nachiket87?s=64" alt="nachiket87" width="32" />
 <img src="https://avatars.githubusercontent.com/andrewjtait?s=64" alt="andrewjtait" width="32" />
 <img src="https://avatars.githubusercontent.com/asgerb?s=64" alt="asgerb" width="32" />
 <img src="https://avatars.githubusercontent.com/bbugh?s=64" alt="bbugh" width="32" />

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -165,7 +165,7 @@ module ViewComponent
     #
     # @param path [String] The path to set for the current request.
     # @param host [String] The host to set for the current request.
-    def with_request_url(path, host: nil)
+    def with_request_url(full_path, host: nil)
       old_request_host = vc_test_request.host
       old_request_path_info = vc_test_request.path_info
       old_request_path_parameters = vc_test_request.path_parameters
@@ -173,7 +173,9 @@ module ViewComponent
       old_request_query_string = vc_test_request.query_string
       old_controller = defined?(@vc_test_controller) && @vc_test_controller
 
-      path, query = path.split("?", 2)
+      path, query = full_path.split("?", 2)
+      vc_test_request.instance_variable_set(:@fullpath, full_path)
+      vc_test_request.instance_variable_set(:@original_fullpath, full_path)
       vc_test_request.host = host if host
       vc_test_request.path_info = path
       vc_test_request.path_parameters = Rails.application.routes.recognize_path_with_request(vc_test_request, path, {})

--- a/test/sandbox/app/components/request_url_component.rb
+++ b/test/sandbox/app/components/request_url_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RequestUrlComponent < ViewComponent::Base
+  def call
+    content_tag(:span, request.path, class: "path") + content_tag(:span, request.fullpath, class: "fullpath")
+  end
+end

--- a/test/sandbox/test/components/request_url_component_test.rb
+++ b/test/sandbox/test/components/request_url_component_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RequestUrlComponentTest < ViewComponent::TestCase
+  test "should print path and fullpath" do
+    with_request_url "/products" do
+      render_inline(RequestUrlComponent.new)
+
+      assert_selector ".path", text: "/products"
+      assert_selector ".fullpath", text: "/products"
+    end
+
+    with_request_url "/slots?param=1&paramtwo=2" do
+      render_inline(RequestUrlComponent.new)
+
+      assert_selector ".path", text: "/slots"
+      assert_selector ".fullpath", text: "/slots?param=1&paramtwo=2"
+    end
+
+    with_request_url "/slots" do
+      render_inline(RequestUrlComponent.new)
+
+      assert_selector ".path", text: "/slots"
+      assert_selector ".fullpath", text: "/slots"
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixing https://github.com/ViewComponent/view_component/issues/1867

### What approach did you choose and why?

Issue may be a Rails issue here: https://github.com/rails/rails/blob/8e73e620b1072c831b81604449385dfbb60bdb63/actionpack/lib/action_dispatch/http/request.rb#L262

Where `@fullpath` is cached from previous request. To get around this, I have manually set the values of `@fullpath` and `@original_fullpath` in the test helper.

A similar issue was fixed here: https://github.com/ViewComponent/view_component/commit/4241a14be92298852d80b12308bf3da9390d4db5


