### PR TITLE
Search for the Rails module in the root namespace

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ nav_order: 5
 
 * Fix bug where the `Rails` module wasn't being searched from the root namespace.
 
+    *Zenéixe*
+
 * Fix bug where `#with_request_url`, set the incorrect `request.fullpath`.
 
     *Nachiket Pusalkar*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Fix bug where the `Rails` module wasn't being searched from the root namespace
+* Fix bug where the `Rails` module wasn't being searched from the root namespace.
 
 * Fix bug where `#with_request_url`, set the incorrect `request.fullpath`.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ nav_order: 5
 
 ## main
 
+* Fix bug where the `Rails` module wasn't being searched from the root namespace
+
 * Fix bug where `#with_request_url`, set the incorrect `request.fullpath`.
 
     *Nachiket Pusalkar*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -219,7 +219,7 @@ module ViewComponent
       @__vc_helpers ||= __vc_original_view_context || controller.view_context
     end
 
-    if Rails.env.development? || Rails.env.test?
+    if ::Rails.env.development? || ::Rails.env.test?
       def method_missing(method_name, *args) # rubocop:disable Style/MissingRespondToMissing
         super
       rescue => e # rubocop:disable Style/RescueStandardError


### PR DESCRIPTION
Fix for the issue described here: https://github.com/ViewComponent/view_component/issues/1891

```
NoMethodError: undefined method `env' for MyProject::Rails:Module (NoMethodError)

    if Rails.env.development? || Rails.env.test?
            ^^^^
/home/circleci/project/vendor/bundle/ruby/3.2.0/gems/view_component-3.7.0/lib/view_component/base.rb:222:in `<class:Base>'
```

The issue started with version `3.6.0`, the code above was introduced with this PR: https://github.com/ViewComponent/view_component/pull/1841

### What are you trying to accomplish?

Fix the issue

### What approach did you choose and why?

By specifying the root namespace for `Rails` we avoid the ambiguity. It seems to be the simplest possible fix at hand