### PR TITLE
Fix small grammatical funkiness on ComponentSlot documentation

### DIFF
--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -98,7 +98,7 @@ Arguments passed when calling a component slot will be used to initialize the co
 ```ruby
 # blog_component.rb
 class BlogComponent < ViewComponent::Base
-  # Since `HeaderComponent` is nested inside of this component, we've to
+  # Since `HeaderComponent` is nested inside of this component, we have to
   # reference it as a string instead of a class name.
   renders_one :header, "HeaderComponent"
 


### PR DESCRIPTION
### What are you trying to accomplish?

Small change to docs. `we've to` read very strangely to me, so I pulled apart the contraction.

### What approach did you choose and why?
N/A

### Anything you want to highlight for special attention from reviewers?
N/A