### PR TITLE
Fix html escaping on non strings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,11 @@ nav_order: 5
 
 ## main
 
+* Fix html escaping in `#call` for non strings.
+
+    *Reegan Viljoen*
+
+
 * Update CI configuration to use `Appraisal`.
 
     *Hans Lemuet, Simon Fish*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,6 @@ nav_order: 5
 
     *Reegan Viljoen*
 
-
 * Update CI configuration to use `Appraisal`.
 
     *Hans Lemuet, Simon Fish*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -308,7 +308,7 @@ module ViewComponent
     end
 
     def maybe_escape_html(text)
-      text = text.to_s unless text.is_a?(String)# ensure we're working with a string because some things like active storage dont return strings
+      text = text.to_s unless text.is_a?(String) # ensure we're working with a string because some things like active storage dont return strings
 
       return text if request && !request.format.html?
       return text if text.nil? || text.empty?

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -308,6 +308,8 @@ module ViewComponent
     end
 
     def maybe_escape_html(text)
+      text = text.to_s # ensure we're working with a string because some things like active storage dont return strings
+
       return text if request && !request.format.html?
       return text if text.nil? || text.empty?
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -308,7 +308,7 @@ module ViewComponent
     end
 
     def maybe_escape_html(text)
-      text = text.to_s # ensure we're working with a string because some things like active storage dont return strings
+      text = text.to_s unless text.is_a?(String)# ensure we're working with a string because some things like active storage dont return strings
 
       return text if request && !request.format.html?
       return text if text.nil? || text.empty?

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -308,10 +308,8 @@ module ViewComponent
     end
 
     def maybe_escape_html(text)
-      text = text.to_s unless text.is_a?(String) # ensure we're working with a string because some things like active storage dont return strings
-
       return text if request && !request.format.html?
-      return text if text.nil? || text.empty?
+      return text if text.blank?
 
       if text.html_safe?
         text

--- a/test/sandbox/app/components/inline_slot_html_escape_component.rb
+++ b/test/sandbox/app/components/inline_slot_html_escape_component.rb
@@ -1,0 +1,18 @@
+class InlineSlotHtmlEscapeComponent < ViewComponent::Base
+  renders_one :empty_state
+
+  def initialize(heading:, paragraph:, url:)
+    @heading = heading
+    @paragraph = paragraph
+    @url = url
+  end
+
+  def call
+    return empty_state unless @heading.attached?
+
+    link_to @url do
+      tag.h1(@heading) +
+        tag.p(@paragraph)
+    end
+  end
+end

--- a/test/sandbox/app/components/inline_slot_html_escape_component.rb
+++ b/test/sandbox/app/components/inline_slot_html_escape_component.rb
@@ -1,9 +1,9 @@
 class InlineSlotHtmlEscapeComponent < ViewComponent::Base
   renders_one :empty_state
 
-  def initialize(heading:, paragraph:, url:)
+  def initialize(counter:, heading:, url:)
+    @counter = counter
     @heading = heading
-    @paragraph = paragraph
     @url = url
   end
 
@@ -11,8 +11,8 @@ class InlineSlotHtmlEscapeComponent < ViewComponent::Base
     return empty_state unless @heading.nil?
 
     link_to @url do
-      @heading +
-        tag.p(@paragraph)
+      @counter +
+        tag.p(@heading)
     end
   end
 end

--- a/test/sandbox/app/components/inline_slot_html_escape_component.rb
+++ b/test/sandbox/app/components/inline_slot_html_escape_component.rb
@@ -8,10 +8,10 @@ class InlineSlotHtmlEscapeComponent < ViewComponent::Base
   end
 
   def call
-    return empty_state unless @heading.attached?
+    return empty_state unless @heading.nil?
 
     link_to @url do
-      tag.h1(@heading) +
+      @heading +
         tag.p(@paragraph)
     end
   end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -754,9 +754,9 @@ class SlotableTest < ViewComponent::TestCase
   end
 
   def test_inline_slot_html_escape
-    render_inline InlineSlotHtmlEscapeComponent.new(heading: 'hello', paragraph: 'lorem ipsum', url: '/some_url') do |component|
+    render_inline InlineSlotHtmlEscapeComponent.new(heading: 'lorem ipsum', counter: 12,  url: '/some_url') do |component|
       component.with_empty_state do
-        12
+        'empty state'
       end
     end
   end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -754,9 +754,9 @@ class SlotableTest < ViewComponent::TestCase
   end
 
   def test_inline_slot_html_escape
-    render_inline InlineSlotHtmlEscapeComponent.new(heading: 'lorem ipsum', counter: 12,  url: '/some_url') do |component|
+    render_inline InlineSlotHtmlEscapeComponent.new(heading: "lorem ipsum", counter: 12, url: "/some_url") do |component|
       component.with_empty_state do
-        'empty state'
+        "empty state"
       end
     end
   end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -753,8 +753,16 @@ class SlotableTest < ViewComponent::TestCase
     end
   end
 
-  def test_inline_slot_html_escape
+  def test_inline_slot_html_escape_with_integer
     render_inline InlineSlotHtmlEscapeComponent.new(heading: "lorem ipsum", counter: 12, url: "/some_url") do |component|
+      component.with_empty_state do
+        "empty state"
+      end
+    end
+  end
+
+  def test_inline_slot_html_escape_with_json
+    render_inline InlineSlotHtmlEscapeComponent.new(heading: "lorem ipsum", counter: {foo: "bar"}.to_json, url: "/some_url") do |component|
       component.with_empty_state do
         "empty state"
       end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -752,4 +752,12 @@ class SlotableTest < ViewComponent::TestCase
       end
     end
   end
+
+  def test_inline_slot_html_escape
+    render InlineSlotHtmlEscapeComponent.new(heading: 'test', paragraph: 'lorem ipsum', url: root_path) do |component|
+      component.with_empty_state do
+        'No avatar'
+      end
+    end
+  end
 end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -754,9 +754,9 @@ class SlotableTest < ViewComponent::TestCase
   end
 
   def test_inline_slot_html_escape
-    render InlineSlotHtmlEscapeComponent.new(heading: 'test', paragraph: 'lorem ipsum', url: root_path) do |component|
+    render_inline InlineSlotHtmlEscapeComponent.new(heading: 'hello', paragraph: 'lorem ipsum', url: '/some_url') do |component|
       component.with_empty_state do
-        'No avatar'
+        12
       end
     end
   end


### PR DESCRIPTION
closes #1955
### What are you trying to accomplish?
 When an integer or any non-string is used inside call the html escaping throw an error(described in the linked issue)

### What approach did you choose and why?

I replaced `text.nil? || text.empty?` for with type safe `.blank?` so any type can be escaped as is allowed in templates
