### PR TITLE
Defer to built-in action caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
       with:
         ruby-version: 3.2
         bundler-cache: true
+        working-directory: 'view_component'
     - uses: actions/setup-node@v4
       with:
         node-version: 16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2
+        ruby-version: 3.3
         bundler-cache: true
         working-directory: 'view_component'
     - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,9 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.3
-    - uses: actions/cache@v4
-      with:
-        path: vendor/bundle
-        key: gems-build-rails-main-ruby-3.3-${{ hashFiles('**/Gemfile.lock') }}
+        bundler-cache: true
     - name: Run benchmarks
       run: |
-        bundle config path vendor/bundle
-        bundle update
         bundle exec rake partial_benchmark
         bundle exec rake translatable_benchmark
   test:
@@ -104,22 +99,16 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2
+        bundler-cache: true
     - uses: actions/setup-node@v4
       with:
         node-version: 16
-    - uses: actions/cache@v4
-      with:
-        path: |
-          node_modules
-          vendor/bundle
-        key: gems-build-pvc-${{ hashFiles('**/Gemfile.lock') }}-${{ hashFiles('**/package-json.lock') }}
+        cache: 'npm'
     - name: Build and test with Rake
       run: |
         cd primer_view_components
         npm ci
         cd demo && npm ci && cd ..
-        bundle config path vendor/bundle
-        bundle install
         bundle exec rake
       env:
         VIEW_COMPONENT_PATH: ../view_component
@@ -134,16 +123,11 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.3
+        bundler-cache: true
     - name: Download coverage results
       uses: actions/download-artifact@v3
-    - uses: actions/cache@v4
-      with:
-        path: vendor/bundle
-        key: gems-build-rails-main-ruby-3.3-${{ hashFiles('**/Gemfile.lock') }}
     - name: Collate simplecov
       run: |
-        bundle config path vendor/bundle
-        bundle update
         bundle exec rake coverage:report
       env:
         RAILS_VERSION: '~> 7.1.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         cd primer_view_components
         npm ci
         cd demo && npm ci && cd ..
-        bundle exec rake
+        bundle && bundle exec rake
       env:
         VIEW_COMPONENT_PATH: ../view_component
         RAILS_VERSION: '7.1.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,5 +131,3 @@ jobs:
     - name: Collate simplecov
       run: |
         bundle exec rake coverage:report
-      env:
-        RAILS_VERSION: '~> 7.1.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
       with:
         node-version: 16
         cache: 'npm'
+        cache-dependency-path: 'primer_view_components/package-lock.json'
     - name: Build and test with Rake
       run: |
         cd primer_view_components

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Defer to built-in caching for language environment setup, rather than manually using `actions/cache` in CI.
+
+    *Simon Fish*
+
 * Add test coverage for use of `turbo_stream` helpers in components when `capture_compatibility_patch_enabled` is `true`.
 
   *Simon Fish*


### PR DESCRIPTION
Closes #1937

Instead of using `actions/cache` directly, defer to the `setup-ruby` and `setup-node` actions' native support, which uses this under the hood.