### PR TITLE
Use component path for generating RSpec files

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,16 +12,9 @@ nav_order: 5
 
 * Use component path for generating RSpec files.
 
-  When generating new RSpec files for components, the generator will use the
-  `view_component_path` value in the config to decide where to put the new spec
-  file. For instance, if the `view_component_path` option has been changed to
-  `app/views/components`, the generator will put the spec file in
-  `spec/views/components`. **If the `view_component_path` doesn't start with
-  `app/`, then the generator will fall back to `spec/components/`.**
+  When generating new RSpec files for components, the generator will use the `view_component_path` value in the config to decide where to put the new spec file. For instance, if the `view_component_path` option has been changed to `app/views/components`, the generator will put the spec file in `spec/views/components`. **If the `view_component_path` doesn't start with `app/`, then the generator will fall back to `spec/components/.**`
 
-  This feature is enabled via the
-  `config.view_component.generate.use_component_path_for_rspec_tests`
-  option. Set to `true` to enable this new functionality.
+  This feature is enabled via the `config.view_component.generate.use_component_path_for_rspec_tests` option, defaulting to `false`. The default will change to `true` in ViewComponent v4.
 
     *William Mathewson*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,21 @@ nav_order: 5
 
 ## main
 
+* Use component path for generating RSpec files.
+
+  When generating new RSpec files for components, the generator will use the
+  `view_component_path` value in the config to decide where to put the new spec
+  file. For instance, if the `view_component_path` option has been changed to
+  `app/views/components`, the generator will put the spec file in
+  `spec/views/components`. **If the `view_component_path` doesn't start with
+  `app/`, then the generator will fall back to `spec/components/`.**
+
+  This feature is enabled via the
+  `config.view_component.generate.use_component_path_for_rspec_tests`
+  option. Set to `true` to enable this new functionality.
+
+    *William Mathewson*
+
 ## 3.11.0
 
 * Fix running non-integration tests under Rails main.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,9 +12,9 @@ nav_order: 5
 
 * Use component path for generating RSpec files.
 
-  When generating new RSpec files for components, the generator will use the `view_component_path` value in the config to decide where to put the new spec file. For instance, if the `view_component_path` option has been changed to `app/views/components`, the generator will put the spec file in `spec/views/components`. **If the `view_component_path` doesn't start with `app/`, then the generator will fall back to `spec/components/.**`
+When generating new RSpec files for components, the generator will use the `view_component_path` value in the config to decide where to put the new spec file. For instance, if the `view_component_path` option has been changed to `app/views/components`, the generator will put the spec file in `spec/views/components`. **If the `view_component_path` doesn't start with `app/`, then the generator will fall back to `spec/components/.**`
 
-  This feature is enabled via the `config.view_component.generate.use_component_path_for_rspec_tests` option, defaulting to `false`. The default will change to `true` in ViewComponent v4.
+This feature is enabled via the `config.view_component.generate.use_component_path_for_rspec_tests` option, defaulting to `false`. The default will change to `true` in ViewComponent v4.
 
     *William Mathewson*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ nav_order: 5
 
 * Use component path for generating RSpec files.
 
-When generating new RSpec files for components, the generator will use the `view_component_path` value in the config to decide where to put the new spec file. For instance, if the `view_component_path` option has been changed to `app/views/components`, the generator will put the spec file in `spec/views/components`. **If the `view_component_path` doesn't start with `app/`, then the generator will fall back to `spec/components/.`**
+When generating new RSpec files for components, the generator will use the `view_component_path` value in the config to decide where to put the new spec file. For instance, if the `view_component_path` option has been changed to `app/views/components`, the generator will put the spec file in `spec/views/components`. **If the `view_component_path` doesn't start with `app/`, then the generator will fall back to `spec/components/`.**
 
 This feature is enabled via the `config.view_component.generate.use_component_path_for_rspec_tests` option, defaulting to `false`. The default will change to `true` in ViewComponent v4.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ nav_order: 5
 
 * Use component path for generating RSpec files.
 
-When generating new RSpec files for components, the generator will use the `view_component_path` value in the config to decide where to put the new spec file. For instance, if the `view_component_path` option has been changed to `app/views/components`, the generator will put the spec file in `spec/views/components`. **If the `view_component_path` doesn't start with `app/`, then the generator will fall back to `spec/components/.**`
+When generating new RSpec files for components, the generator will use the `view_component_path` value in the config to decide where to put the new spec file. For instance, if the `view_component_path` option has been changed to `app/views/components`, the generator will put the spec file in `spec/views/components`. **If the `view_component_path` doesn't start with `app/`, then the generator will fall back to `spec/components/.`**
 
 This feature is enabled via the `config.view_component.generate.use_component_path_for_rspec_tests` option, defaulting to `false`. The default will change to `true` in ViewComponent v4.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -217,6 +217,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/milk1000cc?s=64" alt="milk1000cc" width="32" />
 <img src="https://avatars.githubusercontent.com/aduth?s=64" alt="aduth" width="32" />
 <img src="https://avatars.githubusercontent.com/htcarr3?s=64" alt="htcarr3" width="32" />
+<img src="https://avatars.githubusercontent.com/neanias?s=64" alt="neanias" width="32" />
 
 ## Who uses ViewComponent?
 

--- a/lib/rails/generators/rspec/component_generator.rb
+++ b/lib/rails/generators/rspec/component_generator.rb
@@ -1,18 +1,30 @@
 # frozen_string_literal: true
 
