### PR TITLE
Add slot unwrapping API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add API for "unwrapping" slots, i.e. return the component instance inside `ViewComponent::Slot`.
+
+    *Cameron Dutro*
+
 * Don't add ActionDispatch::Static middleware unless `public_file_server.enabled`.
 
     *Daniel Gonzalez*

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -219,6 +219,25 @@ end
 
 _Note: While a lambda is called when the `with_*` method is called, a returned component isn't rendered until first use._
 
+## Retrieving slot component instances
+
+Since 3.8.0
+{: .label }
+
+Component slots are wrapped in an instance of `ViewComponent::Slot` which transparently proxies method calls to the original instance via Ruby's `#method_missing`. To retrieve the underlying component instance(s), call the corresponding `*_instance` or `*_instances` method.
+
+```ruby
+blog = BlogComponent.new { ... }
+
+# renders_one slot
+blog.header  # returns an instance of ViewComponent::Slot
+blog.header_instance  # returns an instance of BlogComponent::HeaderComponent
+
+# renders_many slot
+blog.posts  # returns an array of ViewComponent::Slot instances
+blog.post_instances  # returns an array of BlogComponent::PostComponent instances
+```
+
 ## Rendering collections
 
 Since 2.23.0

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -227,15 +227,15 @@ Since 3.8.0
 Component slots are wrapped in an instance of `ViewComponent::Slot` which transparently proxies method calls to the original instance via Ruby's `#method_missing`. To retrieve the underlying component instance(s), call the corresponding `*_instance` or `*_instances` method.
 
 ```ruby
-blog = BlogComponent.new { ... }
+render(BlogComponent.new) do |blog|
+  # renders_one slot
+  blog.header  # returns an instance of ViewComponent::Slot
+  blog.header_instance  # returns an instance of BlogComponent::HeaderComponent
 
-# renders_one slot
-blog.header  # returns an instance of ViewComponent::Slot
-blog.header_instance  # returns an instance of BlogComponent::HeaderComponent
-
-# renders_many slot
-blog.posts  # returns an array of ViewComponent::Slot instances
-blog.post_instances  # returns an array of BlogComponent::PostComponent instances
+  # renders_many slot
+  blog.posts  # returns an array of ViewComponent::Slot instances
+  blog.post_instances  # returns an array of BlogComponent::PostComponent instances
+end
 ```
 
 ## Rendering collections

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -92,10 +92,6 @@ module ViewComponent
             get_slot(slot_name)
           end
 
-          define_method "#{slot_name}_instance" do
-            extract_component_instance(get_slot(slot_name))
-          end
-
           define_method "#{slot_name}?" do
             get_slot(slot_name).present?
           end
@@ -106,7 +102,14 @@ module ViewComponent
             self
           end
 
-          register_slot(slot_name, collection: false, callable: callable)
+          slot_def = register_slot(slot_name, collection: false, callable: callable)
+
+          # _instance methods should only be defined for component slots
+          if slot_def.include?(:renderable) || slot_def.include?(:renderable_class_name)
+            define_method "#{slot_name}_instance" do
+              extract_component_instance(get_slot(slot_name))
+            end
+          end
         end
       end
 
@@ -183,17 +186,20 @@ module ViewComponent
             get_slot(slot_name)
           end
 
-          define_method "#{singular_name}_instances" do
-            get_slot(slot_name).map do |slot|
-              extract_component_instance(slot)
-            end
-          end
-
           define_method "#{slot_name}?" do
             get_slot(slot_name).present?
           end
 
-          register_slot(slot_name, collection: true, callable: callable)
+          slot_def = register_slot(slot_name, collection: true, callable: callable)
+
+          # _instances methods should only be defined for component slots
+          if slot_def.include?(:renderable) || slot_def.include?(:renderable_class_name)
+            define_method "#{singular_name}_instances" do
+              get_slot(slot_name).map do |slot|
+                extract_component_instance(slot)
+              end
+            end
+          end
         end
       end
 

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -433,7 +433,9 @@ module ViewComponent
     ruby2_keywords(:set_polymorphic_slot) if respond_to?(:ruby2_keywords, true)
 
     def extract_component_instance(slot)
