### PR TITLE
Don't break "rails stats" if app/components is missing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Don’t break `rails stats` if ViewComponent path is missing
+* Don’t break `rails stats` if ViewComponent path is missing.
 
     *Claudio Baccigalupo*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Don’t break `rails stats` if ViewComponent path is missing
+
+    *Claudio Baccigalupo*
+
 * Add deprecation warnings for EOL ruby and Rails versions and patches associated with them.
 
     *Reegan Viljoen*

--- a/lib/view_component/rails/tasks/view_component.rake
+++ b/lib/view_component/rails/tasks/view_component.rake
@@ -7,7 +7,8 @@ namespace :view_component do
     # :nocov:
     require "rails/code_statistics"
 
-    ::STATS_DIRECTORIES << ["ViewComponents", ViewComponent::Base.view_component_path]
+    dir = ViewComponent::Base.view_component_path
+    ::STATS_DIRECTORIES << ["ViewComponents", dir] if File.directory?(Rails.root + dir)
     # :nocov:
   end
 end


### PR DESCRIPTION
After #1050, running `rails stats` on a Rails app with `view_component` in its Gemfile will also include the statistics (lines of code, …) for the `ViewComponent` code which, by default, is included in `app/components`.

A Rails app, however, could have the `view_component` library in the Gemfile and not have the matching folder (`app/components` by default). In this scenario, `rails stats` fails:

```
rails stats --trace

** Invoke stats (first_time)
** Invoke view_component:statsetup (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute view_component:statsetup
** Execute stats
rails aborted!
Errno::ENOENT: No such file or directory @ dir_initialize - app/components (Errno::ENOENT)
<internal:dir>:98:in `open'
/gems/3.2.0/gems/railties-7.0.7.2/lib/rails/code_statistics.rb:46:in `foreach'
/gems/3.2.0/gems/railties-7.0.7.2/lib/rails/code_statistics.rb:46:in `calculate_directory_statistics'
/gems/3.2.0/gems/railties-7.0.7.2/lib/rails/code_statistics.rb:40:in `block in calculate_statistics'
/gems/3.2.0/gems/railties-7.0.7.2/lib/rails/code_statistics.rb:40:in `map'
/gems/3.2.0/gems/railties-7.0.7.2/lib/rails/code_statistics.rb:40:in `calculate_statistics'
/gems/3.2.0/gems/railties-7.0.7.2/lib/rails/code_statistics.rb:21:in `initialize'
/gems/3.2.0/gems/railties-7.0.7.2/lib/rails/tasks/statistics.rake:36:in `new'
/gems/3.2.0/gems/railties-7.0.7.2/lib/rails/tasks/statistics.rake:36:in `block in <main>'
...
```

---

This PR solves the issue by following the example of the original statistics.rake file (https://github.com/rails/rails/blob/5621c93bfc8e8aefab90223dcf0edf4b10e5dcf6/railties/lib/rails/tasks/statistics.rake#L36) which checks whether a folder exists before trying to output stats for it.
