### PR TITLE
Fix show_exceptions setting for Rails main

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Use correct value for the `config.action_dispatch.show_exceptions` config option for edge Rails.
+
+    *Cameron Dutro*
+
 * Remove unsupported versions of Rails & Ruby from CI matrix.
 
     *Reegan Viljoen*

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -17,7 +17,7 @@ Sandbox::Application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = (Rails::VERSION::STRING < "7.1") ? false : :none
 
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
### What are you trying to accomplish?

Rails main [recently changed](https://github.com/rails/rails/commit/ec2c2666c255029593dda2f78e89b457cf8509fc) the allowable values for `config.action_dispatch.show_exceptions`. We set it to `false` which is no longer supported. The analogous setting is now `:none`.