+require "rails/generators/abstract_generator"
+
 module Rspec
   module Generators
     class ComponentGenerator < ::Rails::Generators::NamedBase
+      include ViewComponent::AbstractGenerator
+
       source_root File.expand_path("templates", __dir__)
 
       def create_test_file
-        template "component_spec.rb", File.join("spec/components", class_path, "#{file_name}_component_spec.rb")
+        template "component_spec.rb", File.join(spec_component_path, class_path, "#{file_name}_component_spec.rb")
       end
 
       private
 
-      def file_name
-        @_file_name ||= super.sub(/_component\z/i, "")
+      def spec_component_path
+        return "spec/components" unless ViewComponent::Base.config.generate.use_component_path_for_rspec_tests
+
+        configured_component_path = component_path
+        if configured_component_path.start_with?("app#{File::SEPARATOR}")
+          _app, *rest_of_path = Pathname.new(configured_component_path).each_filename.to_a
+          File.join("spec", *rest_of_path)
+        else
+          "spec/components"
+        end
       end
     end
   end

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -79,6 +79,19 @@ module ViewComponent
       # Defaults to `""`. If this is blank, the generator will use
       # `ViewComponent.config.preview_paths` if defined,
       # `"test/components/previews"` otherwise
+      #
+      # #### `#use_component_path_for_rspec_tests`
+      #
+      # Whether to use the `config.view_component_path` when generating new
+      # RSpec component tests:
+      #
+      #     config.view_component.generate.use_component_path_for_rspec_tests = true
+      #
+      # When this is `true`, the generator will use the `view_component_path` as
+      # its guide for deciding where to generate the new RSpec component test.
+      # For example, if the `view_component_path` option has been changed to
+      # `app/views/components`, then the generator will create a new spec file
+      # in `spec/views/components/` rather than the usual `spec/components/`.
 
       # @!attribute preview_controller
       # @return [String]

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -87,11 +87,11 @@ module ViewComponent
       #
       #     config.view_component.generate.use_component_path_for_rspec_tests = true
       #
-      # When this is `true`, the generator will use the `view_component_path` as
-      # its guide for deciding where to generate the new RSpec component test.
-      # For example, if the `view_component_path` option has been changed to
+      # When set to `true`, the generator will use the `view_component_path` to
+      # decide where to generate the new RSpec component test.
+      # For example, if the `view_component_path` is
       # `app/views/components`, then the generator will create a new spec file
-      # in `spec/views/components/` rather than the usual `spec/components/`.
+      # in `spec/views/components/` rather than the default `spec/components/`.
 
       # @!attribute preview_controller
       # @return [String]

--- a/test/sandbox/test/generators/rspec_generator_test.rb
+++ b/test/sandbox/test/generators/rspec_generator_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rails/generators/rspec/component_generator"
+
+Rails.application.load_generators
+
+class RSpecGeneratorTest < Rails::Generators::TestCase
+  tests Rspec::Generators::ComponentGenerator
+  destination Dir.mktmpdir
+  setup :prepare_destination
+
+  def test_generates_component
+    run_generator %w[Dummy data]
+
+    assert_file "spec/components/dummy_component_spec.rb" do |content|
+      assert_match(
+        "RSpec.describe DummyComponent, type: :component do", content
+      )
+    end
+  end
+
+  def test_generates_component_with_unchanged_component_path_with_config_flag
+    with_generate_option(:use_component_path_for_rspec_tests, true) do
+      run_generator %w[Dummy data]
+
+      assert_file "spec/components/dummy_component_spec.rb" do |content|
+        assert_match(
+          "RSpec.describe DummyComponent, type: :component do", content
+        )
+      end
+    end
+  end
+
+  def test_generates_component_with_different_component_path_with_config_flag
+    with_generate_option(:use_component_path_for_rspec_tests, true) do
+      with_custom_component_path("app/views/components") do
+        run_generator %w[Dummy data]
+
+        assert_file "spec/views/components/dummy_component_spec.rb" do |content|
+          assert_match(
+            "RSpec.describe DummyComponent, type: :component do", content
+          )
+        end
+      end
+    end
+  end
+
+  def test_generates_component_with_different_component_path_without_config_flag
+    with_custom_component_path("app/views/components") do
+      run_generator %w[Dummy data]
+
+      assert_file "spec/components/dummy_component_spec.rb" do |content|
+        assert_match(
+          "RSpec.describe DummyComponent, type: :component do", content
+        )
+      end
+    end
+  end
+
+  def test_generates_component_with_non_app_component_path
+    with_generate_option(:use_component_path_for_rspec_tests, true) do
+      with_config_option(:view_component_path, "lib/views/components") do
+        run_generator %w[Dummy data]
+
+        assert_file "spec/components/dummy_component_spec.rb" do |content|
+          assert_match(
+            "RSpec.describe DummyComponent, type: :component do", content
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Generally, the path to an RSpec file should match the app path, but substituting `app` for `spec`. If a user changes the generation path for their components, then the generator should use an appropriate path that matches that. In the example where the user changes the generation path from `app/components` to `app/views/components`, the RSpec component spec should be created in `spec/views/components`.

### What approach did you choose and why?

The logic chosen here checks that the component is still being generated into the `app` dir, otherwise it will just fallback on the usual destination of `spec/components`. I've used simple string matching of `start_with?("app#{File::SEPARATOR}")`, but maybe using something in the `File` or `Pathname` classes would be more flexible.

### Anything you want to highlight for special attention from reviewers?

Since this includes the `AbstractGenerator`, we can remove the `file_name` method as it's provided by the module.

(Hi, Simon!)