### PR TITLE
Use modern subscribe syntax

### DIFF
--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -23,8 +23,7 @@ Setting `use_deprecated_instrumentation_name` configures the event name. If `fal
 Subscribe to the event:
 
 ```ruby
-ActiveSupport::Notifications.subscribe("render.view_component") do |*args| # or !render.view_component
-  event = ActiveSupport::Notifications::Event.new(*args)
+ActiveSupport::Notifications.subscribe("render.view_component") do |event| # or !render.view_component
   event.name    # => "render.view_component"
   event.payload # => { name: "MyComponent", identifier: "/Users/mona/project/app/components/my_component.rb" }
 end


### PR DESCRIPTION
### What are you trying to accomplish?

The modern syntax is shorter and captures CPU time and allocations, see https://github.com/rails/rails/pull/49433