### PR TITLE
Fix running non-integration tests under Rails main

### DIFF
--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -238,6 +238,8 @@ module ViewComponent
     #
     # @return [ActionDispatch::TestRequest]
     def vc_test_request
+      require "action_controller/test_case"
+
       @vc_test_request ||=
         begin
           out = ActionDispatch::TestRequest.create


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide a description of the changes. Link to any related issues or projects. -->

A [recent PR](https://github.com/rails/rails/pull/51150) merged into Rails main a few hours ago has broken the primer/view_component test suite, which now reports the `ActionController::TestSession` constant does not exist. This makes sense because the Rails PR in question removed the following line:

```ruby
require "action_controller/test_case"
```

Along with `ActionController::TestCase`, test_case.rb also defines `ActionController::TestSession`. For most test suites, removing these requires is not a problem, since integration tests inherit from the autoloaded `ActionController::TestCase`. When `TestCase` autoloads, so does `TestSession`.

However, view_component lets you render previews from both integration tests _and_ unit tests. If any of your integration tests run first, `TestSession` gets autoloaded and everything works as expected. If a unit test runs first, or if your test suite does not define any integration tests, `TestSession` does not get autoloaded and is not available when `render_preview` is called.

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

I modified the `#vc_test_request` method to always `require "action_controller/test_case"` before attempting to reference the `ActionController::TestSession` constant.