### PR TITLE
Add strict helpers

### DIFF
--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -54,12 +54,12 @@ module ViewComponent
 
     # :doc:
     def default_preview_layout
-      ViewComponent::Base.config.default_preview_layout
+      GlobalConfig.default_preview_layout
     end
 
     # :doc:
     def show_previews?
-      ViewComponent::Base.config.show_previews
+      GlobalConfig.show_previews
     end
 
     # :doc:
@@ -102,7 +102,7 @@ module ViewComponent
     end
 
     def prepend_preview_examples_view_path
-      prepend_view_path(ViewComponent::Base.preview_paths)
+      prepend_view_path(GlobalConfig.preview_paths)
     end
   end
 end

--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -54,12 +54,12 @@ module ViewComponent
 
     # :doc:
     def default_preview_layout
-      GlobalConfig.default_preview_layout
+      ViewComponent::Base.config.default_preview_layout
     end
 
     # :doc:
     def show_previews?
-      GlobalConfig.show_previews
+      ViewComponent::Base.config.show_previews
     end
 
     # :doc:
@@ -102,7 +102,7 @@ module ViewComponent
     end
 
     def prepend_preview_examples_view_path
-      prepend_view_path(GlobalConfig.preview_paths)
+      prepend_view_path(ViewComponent::Base.config.preview_paths)
     end
   end
 end

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -35,7 +35,7 @@ module PreviewHelper
       # Fetch template source via finding it through preview paths
       # to accomodate source view when exclusively using templates
       # for previews for Rails < 6.1.
-      all_template_paths = ViewComponent::Base.config.preview_paths.map do |preview_path|
+      all_template_paths = ViewComponent::GlobalConfig.preview_paths.map do |preview_path|
         Dir.glob("#{preview_path}/**/*")
       end.flatten
 
@@ -80,6 +80,6 @@ module PreviewHelper
   # :nocov:
 
   def serve_static_preview_assets?
-    ViewComponent::Base.config.show_previews && Rails.application.config.public_file_server.enabled
+    ViewComponent::GlobalConfig.show_previews && Rails.application.config.public_file_server.enabled
   end
 end

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -35,7 +35,7 @@ module PreviewHelper
       # Fetch template source via finding it through preview paths
       # to accomodate source view when exclusively using templates
       # for previews for Rails < 6.1.
-      all_template_paths = ViewComponent::GlobalConfig.preview_paths.map do |preview_path|
+      all_template_paths = ViewComponent::Base.config.preview_paths.map do |preview_path|
         Dir.glob("#{preview_path}/**/*")
       end.flatten
 
@@ -80,6 +80,6 @@ module PreviewHelper
   # :nocov:
 
   def serve_static_preview_assets?
-    ViewComponent::GlobalConfig.show_previews && Rails.application.config.public_file_server.enabled
+    ViewComponent::Base.config..show_previews && Rails.application.config.public_file_server.enabled
   end
 end

--- a/app/views/view_components/preview.html.erb
+++ b/app/views/view_components/preview.html.erb
@@ -1,5 +1,5 @@
 <% if @render_args[:component] %>
-  <% if ViewComponent::Base.config.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 %>
+  <% if ViewComponent::GlobalConfig.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 %>
     <%= render(@render_args[:component], @render_args[:args], &@render_args[:block]) %>
   <% else %>
     <%= render_component(@render_args[:component], &@render_args[:block]) %>
@@ -8,6 +8,6 @@
   <%= render template: @render_args[:template], locals: @render_args[:locals] || {} %>
 <% end %>
 
-<% if ViewComponent::Base.config.show_previews_source %>
+<% if ViewComponent::GlobalConfig.show_previews_source %>
   <%= preview_source %>
 <% end %>

--- a/app/views/view_components/preview.html.erb
+++ b/app/views/view_components/preview.html.erb
@@ -1,5 +1,5 @@
 <% if @render_args[:component] %>
-  <% if ViewComponent::GlobalConfig.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 %>
+  <% if ViewComponent::Base.config.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 %>
     <%= render(@render_args[:component], @render_args[:args], &@render_args[:block]) %>
   <% else %>
     <%= render_component(@render_args[:component], &@render_args[:block]) %>
