### PR TITLE
Added [Rails Designer](https://railsdesigner.com/) to resources page

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -13,6 +13,7 @@ _Is this page missing a link? Open a PR!_
 - [Primer ViewComponents](https://primer.style/view-components/)
 - [GOV.UK Rails Components](https://govuk-components.netlify.app/)
 - [Polaris ViewComponents](https://github.com/baoagency/polaris_view_components)
+- [Rails Designer](https://railsdesigner.com/)
 
 ## Frameworks using ViewComponent
 


### PR DESCRIPTION
Added [Rails Designer](https://railsdesigner.com/) to resources page under the ViewComponent libraries section. Note that Rails Designer is not OSS, but a commercial product!