### PR TITLE
Use native String#end_with?, not the ActiveSupport wrapper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Replace usage of `String#ends_with?` with `String#end_with?` to reduce the dependency on ActiveSupport core extensions.
+
+    *halo*
+
 * Don't add ActionDispatch::Static middleware unless `public_file_server.enabled`.
 
     *Daniel Gonzalez*

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -322,7 +322,7 @@ module ViewComponent
       end
 
       def raise_if_slot_ends_with_question_mark(slot_name)
-        raise SlotPredicateNameError.new(name, slot_name) if slot_name.to_s.ends_with?("?")
+        raise SlotPredicateNameError.new(name, slot_name) if slot_name.to_s.end_with?("?")
       end
 
       def raise_if_slot_conflicts_with_call(slot_name)


### PR DESCRIPTION
### What are you trying to accomplish?

I noticed a call to [`String#ends_with?`](https://github.com/rails/rails/blob/939fd3bc41bbb90194e4b93a001c803bdceb592c/activesupport/lib/active_support/core_ext/string/starts_ends_with.rb
), which is an ActiveSupport core `String` extension [introduced](https://github.com/rails/rails/commit/7a4a12aeaa2627008a478059aeec5ea38648c19e) in 2005. 

To reduce dependencies, I suggest using the ruby native `String#end_with?` (notice the missing "s") method instead. It's been in Ruby at least [since 2.7.8](https://ruby-doc.org/2.7.8/String.html#method-i-end_with-3F).

### What approach did you choose and why?

I'm trying to create a gem that has some custom view components. Yet, I found no definite way to define the dependencies for a gem like mine. Some [don't require `rails` at all](https://github.com/betagouv/dsfr-view-components/blob/7b8156605f434a907a8a1449ae0ca3d8e5637d0a/dsfr-view-components.gemspec#L32-L34), some require [all of `rails`](https://github.com/baoagency/polaris_view_components/blob/3c5b988dfeff8f0ba7867e5fb76e43d77785ce79/polaris_view_components.gemspec#L26) (even `activejob`), some depend [only on `actionview` and `actionsupport`](https://github.com/pantographe/view_component-form/blob/280c902e626f31f69ab3164c06d1ddee2504c8c8/view_component-form.gemspec#L29C11-L30), the `view_component` gem itself [only requires activesupport](https://github.com/ViewComponent/view_component/blob/00cdde88e7b9d45e557edd70fd4839b32276a744/view_component.gemspec#L32C32-L32C45) and `actionview` implicitly (I'm not sure why).

Having that in mind, I tried to not depend on the entirety of Rails, and a minimal test setup code like this was sufficient to create a test suite for my components:

```ruby
# test_helper.rb

# Create a minimal Rails app
require 'view_component/engine'
require 'action_controller'

class MyApplication < Rails::Application; end
Rails.application.routes.draw { resource :home }
class ApplicationController < ActionController::Base; end

# Make the view_component gem boot
require 'view_component/base'
require 'action_controller/test_case'
ViewComponent::Base.config.view_component_path = File.expand_path('../app/components', __dir__)
```

However, my gem tests didn't pass because of this one call to `ends_with?` – yet, when I add the following line, all my tests naturally pass:

```ruby
require 'active_support/core_ext/string/starts_ends_with'
```

### Final thoughts

I know this is just a minimal change and maybe I'm foolish for not requiring all of Rails in my test suite. I'm also fully aware that in the future, I might not be able to use my approach any more, if more dependencies on Rails-internals are implicitly used inside of the view_component gem. 

But at the very least, I thought, I'd be able to press the question of a canonical way to create gems that contain view components. If you tell me to load an entire rails dummy app in my test suite instead, then you can disregard this pull request :)

Thank you for your time. It's *very* exciting to see your gem develop from generation to [generation](https://github.com/ViewComponent/view_component/issues/1855).