### PR TITLE
Remove `with_variant` in API docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Remove `with_variant` in API docs.
+
+    *Tyson Gach*
+
 * Remove unsupported versions of Rails & Ruby from CI matrix.
 
     *Reegan Viljoen*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Remove `with_variant` in API docs.
+* Remove `with_variant` test helper.
 
     *Tyson Gach*
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -374,16 +374,6 @@ with_request_url("/users/42", host: "app.example.com") do
 end
 ```
 
-### `#with_variant(variant)`
-
-Set the Action Pack request variant for the given block:
-
-```ruby
-with_variant(:phone) do
-  render_inline(MyComponent.new)
-end
-```
-
 ## Errors
 
 ### `AlreadyDefinedPolymorphicSlotSetterError`

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -117,20 +117,6 @@ def test_renders_slots_with_content
 end
 ```
 
-## Action Pack Variants
-
-Use the `with_variant` helper to test specific variants:
-
-```ruby
-def test_render_component_for_tablet
-  with_variant :tablet do
-    render_inline(ExampleComponent.new(title: "my title")) { "Hello, tablets!" }
-
-    assert_selector("span[title='my title']", text: "Hello, tablets!")
-  end
-end
-```
-
 ## Configuring the controller used in tests
 
 Since 2.27.0

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -114,24 +114,6 @@ module ViewComponent
     end
     ruby2_keywords(:render_in_view_context) if respond_to?(:ruby2_keywords, true)
 
-    # Set the Action Pack request variant for the given block:
-    #
-    # ```ruby
-    # with_variant(:phone) do
-    #   render_inline(MyComponent.new)
-    # end
-    # ```
-    #
-    # @param variant [Symbol] The variant to be set for the provided block.
-    def with_variant(variant)
-      old_variants = vc_test_controller.view_context.lookup_context.variants
-
-      vc_test_controller.view_context.lookup_context.variants = variant
-      yield
-    ensure
-      vc_test_controller.view_context.lookup_context.variants = old_variants
-    end
-
     # Set the controller to be used while executing the given block,
     # allowing access to controller-specific methods:
     #


### PR DESCRIPTION
### What are you trying to accomplish?

The `with_variant` method was removed in v3.0.0 - this removes its mention from the docs.

Relevant changelog entry: https://github.com/ViewComponent/view_component/blob/main/docs/CHANGELOG.md#v300