### PR TITLE
Error related to naming a slot with an uncountable name.

### DIFF
--- a/test/sandbox/app/components/naming_slot_test_component.html.slim
+++ b/test/sandbox/app/components/naming_slot_test_component.html.slim
@@ -1,0 +1,3 @@
+div
+  - series.each do |serie|
+    = serie.name

--- a/test/sandbox/app/components/naming_slot_test_component.rb
+++ b/test/sandbox/app/components/naming_slot_test_component.rb
@@ -2,6 +2,8 @@ class NamingSlotTestComponent < ViewComponent::Base
   renders_many :series, "Serie"
 
   class Serie < ViewComponent::Base
+    attr_reader :name
+
     def initialize(name:)
       @name = name
     end

--- a/test/sandbox/app/components/naming_slot_test_component.rb
+++ b/test/sandbox/app/components/naming_slot_test_component.rb
@@ -1,0 +1,9 @@
+class NamingSlotTestComponent < ViewComponent::Base
+  renders_many :series, "Serie"
+
+  class Serie < ViewComponent::Base
+    def initialize(name:)
+      @name = name
+    end
+  end
+end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -719,4 +719,11 @@ class SlotableTest < ViewComponent::TestCase
 
     assert component.title.content?
   end
+
+  def test_slot_with_unplurialized_name
+    component = NamingSlotTestComponent.new
+    component.with_serie(name: "John Doe")
+
+    assert_equal "John Doe", component.series.first.name
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

I am submitting this PR to report an error related to naming a slot with an uncountable name in my component. I attempted to create a slot named "series," but it resulted in an error. This error is due to the fact that the name "series" is uncountable and does not follow Rails convention.

With reference to the uncountable words defined in [Rails' inflections list](https://github.com/rails/rails/blob/632bcb391840bacc77556eee6707178ddf293b99/activesupport/lib/active_support/inflections.rb#L70), I expected to use the name "series" for my slot. However, Rails expects a pluralized slot name, leading to this error.

Here is the specific error message I encountered:

````
Error:
SlotableTest#test_slot_with_unplurialized_name:
NoMethodError: undefined method `with_serie' for #<NamingSlotTestComponent:0x000000010fd97c30 @_routes=nil>
Did you mean?  with_series
````

### What approach did you choose and why?

I suggest creating a more explicit error message or exploring alternative ways to resolve this issue.