-      slot.instance_variable_get(:@__vc_component_instance)
+      slot.instance_eval do
+        @__vc_component_instance if defined?(@__vc_component_instance)
+      end
     end
   end
 end

--- a/test/sandbox/app/components/polymorphic_slot_component.rb
+++ b/test/sandbox/app/components/polymorphic_slot_component.rb
@@ -22,7 +22,7 @@ class PolymorphicSlotComponent < ViewComponent::Base
 
   renders_one :footer, types: {
     standard: "StandardFooter",
-    special: "SpecialFooter"
+    special: -> { "special footer" }
   }
 
   renders_many :items, types: {
@@ -56,8 +56,8 @@ class PolymorphicSlotComponent < ViewComponent::Base
   end
 
   class StandardFooter < ViewComponent::Base
-  end
-
-  class SpecialFooter < ViewComponent::Base
+    def call
+      "standard footer"
+    end
   end
 end

--- a/test/sandbox/app/components/polymorphic_slot_component.rb
+++ b/test/sandbox/app/components/polymorphic_slot_component.rb
@@ -20,6 +20,11 @@ class PolymorphicSlotComponent < ViewComponent::Base
     special: lambda { |&block| content_tag(:div, class: "special", &block) }
   }
 
+  renders_one :footer, types: {
+    standard: "StandardFooter",
+    special: "SpecialFooter"
+  }
+
   renders_many :items, types: {
     passthrough: "PassthroughItem",
     foo: "FooItem",
@@ -48,5 +53,11 @@ class PolymorphicSlotComponent < ViewComponent::Base
         "foo item"
       end
     end
+  end
+
+  class StandardFooter < ViewComponent::Base
+  end
+
+  class SpecialFooter < ViewComponent::Base
   end
 end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class SlotableTest < ViewComponent::TestCase
   def test_renders_slots
-    render_inline(SlotsComponent.new(classes: "mt-4")) do |component|
+    render_inline(c = SlotsComponent.new(classes: "mt-4")) do |component|
       component.with_title do
         "This is my title!"
       end
@@ -33,6 +33,8 @@ class SlotableTest < ViewComponent::TestCase
         "This is the footer"
       end
     end
+
+    binding.irb
 
     assert_selector(".card.mt-4")
 
@@ -516,13 +518,15 @@ class SlotableTest < ViewComponent::TestCase
   end
 
   def test_polymorphic_slot_with_setters
-    render_inline(PolymorphicSlotComponent.new) do |component|
+    render_inline(c = PolymorphicSlotComponent.new) do |component|
       component.with_header_standard { "standard" }
       component.with_foo_field(class_names: "custom-foo1")
       component.with_bar_field(class_names: "custom-bar1")
       component.with_item_foo(class_names: "custom-foo2")
       component.with_item_bar(class_names: "custom-bar2")
     end
+
+    binding.irb
 
     assert_selector("div .standard", text: "standard")
     assert_selector("div .foo.custom-foo1")


### PR DESCRIPTION
Fixes https://github.com/ViewComponent/view_component/issues/1737

### What are you trying to accomplish?

This PR introduces an API for retrieving the underlying component instance inside `ViewComponent::Slot`s. At the moment, getting a reference to the underlying component necessitates using `instance_variable_get`, eg:

```ruby
class MyComponent < ViewComponent::Base
  renders_one :header, HeaderComponent
  renders_many :items, ItemComponent
end

render(MyComponent.new) do |component|
  # returns an instance of ViewComponent::Slot
  component.header

  # returns an instance of HeaderComponent
  component.header.instance_variable_get(:@__vc_component_instance)
end
```

This is awkward. The `@__vc_component_instance` is private and not designed to be accessed outside the `Slot` class.

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

I propose the following API:

```ruby
render(MyComponent.new) do |component|
  # returns an instance of HeaderComponent
  component.header_instance

  # returns an array of ItemComponent instances
  component.item_instances
end
```

This works for any component slot. For lambda slots, the `*_instance` methods are not defined.

### Anything you want to highlight for special attention from reviewers?

Is the `_instance` suffix the best naming? Maybe `_component` would be better? Open to suggestions 😄 