@@ -8,6 +8,6 @@
   <%= render template: @render_args[:template], locals: @render_args[:locals] || {} %>
 <% end %>
 
-<% if ViewComponent::GlobalConfig.show_previews_source %>
+<% if ViewComponent::Base.config.show_previews_source %>
   <%= preview_source %>
 <% end %>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,11 +10,15 @@ nav_order: 6
 
 ## main
 
+* Add Strict helpers mode.
+
+    *Reegan Viljoen*
+
 * Introduce component-local config and migrate `strip_trailing_whitespace` to use it under the hood.
 
-    *Simon Fish*
+   *Simon Fish*
 
-* Add docs about Slack channel in Ruby Central workspace. (Join us! #oss-view-component). Email joelhawksley@github.com for an invite.
+* Add docs about Slack channel in Ruby Central workspace. (Join us! #oss-view-component). Email <joelhawksley@github.com> for an invite.
 
     *Joel Hawksley
 
@@ -1470,7 +1474,7 @@ Run into an issue with this release? [Let us know](https://github.com/ViewCompon
 
     *Joel Hawksley*
 
-* The ViewComponent team at GitHub is hiring! We're looking for a Rails engineer with accessibility experience: [https://boards.greenhouse.io/github/jobs/4020166](https://boards.greenhouse.io/github/jobs/4020166). Reach out to joelhawksley@github.com with any questions!
+* The ViewComponent team at GitHub is hiring! We're looking for a Rails engineer with accessibility experience: [https://boards.greenhouse.io/github/jobs/4020166](https://boards.greenhouse.io/github/jobs/4020166). Reach out to <joelhawksley@github.com> with any questions!
 
 * The ViewComponent team is hosting a happy hour at RailsConf. Join us for snacks, drinks, and stickers: [https://www.eventbrite.com/e/viewcomponent-happy-hour-tickets-304168585427](https://www.eventbrite.com/e/viewcomponent-happy-hour-tickets-304168585427)
 
@@ -2234,7 +2238,7 @@ Run into an issue with this release? [Let us know](https://github.com/ViewCompon
 
     *Matheus Richard*
 
-* Are you interested in building the future of ViewComponent? GitHub is looking to hire a Senior Engineer to work on Primer ViewComponents and ViewComponent. Apply here: [US/Canada](https://github.com/careers) / [Europe](https://boards.greenhouse.io/github/jobs/3132294). Feel free to reach out to joelhawksley@github.com with any questions.
+* Are you interested in building the future of ViewComponent? GitHub is looking to hire a Senior Engineer to work on Primer ViewComponents and ViewComponent. Apply here: [US/Canada](https://github.com/careers) / [Europe](https://boards.greenhouse.io/github/jobs/3132294). Feel free to reach out to <joelhawksley@github.com> with any questions.
 
     *Joel Hawksley*
 
@@ -2252,7 +2256,7 @@ Run into an issue with this release? [Let us know](https://github.com/ViewCompon
 
 ## 2.31.0
 
-_Note: This release includes an underlying change to Slots that may affect incorrect usage of the API, where Slots were set on a line prefixed by `<%=`. The result of setting a Slot shouldn't be returned. (`<%`)_
+*Note: This release includes an underlying change to Slots that may affect incorrect usage of the API, where Slots were set on a line prefixed by `<%=`. The result of setting a Slot shouldn't be returned. (`<%`)*
 
 * Add `#with_content` to allow setting content without a block.
 
@@ -2700,7 +2704,7 @@ _Note: This release includes an underlying change to Slots that may affect incor
 
   * The gem name is now `view_component`.
   * ViewComponent previews are now accessed at `/rails/view_components`.
-  * ViewComponents can _only_ be rendered with the instance syntax: `render(MyComponent.new)`. Support for all other syntaxes has been removed.
+  * ViewComponents can *only* be rendered with the instance syntax: `render(MyComponent.new)`. Support for all other syntaxes has been removed.
   * ActiveModel::Validations have been removed. ViewComponent generators no longer include validations.
   * In Rails 6.1, no monkey patching is used.
   * `to_component_class` has been removed.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 6
 
 ## main
 
-* Add Strict helpers mode.
+* Add `helpers_enabled` config.
 
     *Reegan Viljoen*
 

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -55,7 +55,7 @@ end
 
 By default, ViewComponents don't have access to helper methods defined externally. The `use_helpers` method allows external helpers to be called from the component.
 
-`use_helpers` defines the helper on the component, similar to `delegate`:
+`use_helpers` defines the helper on the component and is similar in use to using `delegate` on helpers.
 
 ```ruby
 class UseHelpersComponent < ViewComponent::Base

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -55,7 +55,7 @@ end
 
 By default, ViewComponents don't have access to helper methods defined externally. The `use_helpers` method allows external helpers to be called from the component.
 
-`use_helpers` defines the helper on the component and is similar in use to using `delegate` on helpers.
+`use_helpers` defines the helper on the component, similar to `delegate`:
 
 ```ruby
 class UseHelpersComponent < ViewComponent::Base

--- a/lib/rails/generators/abstract_generator.rb
+++ b/lib/rails/generators/abstract_generator.rb
@@ -29,7 +29,7 @@ module ViewComponent
     end
 
     def component_path
-      ViewComponent::Base.config.view_component_path
+      GlobalConfig.view_component_path
     end
 
     def stimulus_controller
@@ -42,15 +42,15 @@ module ViewComponent
     end
 
     def sidecar?
-      options["sidecar"] || ViewComponent::Base.config.generate.sidecar
+      options["sidecar"] || GlobalConfig.generate.sidecar
     end
 
     def stimulus?
-      options["stimulus"] || ViewComponent::Base.config.generate.stimulus_controller
+      options["stimulus"] || GlobalConfig.generate.stimulus_controller
     end
 
     def typescript?
-      options["typescript"] || ViewComponent::Base.config.generate.typescript
+      options["typescript"] || GlobalConfig.generate.typescript
     end
   end
 end

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -13,9 +13,9 @@ module Rails
       check_class_collision suffix: "Component"
 
       class_option :inline, type: :boolean, default: false
-      class_option :locale, type: :boolean, default: ViewComponent::Base.config.generate.locale
+      class_option :locale, type: :boolean, default: ViewComponent::GlobalConfig.generate.locale
       class_option :parent, type: :string, desc: "The parent class for the generated component"
-      class_option :preview, type: :boolean, default: ViewComponent::Base.config.generate.preview
+      class_option :preview, type: :boolean, default: ViewComponent::GlobalConfig.generate.preview
       class_option :sidecar, type: :boolean, default: false
       class_option :stimulus, type: :boolean,
         default: ViewComponent::Base.config.generate.stimulus_controller
@@ -42,7 +42,7 @@ module Rails
       def parent_class
         return options[:parent] if options[:parent]
 
-        ViewComponent::Base.config.component_parent_class || default_parent_class
+        ViewComponent::GlobalConfig.component_parent_class || default_parent_class
       end
 
       def initialize_signature

--- a/lib/rails/generators/locale/component_generator.rb
+++ b/lib/rails/generators/locale/component_generator.rb
@@ -12,7 +12,7 @@ module Locale
       class_option :sidecar, type: :boolean, default: false
 
       def create_locale_file
-        if ViewComponent::Base.config.generate.distinct_locale_files
+        if ViewComponent::GlobalConfig.generate.distinct_locale_files
           I18n.available_locales.each do |locale|
             create_file destination(locale), translations_hash([locale]).to_yaml
           end

--- a/lib/rails/generators/preview/component_generator.rb
+++ b/lib/rails/generators/preview/component_generator.rb
@@ -4,13 +4,13 @@ module Preview
   module Generators
     class ComponentGenerator < ::Rails::Generators::NamedBase
       source_root File.expand_path("templates", __dir__)
-      class_option :preview_path, type: :string, desc: "Path for previews, required when multiple preview paths are configured", default: ViewComponent::Base.config.generate.preview_path
+      class_option :preview_path, type: :string, desc: "Path for previews, required when multiple preview paths are configured", default: ViewComponent::GlobalConfig.generate.preview_path
 
       argument :attributes, type: :array, default: [], banner: "attribute"
       check_class_collision suffix: "ComponentPreview"
 
       def create_preview_file
-        preview_paths = ViewComponent::Base.config.preview_paths
+        preview_paths = ViewComponent::GlobalConfig.preview_paths
         optional_path = options[:preview_path]
         return if preview_paths.count > 1 && optional_path.blank?
 

--- a/lib/rails/generators/rspec/component_generator.rb
+++ b/lib/rails/generators/rspec/component_generator.rb
@@ -16,7 +16,7 @@ module Rspec
       private
 
       def spec_component_path
-        return "spec/components" unless ViewComponent::Base.config.generate.use_component_path_for_rspec_tests
+        return "spec/components" unless ViewComponent::GlobalConfig.generate.use_component_path_for_rspec_tests
 
         configured_component_path = component_path
         if configured_component_path.start_with?("app#{File::SEPARATOR}")

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -13,6 +13,7 @@ module ViewComponent
   autoload :ComponentError
   autoload :Config
   autoload :Deprecation
+  autoload :GlobalConfig
   autoload :InlineTemplate
   autoload :Instrumentation
   autoload :Preview

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -43,9 +43,8 @@ module ViewComponent
     RESERVED_PARAMETER = :content
     VC_INTERNAL_DEFAULT_FORMAT = :html
 
-    use_helpers :form_authenticity_token, :protect_against_forgery?, :config, :content_security_policy_nonce
-
     # For CSRF authenticity tokens in forms and Content Security Policy nonces
+    use_helpers :form_authenticity_token, :protect_against_forgery?, :config, :content_security_policy_nonce
 
     attr_accessor :__vc_original_view_context
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -520,16 +520,6 @@ module ViewComponent
         # `compile` defines
         compile
 
-        if child.superclass == ViewComponent::Base
-          child.define_singleton_method(:component_config) do
-            @@component_config ||= Rails.application.config.view_component.inheritable_copy
-          end
-        else
-          child.define_singleton_method(:component_config) do
-            @@component_config ||= superclass.component_config.inheritable_copy
-          end
-        end
-
         # Give the child its own personal #render_template_for to protect against the case when
         # eager loading is disabled and the parent component is rendered before the child. In
         # such a scenario, the parent will override ViewComponent::Base#render_template_for,

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -522,6 +522,18 @@ module ViewComponent
         # `compile` defines
         compile
 
+        child.include ActiveSupport::Configurable
+
+        if child.superclass == ViewComponent::Base
+          child.define_singleton_method(:config) do
+            @@config ||= Rails.application.config.view_component.inheritable_copy
+          end
+        else
+          child.define_singleton_method(:config) do
+            @@config ||= superclass.config.inheritable_copy
+          end
+        end
+
         # Give the child its own personal #render_template_for to protect against the case when
         # eager loading is disabled and the parent component is rendered before the child. In
         # such a scenario, the parent will override ViewComponent::Base#render_template_for,

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "action_view"
-require "active_support/configurable"
 require "view_component/collection"
 require "view_component/compile_cache"
 require "view_component/compiler"
@@ -231,7 +230,6 @@ module ViewComponent
     # @return [ActionView::Base]
     def helpers
       raise HelpersCalledBeforeRenderError if view_context.nil?
-
       # Attempt to re-use the original view_context passed to the first
       # component rendered in the rendering pipeline. This prevents the
       # instantiation of a new view_context via `controller.view_context` which
@@ -522,15 +520,13 @@ module ViewComponent
         # `compile` defines
         compile
 
-        child.include ActiveSupport::Configurable
-
         if child.superclass == ViewComponent::Base
-          child.define_singleton_method(:config) do
-            @@config ||= Rails.application.config.view_component.inheritable_copy
+          child.define_singleton_method(:component_config) do
+            @@component_config ||= Rails.application.config.view_component.inheritable_copy
           end
         else
-          child.define_singleton_method(:config) do
-            @@config ||= superclass.config.inheritable_copy
+          child.define_singleton_method(:component_config) do
+            @@component_config ||= superclass.component_config.inheritable_copy
           end
         end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -43,6 +43,8 @@ module ViewComponent
     RESERVED_PARAMETER = :content
     VC_INTERNAL_DEFAULT_FORMAT = :html
 
+    use_helpers :form_authenticity_token, :protect_against_forgery?, :config, :content_security_policy_nonce
+
     # For CSRF authenticity tokens in forms and Content Security Policy nonces
 
     attr_accessor :__vc_original_view_context
@@ -70,19 +72,7 @@ module ViewComponent
     # @return [String]
     def render_in(view_context, &block)
       self.class.compile(raise_errors: true)
-      if ViewComponent::Base.config.strict_helpers_enabled
-        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-          use_helpers :form_authenticity_token, :protect_against_forgery?, :config, :content_security_policy_nonce
-        RUBY
-      else
-        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-          # For CSRF authenticity tokens in forms
-          delegate :form_authenticity_token, :protect_against_forgery?, :config, to: :helpers
 
-          # For Content Security Policy nonces
-          delegate :content_security_policy_nonce, to: :helpers
-        RUBY
-      end
       @view_context = view_context
       self.__vc_original_view_context ||= view_context
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -44,7 +44,6 @@ module ViewComponent
     VC_INTERNAL_DEFAULT_FORMAT = :html
 
     # For CSRF authenticity tokens in forms and Content Security Policy nonces
-    use_helpers :form_authenticity_token, :protect_against_forgery?, :config, :content_security_policy_nonce
 
     attr_accessor :__vc_original_view_context
 
@@ -71,7 +70,19 @@ module ViewComponent
     # @return [String]
     def render_in(view_context, &block)
       self.class.compile(raise_errors: true)
+      if ViewComponent::Base.config.strict_helpers_enabled
+        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+          use_helpers :form_authenticity_token, :protect_against_forgery?, :config, :content_security_policy_nonce
+        RUBY
+      else
+        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+          # For CSRF authenticity tokens in forms
+          delegate :form_authenticity_token, :protect_against_forgery?, :config, to: :helpers
 
+          # For Content Security Policy nonces
+          delegate :content_security_policy_nonce, to: :helpers
+        RUBY
+      end
       @view_context = view_context
       self.__vc_original_view_context ||= view_context
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -43,11 +43,8 @@ module ViewComponent
     RESERVED_PARAMETER = :content
     VC_INTERNAL_DEFAULT_FORMAT = :html
 
-    # For CSRF authenticity tokens in forms
-    delegate :form_authenticity_token, :protect_against_forgery?, :config, to: :helpers
-
-    # For Content Security Policy nonces
-    delegate :content_security_policy_nonce, to: :helpers
+    # For CSRF authenticity tokens in forms and Content Security Policy nonces
+    use_helpers :form_authenticity_token, :protect_against_forgery?, :config, :content_security_policy_nonce
 
     attr_accessor :__vc_original_view_context
 
@@ -230,6 +227,8 @@ module ViewComponent
     # @return [ActionView::Base]
     def helpers
       raise HelpersCalledBeforeRenderError if view_context.nil?
+
+      raise StrictHelperError if ViewComponent::Base.strict_helpers_enabled
       # Attempt to re-use the original view_context passed to the first
       # component rendered in the rendering pipeline. This prevents the
       # instantiation of a new view_context via `controller.view_context` which
@@ -246,7 +245,8 @@ module ViewComponent
         super
       rescue => e # rubocop:disable Style/RescueStandardError
         e.set_backtrace e.backtrace.tap(&:shift)
-        raise e, <<~MESSAGE.chomp if view_context && e.is_a?(NameError) && helpers.respond_to?(method_name)
+        if ViewComponent::Base.strict_helpers_enabled
+          raise e, <<~MESSAGE.chomp if view_context && e.is_a?(NameError) && (__vc_original_view_context.respond_to?(method_name)|| controller.view_context.respond_to?(method_name))
           #{e.message}
 
           You may be trying to call a method provided as a view helper. Did you mean `helpers.#{method_name}`?

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -26,7 +26,10 @@ module ViewComponent
           test_controller: "ApplicationController",
           default_preview_layout: nil,
           capture_compatibility_patch_enabled: false,
-          helpers_enabled: true
+          helpers_enabled: true,
+          component_defaults: ActiveSupport::InheritableOptions.new({
+            strict_helpers_enabled: false
+          })
         })
       end
 

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -26,7 +26,7 @@ module ViewComponent
           test_controller: "ApplicationController",
           default_preview_layout: nil,
           capture_compatibility_patch_enabled: false,
-          strict_helpers_enabled: false
+          helpers_enabled: true
         })
       end
 
@@ -174,10 +174,10 @@ module ViewComponent
       # previews.
       # Defaults to `false`.
 
-      # @!attribute strict_helpers_enabled
+      # @!attribute helpers_enabled
       # @return [Boolean]
-      # Enables the experimental strict helpers mode wich throws ViewComponent::StrictHelperError when helpers is used
-      # Defaults to `false`.
+      # Enables the use of #helpers
+      # Defaults to `True`.
 
       def default_preview_paths
         (default_rails_preview_paths + default_rails_engines_preview_paths).uniq

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -11,7 +11,7 @@ module ViewComponent
       alias_method :default, :new
 
       def defaults
-        ActiveSupport::OrderedOptions.new.merge!({
+        ActiveSupport::InheritableOptions.new({
           generate: default_generate_options,
           preview_controller: "ViewComponentsController",
           preview_route: "/rails/view_components",

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -25,7 +25,8 @@ module ViewComponent
           preview_paths: default_preview_paths,
           test_controller: "ApplicationController",
           default_preview_layout: nil,
-          capture_compatibility_patch_enabled: false
+          capture_compatibility_patch_enabled: false,
+          strict_helpers_enabled: false
         })
       end
 
@@ -171,6 +172,11 @@ module ViewComponent
       # Enables the experimental capture compatibility patch that makes ViewComponent
       # compatible with forms, capture, and other built-ins.
       # previews.
+      # Defaults to `false`.
+
+      # @!attribute strict_helpers_enabled
+      # @return [Boolean]
+      # Enables the experimental strict helpers mode wich throws ViewComponent::StrictHelperError when helpers is used
       # Defaults to `false`.
 
       def default_preview_paths

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -6,7 +6,7 @@ require "view_component/deprecation"
 
 module ViewComponent
   class Engine < Rails::Engine # :nodoc:
-    config.view_component = ViewComponent::Config.current
+    config.view_component = ViewComponent::Config.defaults
 
     if Rails.version.to_f < 8.0
       rake_tasks do

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -29,7 +29,7 @@ module ViewComponent
     initializer "view_component.set_configs" do |app|
       options = app.config.view_component
 
-      %i[generate preview_controller preview_route show_previews_source].each do |config_option|
+      %i[generate preview_controller preview_route].each do |config_option|
         options[config_option] ||= ViewComponent::Base.public_send(config_option)
       end
       options.instrumentation_enabled = false if options.instrumentation_enabled.nil?

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -228,6 +228,10 @@ module ViewComponent
     MESSAGE = "ViewComponent SystemTest controller attempted to load a file outside of the expected directory."
   end
 
+  class StrictHelperError < BaseError
+    MESSAGE = "ViewComponent strict helper mode is enbaled so #helpers is disabled."
+  end
+
   class AlreadyDefinedPolymorphicSlotSetterError < StandardError
     MESSAGE =
       "A method called 'SETTER_METHOD_NAME' already exists and would be overwritten by the 'SETTER_NAME' polymorphic " \

--- a/lib/view_component/global_config.rb
+++ b/lib/view_component/global_config.rb
@@ -1,0 +1,3 @@
+module ViewComponent
+  GlobalConfig = defined?(Rails) ? Rails.application.config.view_component : Base.config
+end

--- a/lib/view_component/global_config.rb
+++ b/lib/view_component/global_config.rb
@@ -1,3 +1,3 @@
 module ViewComponent
-  GlobalConfig = defined?(Rails) && Rails.application ? Rails.application.config.view_component : Base.config
+  GlobalConfig = (defined?(Rails) && Rails.application) ? Rails.application.config.view_component : Base.config # standard:disable Naming/ConstantName
 end

--- a/lib/view_component/global_config.rb
+++ b/lib/view_component/global_config.rb
@@ -1,3 +1,3 @@
 module ViewComponent
-  GlobalConfig = defined?(Rails) ? Rails.application.config.view_component : Base.config
+  GlobalConfig = defined?(Rails) && Rails.application ? Rails.application.config.view_component : Base.config
 end

--- a/lib/view_component/instrumentation.rb
+++ b/lib/view_component/instrumentation.rb
@@ -23,7 +23,7 @@ module ViewComponent # :nodoc:
     private
 
     def notification_name
-      return "!render.view_component" if ViewComponent::Base.config.use_deprecated_instrumentation_name
+      return "!render.view_component" if GlobalConfig.use_deprecated_instrumentation_name
 
       "render.view_component"
     end

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -109,7 +109,7 @@ module ViewComponent # :nodoc:
       private
 
       def preview_paths
-        Base.preview_paths
+        ViewComponent::GlobalConfig.preview_paths
       end
     end
   end

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -250,7 +250,8 @@ module ViewComponent
     #
     # @return [ActionController::Base]
     def vc_test_controller
-      @vc_test_controller ||= __vc_test_helpers_build_controller(Base.test_controller.constantize)
+      config_source = defined?(Rails) ? Rails.application.config.view_component : ViewComponent::Base
+      @vc_test_controller ||= __vc_test_helpers_build_controller(config_source.test_controller.constantize)
     end
 
     # Access the request used by `render_inline`:

--- a/lib/view_component/use_helpers.rb
+++ b/lib/view_component/use_helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "view_component/errors"
+
 module ViewComponent::UseHelpers
   extend ActiveSupport::Concern
 
@@ -13,7 +15,7 @@ module ViewComponent::UseHelpers
 
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
         def #{helper_method_name}(*args, &block)
-          raise HelpersCalledBeforeRenderError if view_context.nil?
+          raise ::ViewComponent::HelpersCalledBeforeRenderError if view_context.nil?
 
           #{define_helper(helper_method: helper_method, source: from)}
         end

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -127,6 +127,18 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     assert !exception_message_regex.match?(exception.message)
   end
 
+  def test_no_heleprs_error_if_helpers_disabled
+    with_helpers_enabled_config(false) do
+      exception = assert_raises(NoMethodError) { Class.new(ViewComponent::Base).new.current_user }
+      exception_message_regex = Regexp.new <<~MESSAGE.chomp, Regexp::MULTILINE
+        undefined method `current_user' for .*
+
+        You may be trying to call a method provided as a view helper. To use it try decalring it using use_helpers :current_user'?
+      MESSAGE
+      assert !exception_message_regex.match?(exception.message)
+    end
+  end
+
   def test_no_method_error_references_helper_if_view_context_present
     view_context = ActionController::Base.new.view_context
     view_context.instance_eval {

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -579,7 +579,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       expected_response_body = <<~TURBOSTREAM
         <turbo-stream action="update" target="area1"><template><span>Hello, world!</span></template></turbo-stream>
       TURBOSTREAM
-      if ViewComponent::Base.config.capture_compatibility_patch_enabled
+      if ViewComponent::GlobalConfig.capture_compatibility_patch_enabled
         assert_equal expected_response_body, response.body
       else
         assert_not_equal expected_response_body, response.body
@@ -716,8 +716,8 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     Rails.cache.clear
   end
 
-  def test_config_options_shared_between_base_and_engine
-    config_entrypoints = [Rails.application.config.view_component, ViewComponent::Base.config]
+  def test_globalconfig_is_proxy_for_rails_app_config
+    config_entrypoints = [Rails.application.config.view_component, ViewComponent::GlobalConfig]
     2.times do
       config_entrypoints.first.yield_self do |config|
         {

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1277,9 +1277,12 @@ class RenderingTest < ViewComponent::TestCase
       render_inline(MultipleFormatsComponent.new)
 
       assert_equal(rendered_json["hello"], "world")
+    end
   end
 
-  def test_strict_helpers
+  # Since helpers_enabled is true by default, we assume that the converse case
+  # is covered. If that default changes, tests should generally be updated.
+  def test_helpers_proxy_raises_if_helpers_disabled
     with_helpers_enabled_config(false) do
       assert_raises ViewComponent::StrictHelperError do
         render_inline(HelpersProxyComponent.new)
@@ -1311,6 +1314,16 @@ class RenderingTest < ViewComponent::TestCase
 
     assert_nothing_raised do
       render_inline(mock_component.new)
+    end
+  end
+
+  def test_helpers_proxy_raises_if_strict_helpers_enabled
+    with_helpers_enabled_config(true) do
+      with_strict_helpers_config(true) do
+        assert_raises ViewComponent::StrictHelperError do
+          render_inline(HelpersProxyComponent.new)
+        end
+      end
     end
   end
 end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -194,7 +194,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_renders_button_to_component_with_strict_helpers
-    with_strict_helpers_config(true) do
+    with_helpers_enabled_config(false) do
       old_value = ActionController::Base.allow_forgery_protection
       ActionController::Base.allow_forgery_protection = true
 
@@ -371,7 +371,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_renders_component_with_asset_url_with_strict_helpers
-    with_strict_helpers_config(true) do
+    with_helpers_enabled_config(false) do
       component = AssetComponent.new
       assert_match(%r{http://assets.example.com/assets/application-\w+.css}, render_inline(component).text)
 
@@ -816,7 +816,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_renders_component_using_rails_config_with_strict_helpers
-    with_strict_helpers_config(true) do
+    with_helpers_enabled_config(false) do
       render_inline(RailsConfigComponent.new)
 
       assert_text("http://assets.example.com")
@@ -1180,7 +1180,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_content_security_policy_nonce_with_strict_helpers
-    with_strict_helpers_config(true) do
+    with_helpers_enabled_config(false) do
       render_inline(ContentSecurityPolicyNonceComponent.new)
 
       assert_selector("script", text: "\n//<![CDATA[\n  \"alert('hello')\"\n\n//]]>\n", visible: :hidden)
@@ -1280,7 +1280,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_strict_helpers
-    with_strict_helpers_config(true) do
+    with_helpers_enabled_config(false) do
       assert_raises ViewComponent::StrictHelperError do
         render_inline(HelpersProxyComponent.new)
       end

--- a/test/test_engine/test_helper.rb
+++ b/test/test_engine/test_helper.rb
@@ -22,7 +22,7 @@ require "view_component"
 
 Rails::Generators.namespace = TestEngine
 
-def with_config_option(option_name, new_value, config_entrypoint: TestEngine::Engine.config.view_component)
+def with_config_option(option_name, new_value, config_entrypoint: ViewComponent::GlobalConfig)
   old_value = config_entrypoint.public_send(option_name)
   config_entrypoint.public_send(:"#{option_name}=", new_value)
   yield

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -182,6 +182,10 @@ def with_strict_helpers_config(enabled, &block)
   with_config_option(:strict_helpers_enabled, enabled, &block)
 end
 
+def with_helpers_enabled_config(enabled, &block)
+  with_config_option(:helpers_enabled, enabled, &block)
+end
+
 def with_compiler_mode(mode)
   previous_mode = ViewComponent::Compiler.mode
   ViewComponent::Compiler.mode = mode

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -176,6 +176,15 @@ end
 def with_compiler_development_mode(mode)
   previous_mode = ViewComponent::Compiler.development_mode
   ViewComponent::Compiler.development_mode = mode
+end
+
+def with_strict_helpers_config(enabled, &block)
+  with_config_option(:strict_helpers_enabled, enabled, &block)
+end
+
+def with_compiler_mode(mode)
+  previous_mode = ViewComponent::Compiler.mode
+  ViewComponent::Compiler.mode = mode
   yield
 ensure
   ViewComponent::Compiler.development_mode = previous_mode

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -179,7 +179,7 @@ def with_compiler_development_mode(mode)
 end
 
 def with_strict_helpers_config(enabled, &block)
-  with_config_option(:strict_helpers_enabled, enabled, &block)
+  with_config_option(:strict_helpers_enabled, enabled, config_entrypoint: Rails.application.config.view_component.component_defaults, &block)
 end
 
 def with_helpers_enabled_config(enabled, &block)


### PR DESCRIPTION
closses #1976 
### What are you trying to accomplish?

Add a `config.view_component.strict_helpers_enabled` mode to view component which will throw an `ViewComponent::StrictHelperError` when `helpers.<some_helper>` is used.

This 

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?