### PR TITLE
Bump puma

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
-    nio4r (2.5.9)
+    nio4r (2.7.0)
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -183,7 +183,7 @@ GEM
     psych (5.1.2)
       stringio
     public_suffix (5.0.3)
-    puma (6.4.0)
+    puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Bump puma in the Gemfile.lock
+* Bump `puma` in Gemfile.lock.
 
     *Cameron Dutro*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Bump puma in the Gemfile.lock
+
+    *Cameron Dutro*
+
 ## 3.10.0
 
 * Fix html escaping in `#call` for non-strings.


### PR DESCRIPTION
### What are you trying to accomplish?

Puma v6.4.0 contains a security vulnerability. This PR bumps it to a patched version in our Gemfile.lock. We only use puma for tests, but this should quiet the vuln scanners.