### PR TITLE
Exclude I18n reserved keys from html escaping

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Exclude html escaping of I18n reserved keys with `I18n::RESERVED_KEYS` rather than `I18n.reserved_keys_pattern`.
+
+    *Nick Coyne*
+
 * Update CI configuration to use `Appraisal`.
 
     *Hans Lemuet, Simon Fish*

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,7 @@ ViewComponents are Ruby objects, making it easy to follow (and enforce) code qua
 
 ViewComponent is built by over a hundred members of the community, including:
 
+<img src="https://avatars.githubusercontent.com/nickcoyne?s=64" alt="nickcoyne" width="32" />
 <img src="https://avatars.githubusercontent.com/nachiket87?s=64" alt="nachiket87" width="32" />
 <img src="https://avatars.githubusercontent.com/andrewjtait?s=64" alt="andrewjtait" width="32" />
 <img src="https://avatars.githubusercontent.com/asgerb?s=64" alt="asgerb" width="32" />

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -138,8 +138,7 @@ module ViewComponent
     end
 
     def html_escape_translation_options!(options)
-      options.each do |name, value|
-        next if ::I18n.reserved_keys_pattern.match?(name)
+      options.except(*::I18n::RESERVED_KEYS).each do |name, value|
         next if name == :count && value.is_a?(Numeric)
 
         options[name] = ERB::Util.html_escape(value.to_s)

--- a/test/sandbox/config/initializers/i18n.rb
+++ b/test/sandbox/config/initializers/i18n.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 I18n.available_locales = [:en, :fr].freeze

--- a/test/sandbox/config/initializers/i18n.rb
+++ b/test/sandbox/config/initializers/i18n.rb
@@ -1,0 +1,1 @@
+I18n.available_locales = [:en, :fr].freeze

--- a/test/sandbox/test/translatable_test.rb
+++ b/test/sandbox/test/translatable_test.rb
@@ -75,8 +75,8 @@ class TranslatableTest < ViewComponent::TestCase
     )
   end
 
-  def test_translate_with_html_suffix_uses_fallback_for_missing_translations
-    translation = translate(".hello_html", locale: :fr, raise: false, fallback: true)
+  def test_translate_with_html_suffix_applies_reserved_options
+    translation = translate(".hello_html", locale: :fr, raise: false)
     assert_equal(
       "Translation missing: fr.translatable_component.hello_html",
       translation

--- a/test/sandbox/test/translatable_test.rb
+++ b/test/sandbox/test/translatable_test.rb
@@ -75,6 +75,14 @@ class TranslatableTest < ViewComponent::TestCase
     )
   end
 
+  def test_translate_with_html_suffix_uses_fallback_for_missing_translations
+    translation = translate(".hello_html", locale: :fr, raise: false, fallback: true)
+    assert_equal(
+      "Translation missing: fr.translatable_component.hello_html",
+      translation
+    )
+  end
+
   def test_translate_uses_the_helper_when_no_sidecar_file_is_provided
     # The cache needs to be kept clean for TranslatableComponent, otherwise it will rely on the
     # already created i18n_backend.


### PR DESCRIPTION
### What are you trying to accomplish?

With html translation keys, reserved keys are currently being made html safe, thus converting values like `true` to `"true"`. This is disabling some of these keys.

### What approach did you choose and why?

The existing code tries to match reserved keys using the `::I18n.reserved_keys_pattern`, however they will never match, as the pattern is expecting interpolated strings with the translation value. It will match `%{raise}`, but not `raise`, which is what we want. So these reserved key values are all subsequently html escaped.

This PR uses the `I18n::RESERVED_KEYS` constant directly, and excludes those keys from options that will be considered for escaping.

### Anything you want to highlight for special attention from reviewers?

The key that I chose for testing was `:raise`. This meant that I needed a missing translation, so I've added another locale to the `I18n.available_locales`. This also matched the original scenario in my app that caused me to discover the issue.