### PR TITLE
Allow translations to be inherited and overridden in subclasses

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Allow translations to be inherited and overridden in subclasses.
+
+    *Elia Schito*
+
 * Resolve console warnings when running test suite.
 
     *Joel Hawksley*

--- a/docs/guide/translations.md
+++ b/docs/guide/translations.md
@@ -61,7 +61,7 @@ en:
   greeting: "Cheers!"
 ```
 
-The translation is available in subclasses of `ParentComponent`, allowing translations to be used as is or overridden by the child component:
+The translation is available in subclasses of `ParentComponent`, allowing translations to be used as-is or overridden by the subclass:
 
 ```yml
 # app/components/child_component.yml

--- a/docs/guide/translations.md
+++ b/docs/guide/translations.md
@@ -49,3 +49,32 @@ Access global translations via `helpers` or `I18n`:
 <%= helpers.t("hello") %>
 <%= I18n.t("hello") %>
 ```
+
+## Inheritance
+
+Translations are inherited from the component's parent class. Given a parent component with a translation file:
+
+```yml
+# app/components/parent_component.yml
+en:
+  hello: "Hello world!"
+  greeting: "Cheers!"
+```
+
+The translation is available in subclasses of `ParentComponent`, allowing translations to be used as is or overridden by the child component:
+
+```yml
+# app/components/child_component.yml
+en:
+  greeting: "Howdy!"
+```
+
+```rb
+# app/components/child_component.rb
+class ChildComponent < ParentComponent
+  def call
+    t(".hello") # => "Hello world!" (inherited)
+    t(".greeting") # => "Howdy!"    (overridden)
+  end
+end
+```

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -10,6 +10,7 @@ module ViewComponent
     extend ActiveSupport::Concern
 
     HTML_SAFE_TRANSLATION_KEY = /(?:_|\b)html\z/
+    TRANSLATION_EXTENSIONS = %w[yml yaml].freeze
 
     included do
       class_attribute :i18n_backend, instance_writer: false, instance_predicate: false
@@ -23,9 +24,16 @@ module ViewComponent
       def build_i18n_backend
         return if compiled?
 
-        self.i18n_backend = if (translation_files = sidecar_files(%w[yml yaml])).any?
-          # Returning nil cleans up if translations file has been removed since the last compilation
+        # We need to load the translations files from the ancestors so a component
+        # can inherit translations from its parent and is able to overwrite them.
+        translation_files = ancestors.reverse_each.with_object([]) do |ancestor, files|
+          if ancestor.is_a?(Class) && ancestor < ViewComponent::Base
+            files.concat(ancestor.sidecar_files(TRANSLATION_EXTENSIONS))
+          end
+        end
 
+        # In development it will become nil if the translations file is removed
+        self.i18n_backend = if translation_files.any?
           I18nBackend.new(
             i18n_scope: i18n_scope,
             load_paths: translation_files

--- a/test/sandbox/app/components/translatable_subclass_component.rb
+++ b/test/sandbox/app/components/translatable_subclass_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class TranslatableSubclassComponent < TranslatableComponent
+end

--- a/test/sandbox/app/components/translatable_subclass_component.yml
+++ b/test/sandbox/app/components/translatable_subclass_component.yml
@@ -1,0 +1,2 @@
+en:
+  hello: "Hello from subclass sidecar translations!"

--- a/test/sandbox/test/translatable_test.rb
+++ b/test/sandbox/test/translatable_test.rb
@@ -142,6 +142,20 @@ class TranslatableTest < ViewComponent::TestCase
     assert_equal({sidecar: "This is coming from the sidecar"}, TranslatableComponent.translate(".from"))
   end
 
+  def test_inheriting_and_overriding_translations
+    render_inline(TranslatableSubclassComponent.new)
+
+    assert_selector("p.sidecar.shared-key", text: "Hello from subclass sidecar translations!")
+    assert_selector("p.sidecar.nested", text: "This is coming from the sidecar")
+    assert_selector("p.sidecar.missing", text: "This is coming from Rails")
+
+    assert_selector("p.helpers.shared-key", text: "Hello from Rails translations!")
+    assert_selector("p.helpers.nested", text: "This is coming from Rails")
+
+    assert_selector("p.global.shared-key", text: "Hello from Rails translations!")
+    assert_selector("p.global.nested", text: "This is coming from Rails")
+  end
+
   private
 
   def translate(key, **options)


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide a description of the changes. Link to any related issues or projects. -->

Inheriting from a component that uses translations in the template now requires all translations to be replicated in the subclass or it will break. 

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

I resorted to including all parent translation files in the subclass under the subclass `i18n_scope`, thus allowing subclasses to add or replace translations as they see fit.

### Anything you want to highlight for special attention from reviewers?