### PR TITLE
Docs: Use rack-mini-profiler for profiling ViewComponent rendering

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Document using rack-mini-profiler with ViewComponent
+
+    *Thomas Carr*
+
 * Move dependencies to gemspec.
 
     *Joel Hawksley*

--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -35,3 +35,21 @@ end
 When using `render.view_component` with `config.server_timing = true` (default in development) in Rails 7, the browser developer tools display the sum total timing information in Network > Timing under the key `render.view_component`.
 
 ![Browser showing the Server Timing data in the browser dev tools](../images/viewing_instrumentation_sums_in_browser_dev_tools.png "Server Timing data in the browser dev tools")
+
+## Viewing instrumentation breakdowns in rack-mini-profiler
+
+The [rack-mini-profiler gem](https://rubygems.org/gems/rack-mini-profiler) is a popular tool for profiling any rack-based ruby application. 
+
+To profile ViewComponent rendering alongside your views and partials:
+
+```ruby
+# config/environments/development.rb
+# Profile rendering of ViewComponents
+Rack::MiniProfilerRails.subscribe('render.view_component') do |_name, start, finish, _id, payload|
+  Rack::MiniProfilerRails.render_notification_handler(
+    Rack::MiniProfilerRails.shorten_identifier(payload[:identifier]),
+    finish,
+    start
+  )
+end
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -216,6 +216,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/thomascchen?s=64" alt="thomascchen" width="32" />
 <img src="https://avatars.githubusercontent.com/milk1000cc?s=64" alt="milk1000cc" width="32" />
 <img src="https://avatars.githubusercontent.com/aduth?s=64" alt="aduth" width="32" />
+<img src="https://avatars.githubusercontent.com/htcarr3?s=64" alt="htcarr3" width="32" />
 
 ## Who uses ViewComponent?
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR aims to document how to profile ViewComponent rendering alongside regular rails views, partials, and controller actions with the rack-mini-profiler gem. This was discussed in issue #1982. 
