### PR TITLE
Remove offline links from resources.md

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,9 +10,7 @@ nav_order: 5
 
 ## main
 
-* Remove offline links from resource
-
-The `resources.md` file had two offline links and both were removed to keep the file up to date
+* Remove offline links from resources.
 
     *Paulo Henrique Meneses*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ nav_order: 5
 
 ## main
 
+* Remove offline links from resource
+
+The `resources.md` file had two offline links and both were removed to keep the file up to date
+
+    *Paulo Henrique Meneses*
+
 * Fix templates not being correctly populated when caller location label has a prefix.
 
 On the upstream version of Ruby, method owners are now included in backtraces as prefixes. This caused the call stack filtering to not work as intended and thus `source_location` to be incorrect for child ViewComponents, consequently not populating templates correctly.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -31,7 +31,6 @@ _Is this page missing a link? Open a PR!_
 ## Podcasts
 
 - [Code with Jason - ViewComponent with Joel Hawksley, Staff Engineer at GitHub](https://www.codewithjason.com/podcast/9936046-130-viewcomponent-with-joel-hawksley-staff-engineer-at-github/)
-- [Remote Ruby - ViewComponents and the Future of Assets](https://remoteruby.transistor.fm/125)
 - [Ruby Rogues - RUX: JSX-Style Rails View Components](https://topenddevs.com/podcasts/ruby-rogues/episodes/rux-jsx-style-rails-view-components-ruby-517)
 - [Code with Jason - ViewComponent with Joel Hawksley of GitHub](https://www.codewithjason.com/podcast/9478227-088-viewcomponent-with-joel-hawksley-of-github/)
 - [Ruby Rogues - Rethinking the View Layer with Components](https://topenddevs.com/podcasts/ruby-rogues/episodes/rr-461-rethinking-the-view-layer-with-components-with-joel-hawksley)

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -31,6 +31,7 @@ _Is this page missing a link? Open a PR!_
 ## Podcasts
 
 - [Code with Jason - ViewComponent with Joel Hawksley, Staff Engineer at GitHub](https://www.codewithjason.com/podcast/9936046-130-viewcomponent-with-joel-hawksley-staff-engineer-at-github/)
+- [Remote Ruby - ViewComponents and the Future of Assets](https://www.remoteruby.com/2260490/13761017-viewcomponents-and-the-future-of-assets-with-joel-hawksley)
 - [Ruby Rogues - RUX: JSX-Style Rails View Components](https://topenddevs.com/podcasts/ruby-rogues/episodes/rux-jsx-style-rails-view-components-ruby-517)
 - [Code with Jason - ViewComponent with Joel Hawksley of GitHub](https://www.codewithjason.com/podcast/9478227-088-viewcomponent-with-joel-hawksley-of-github/)
 - [Ruby Rogues - Rethinking the View Layer with Components](https://topenddevs.com/podcasts/ruby-rogues/episodes/rr-461-rethinking-the-view-layer-with-components-with-joel-hawksley)

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -50,7 +50,6 @@ _Is this page missing a link? Open a PR!_
 
 ## Articles
 
-- [Ruby-on-Rails ViewComponents tutorial and examples](https://www.bootrails.com/blog/ruby-on-rails-viewcomponents-tutorial-and-examples/)
 - [From partials to ViewComponents: writing reusable front-end code in Rails](https://dev.to/nejremeslnici/from-partials-to-viewcomponents-writing-reusable-front-end-code-in-rails-1c9o)
 - [Snapshot testing ViewComponents with RSpec](https://www.bearer.com/blog/snapshot-testing-viewcomponents-with-rspec)
 - [Don't Cloud Your View With Logic.](https://www.beflagrant.com/blog/dont-cloud-view-with-logic)


### PR DESCRIPTION
### Offline links:
- https://www.bootrails.com/blog/ruby-on-rails-viewcomponents-tutorial-and-examples/
- https://remoteruby.transistor.fm/125

### What are you trying to accomplish?

Remove offline links from `resources.md`

### What approach did you choose and why?

I went through all available links on the resources file to learn more about View Component and noticed some of them were unavailable. It will help keep the resources up to date

### Anything you want to highlight for special attention from reviewers?