### PR TITLE
Update filter in source_location to use base_label

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ nav_order: 5
 
 * Fix templates not being correctly populated when caller location label has a prefix.
 
-On the upstream version of ruby, method owners are now included in backtraces as prefixes. This ruby change caused the callstack filtering to not work as intended, which can lead to `source_location` to be incorrect for child ViewComponents, consequently not populating templates correctly.
+On the upstream version of Ruby, method owners are now included in backtraces as prefixes. This caused the call stack filtering to not work as intended and thus `source_location` to be incorrect for child ViewComponents, consequently not populating templates correctly.
 
     *Allan Pires, Jason Kim*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ nav_order: 5
 
 * Fix templates not being correctly populated when caller location label has a prefix.
 
+On the upstream version of ruby, method owners are now included in backtraces as prefixes. This ruby change caused the callstack filtering to not work as intended, which can lead to `source_location` to be incorrect for child ViewComponents, consequently not populating templates correctly.
+
     *Allan Pires, Jason Kim*
 
 * Use component path for generating RSpec files.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Fix templates not being correctly populated when caller location label has a prefix.
+
+    *Allan Pires, Jason Kim*
+
 * Use component path for generating RSpec files.
 
 When generating new RSpec files for components, the generator will use the `view_component_path` value in the config to decide where to put the new spec file. For instance, if the `view_component_path` option has been changed to `app/views/components`, the generator will put the spec file in `spec/views/components`. **If the `view_component_path` doesn't start with `app/`, then the generator will fall back to `spec/components/`.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -218,6 +218,8 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/aduth?s=64" alt="aduth" width="32" />
 <img src="https://avatars.githubusercontent.com/htcarr3?s=64" alt="htcarr3" width="32" />
 <img src="https://avatars.githubusercontent.com/neanias?s=64" alt="neanias" width="32" />
+<img src="https://avatars.githubusercontent.com/allan-pires?s=64" alt="allan-pires" width="32" />
+<img src="https://avatars.githubusercontent.com/jasonkim?s=64" alt="jasonkim" width="32" />
 
 ## Who uses ViewComponent?
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -537,7 +537,7 @@ module ViewComponent
         # Derive the source location of the component Ruby file from the call stack.
         # We need to ignore `inherited` frames here as they indicate that `inherited`
         # has been re-defined by the consuming application, likely in ApplicationComponent.
-        child.source_location = caller_locations(1, 10).reject { |l| l.label == "inherited" }[0].path
+        child.source_location = caller_locations(1, 10).reject { |l| l.base_label == "inherited" }[0].path
 
         # If Rails application is loaded, removes the first part of the path and the extension.
         if defined?(Rails) && Rails.application

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -537,6 +537,8 @@ module ViewComponent
         # Derive the source location of the component Ruby file from the call stack.
         # We need to ignore `inherited` frames here as they indicate that `inherited`
         # has been re-defined by the consuming application, likely in ApplicationComponent.
+        # We use `base_label` method here instead of `label` to avoid cases where the method
+        # owner is included in a prefix like `ApplicationComponent.inherited`.
         child.source_location = caller_locations(1, 10).reject { |l| l.base_label == "inherited" }[0].path
 
         # If Rails application is loaded, removes the first part of the path and the extension.


### PR DESCRIPTION
### What are you trying to accomplish?

Fix ViewComponent compilation error that happens on a upstream ruby version.

## Why do we need this change?
We need this to make sure templates are being correctly populated in a future ruby release.

The call stack filtering was added by https://github.com/ViewComponent/view_component/pull/281 to correct finding the template for child components. But unfortunately we started to see the following error happening in tests when running against the ruby version https://github.com/ruby/ruby/compare/d4a6c6521aa1a5208939a2cd981a13ca01a07d2a...1232975398a96af3070463292ec0c01e09a06c50:

```
ViewComponent::TemplateError: Couldn't find a template file or inline render method for ApplicationComponent.
    vendor/gems/3.4.0/ruby/3.4.0+0/gems/view_component-3.11.0/lib/view_component/compiler.rb:37:in 'ViewComponent::Compiler#compile'
    vendor/gems/3.4.0/ruby/3.4.0+0/gems/view_component-3.11.0/lib/view_component/base.rb:584:in 'ViewComponent::Base.compile'
    vendor/gems/3.4.0/ruby/3.4.0+0/gems/view_component-3.11.0/lib/view_component/compiler.rb:34:in 'ViewComponent::Compiler#compile'
    vendor/gems/3.4.0/ruby/3.4.0+0/gems/view_component-3.11.0/lib/view_component/base.rb:584:in 'ViewComponent::Base.compile'
    vendor/gems/3.4.0/ruby/3.4.0+0/gems/view_component-3.11.0/lib/view_component/base.rb:72:in 'ViewComponent::Base#render_in'
    vendor/gems/3.4.0/ruby/3.4.0+0/gems/actionview-7.2.0.alpha.94faed4dd4/lib/action_view/template/renderable.rb:16:in 'ActionView::Template::Renderable#render'
```

After some digging looks like this [ruby change](https://github.com/ruby/ruby/pull/9605) adds the method owner in backtraces, which in turn made the [view component filtering](https://github.com/ViewComponent/view_component/blob/main/lib/view_component/base.rb#L540) stop working. The filtering would look for the label `inherited` in the call stack and filter them, but since that ruby change was introduced the label includes the method owner as prefix, so it’s being returned as `ApplicationComponent.inherited`: 

Here's the `caller_locations` on the ruby sha `1232975398a96af3070463292ec0c01e09a06c50` (newer version):
```ruby
"/<redacted>/app/components/application_component.rb:29:in 'ApplicationComponent.inherited'"
"/<redacted>/app/components/<redacted>.rb:5:in '<module:<redacted>>'"
"/<redacted>/app/components/<redacted>.rb:4:in '<top (required)>'"
"<internal:/<redacted>/vendor/ruby/1232975398a96af3070463292ec0c01e09a06c50/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'"
...
```

And here's the `caller_locations` on the ruby sha `5124f9ac7513eb590c37717337c430cb93caa151` (our current version):
```ruby
"/<redacted>/app/components/application_component.rb:29:in `inherited'"
"/<redacted>/app/components/<redacted>.rb:5:in `<module:<redacted>>'"
"/<redacted>/app/components/<redacted>.rb:4:in `<top (required)>'"
"<internal:/<redacted>/vendor/ruby/5124f9ac7513eb590c37717337c430cb93caa151/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'"
...
```

This has caused the filter to stop working and templates to not be correctly populated for the child ViewComponent, which led to the error when trying to compile it.

### What approach did you choose and why?
This goes back to work if instead of filtering by `label` we can use `base_label`, which doesn’t include the method owner prefix.

### Anything you want to highlight for special attention from reviewers?
Thanks for your hard work 😄 