### PR TITLE
Add note to testing docs about `rendered_content` helper

### DIFF
--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -26,7 +26,7 @@ end
 
 _Note: `assert_selector` only matches on visible elements by default. To match on elements regardless of visibility, add `visible: false`. See the [Capybara documentation](https://rubydoc.info/github/jnicklas/capybara/Capybara/Node/Matchers) for more details._
 
-For debugging purposes, the `rendered_content` test helper outputs the full rendered HTML.
+For debugging purposes, the `rendered_content` test helper outputs the rendered HTML.
 
 ## Testing Slots
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -26,6 +26,8 @@ end
 
 _Note: `assert_selector` only matches on visible elements by default. To match on elements regardless of visibility, add `visible: false`. See the [Capybara documentation](https://rubydoc.info/github/jnicklas/capybara/Capybara/Node/Matchers) for more details._
 
+For debugging purposes, you can output the full rendered HTML using the `rendered_content` test helper.
+
 ## Testing Slots
 
 ```ruby

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -26,7 +26,7 @@ end
 
 _Note: `assert_selector` only matches on visible elements by default. To match on elements regardless of visibility, add `visible: false`. See the [Capybara documentation](https://rubydoc.info/github/jnicklas/capybara/Capybara/Node/Matchers) for more details._
 
-For debugging purposes, you can output the full rendered HTML using the `rendered_content` test helper.
+For debugging purposes, the `rendered_content` test helper outputs the full rendered HTML.
 
 ## Testing Slots
 


### PR DESCRIPTION
When writing tests, it's helpful to be able to see the full HTML for a component to debug problems. Add a note about the existing `rendered_content` helper to make it easier for folks to find out how to do this.

I had to source dive to find out how to do this, which is a barrier to people new to the library.