### PR TITLE
Update maybe_escape_html to return when in test env

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Update `maybe_escape_html` to return when in `test` environment.
+
+    *Kathleen Cesar*
+
 * Add `output_preamble` to match `output_postamble`, using the same safety checks.
 
     *Kali Donovan*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -317,6 +317,7 @@ module ViewComponent
     end
 
     def maybe_escape_html(text)
+      return text if ::Rails.env.test?
       return text if request && !request.format.html?
       return text if text.nil? || text.empty?
 


### PR DESCRIPTION
### What are you trying to accomplish?

The changes [here](https://github.com/ViewComponent/view_component/compare/v3.8.0...v3.9.0#diff-b69c75ffd85596e0b5fca1327059ecf3b2930f3f77004c78a268fa85e8ec8d9eR311) caused our specs to fail with `Failure/Error: subject { render_inline(component) } #<Double (anonymous)> received unexpected message :format with (no args)` due to being unable to call `format` on the double we define as a parameter.

### What approach did you choose and why?

Return `text` in `maybe_escape_html` when in a test environment.

### Anything you want to highlight for special attention from reviewers?