### PR TITLE
Move all dependencies into gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@
 
 source "https://rubygems.org"
 gemspec
+
+rails_version = (ENV["RAILS_VERSION"] || "~> 7.0.0").to_s
+gem "rails", (rails_version == "main") ? {git: "https://github.com/rails/rails", ref: "main"} : rails_version

--- a/Gemfile
+++ b/Gemfile
@@ -1,26 +1,3 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
 gemspec
-
-rails_version = (ENV["RAILS_VERSION"] || "~> 7.0.0").to_s
-
-gem "capybara", "~> 3"
-gem "rails", (rails_version == "main") ? {git: "https://github.com/rails/rails", ref: "main"} : rails_version
-
-gem "rspec-rails", "~> 5"
-
-group :test do
-  gem "cuprite", "~> 0.15"
-  gem "puma", "~> 6"
-
-  gem "selenium-webdriver", "4.9.0" # 4.9.1 requires Ruby 3+
-end
-
-if RUBY_VERSION >= "3.1"
-  gem "net-imap", require: false
-  gem "net-pop", require: false
-  gem "net-smtp", require: false
-end
-
-gem "debug"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+source "https://rubygems.org"
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ PATH
       method_source (~> 1.0)
 
 GEM
-  remote: https://rubygems.org/
   specs:
     actioncable (7.0.8)
       actionpack (= 7.0.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       method_source (~> 1.0)
 
 GEM
+  remote: https://rubygems.org/
   specs:
     actioncable (7.0.8)
       actionpack (= 7.0.8)

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -63,10 +63,4 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency "net-pop"
     spec.add_development_dependency "net-smtp"
   end
-
-  rails_version = (ENV["RAILS_VERSION"] || "~> 7.0.0").to_s
-  spec.add_development_dependency(
-    "rails",
-    (rails_version == "main") ? {git: "https://github.com/rails/rails", ref: "main"} : rails_version
-  )
 end

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -36,14 +36,20 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "benchmark-ips", "~> 2.12.0"
   spec.add_development_dependency "better_html"
   spec.add_development_dependency "bundler", "~> 2"
+  spec.add_development_dependency "capybara", "~> 3"
+  spec.add_development_dependency "cuprite", "~> 0.15"
+  spec.add_development_dependency "debug"
   spec.add_development_dependency "erb_lint"
   spec.add_development_dependency "haml", "~> 6"
   spec.add_development_dependency "jbuilder", "~> 2"
   spec.add_development_dependency "m", "~> 1"
   spec.add_development_dependency "minitest", "~> 5.18"
   spec.add_development_dependency "pry", "~> 0.13"
+  spec.add_development_dependency "puma", "~> 6"
   spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec-rails", "~> 5"
   spec.add_development_dependency "rubocop-md", "~> 1"
+  spec.add_development_dependency "selenium-webdriver", "4.9.0"
   spec.add_development_dependency "standard", "~> 1"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
   spec.add_development_dependency "simplecov-console", "~> 0.9.1"
@@ -51,4 +57,16 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sprockets-rails", "~> 3.4.2"
   spec.add_development_dependency "yard", "~> 0.9.25"
   spec.add_development_dependency "yard-activesupport-concern", "~> 0.0.1"
+
+  if RUBY_VERSION >= "3.1"
+    spec.add_development_dependency "net-imap"
+    spec.add_development_dependency "net-pop"
+    spec.add_development_dependency "net-smtp"
+  end
+
+  rails_version = (ENV["RAILS_VERSION"] || "~> 7.0.0").to_s
+  spec.add_development_dependency(
+    "rails",
+    (rails_version == "main") ? {git: "https://github.com/rails/rails", ref: "main"} : rails_version
+  )
 end


### PR DESCRIPTION
### What are you trying to accomplish?

I'm trying to simplify how we manage dependencies in the project.

### What approach did you choose and why?

I moved the remaining contents of `Gemfile` to the gemspec.

### Anything you want to highlight for special attention from reviewers?

This does mean a few extra gems intended for tests will be loaded in development, but I've occasionally wanted to use them in the console anyways, so I think this change is fine 🤷🏻 