### PR TITLE
Fix invalid rubocop errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
 require:
   - standard
   - "rubocop-md"
+inherit_gem:
+  standard: config/base.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,9 +329,6 @@ DEPENDENCIES
   jbuilder (~> 2)
   m (~> 1)
   minitest (~> 5.18)
-  net-imap
-  net-pop
-  net-smtp
   pry (~> 0.13)
   puma (~> 6)
   rails (~> 7.0.0)
@@ -349,4 +346,4 @@ DEPENDENCIES
   yard-activesupport-concern (~> 0.0.1)
 
 BUNDLED WITH
-   2.2.33
+   2.3.7


### PR DESCRIPTION
When running ViewComponent in VSCode I started getting a ton of errors
from Rubocop despite the project using standardrb and requiring it in
the rubocop config.

This fixes the issue by using the `inherit_gem` option in the rubocop
config.
