### PR TITLE
Include `use_helpers` in all components

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Include ViewComponent::UseHelpers by default instead.
+* Include ViewComponent::UseHelpers by default.
 
       *Reegan Viljoen*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Make `use_helpers` a default method for all components
+
+      *Reegan Viljoen*
+
 * Bump `puma` in Gemfile.lock.
 
     *Cameron Dutro*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Make `use_helpers` a default method for all components
+* Include ViewComponent::UseHelpers by default instead.
 
       *Reegan Viljoen*
 

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -55,7 +55,7 @@ end
 
 By default, ViewComponents don't have access to helper methods defined externally. The `use_helpers` method allows external helpers to be called from the component.
 
-`use_helpers` defines the helper on the component and is similar in use to using `delegate` on helpers.
+`use_helpers` defines the helper on the component, similar to `delegate`:
 
 ```ruby
 class UseHelpersComponent < ViewComponent::Base

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -55,12 +55,10 @@ end
 
 By default, ViewComponents don't have access to helper methods defined externally. The `use_helpers` method allows external helpers to be called from the component.
 
-To use the `use_helpers` method, include `ViewComponent::UseHelpers`.
-`UseHelpers` defines the helper on the component and is similar in use to using `delegate` on helpers.
+`use_helpers` defines the helper on the component and is similar in use to using `delegate` on helpers.
 
 ```ruby
 class UseHelpersComponent < ViewComponent::Base
-  include ViewComponent::UseHelpers
   use_helpers :icon
 
   erb_template <<-ERB

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -28,6 +28,7 @@ module ViewComponent
     end
 
     include ViewComponent::InlineTemplate
+    include ViewComponent::UseHelpers
     include ViewComponent::Slotable
     include ViewComponent::Translatable
     include ViewComponent::WithContentHelper

--- a/test/sandbox/app/components/use_helpers_component.rb
+++ b/test/sandbox/app/components/use_helpers_component.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 class UseHelpersComponent < ViewComponent::Base
+  # include ViewComponent::UseHelpers
+  # This module is now part of ViewComponent::Base, but the tests that
+  # use this component are testing the functionality the module provides.
   use_helpers :message
 end

--- a/test/sandbox/app/components/use_helpers_component.rb
+++ b/test/sandbox/app/components/use_helpers_component.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
 class UseHelpersComponent < ViewComponent::Base
-  # include ViewComponent::UseHelpers
-  # This module is now part of ViewComponent::Base, but the tests that
-  # use this component are testing the functionality the module provides.
   use_helpers :message
 end

--- a/test/sandbox/app/components/use_helpers_component.rb
+++ b/test/sandbox/app/components/use_helpers_component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 class UseHelpersComponent < ViewComponent::Base
-  include ViewComponent::UseHelpers
-
   use_helpers :message
 end


### PR DESCRIPTION
### What are you trying to accomplish?

In order to complete #1976 the `#use_helpers` method needs to be added to components by default, so this pr is part of a two part series, hopefully this can bee included with version 4
