### PR TITLE
CHANGELOG.md: Fix multi-line entries re indent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,15 +28,15 @@ nav_order: 5
 
 * Fix templates not being correctly populated when caller location label has a prefix.
 
-On the upstream version of Ruby, method owners are now included in backtraces as prefixes. This caused the call stack filtering to not work as intended and thus `source_location` to be incorrect for child ViewComponents, consequently not populating templates correctly.
+  On the upstream version of Ruby, method owners are now included in backtraces as prefixes. This caused the call stack filtering to not work as intended and thus `source_location` to be incorrect for child ViewComponents, consequently not populating templates correctly.
 
     *Allan Pires, Jason Kim*
 
 * Use component path for generating RSpec files.
 
-When generating new RSpec files for components, the generator will use the `view_component_path` value in the config to decide where to put the new spec file. For instance, if the `view_component_path` option has been changed to `app/views/components`, the generator will put the spec file in `spec/views/components`. **If the `view_component_path` doesn't start with `app/`, then the generator will fall back to `spec/components/`.**
+  When generating new RSpec files for components, the generator will use the `view_component_path` value in the config to decide where to put the new spec file. For instance, if the `view_component_path` option has been changed to `app/views/components`, the generator will put the spec file in `spec/views/components`. **If the `view_component_path` doesn't start with `app/`, then the generator will fall back to `spec/components/`.**
 
-This feature is enabled via the `config.view_component.generate.use_component_path_for_rspec_tests` option, defaulting to `false`. The default will change to `true` in ViewComponent v4.
+  This feature is enabled via the `config.view_component.generate.use_component_path_for_rspec_tests` option, defaulting to `false`. The default will change to `true` in ViewComponent v4.
 
     *William Mathewson*
 
@@ -60,7 +60,7 @@ This feature is enabled via the `config.view_component.generate.use_component_pa
 
 * Include ViewComponent::UseHelpers by default.
 
-      *Reegan Viljoen*
+    *Reegan Viljoen*
 
 * Bump `puma` in Gemfile.lock.
 


### PR DESCRIPTION


### What are you trying to accomplish?

Before this, the names in some Changelog entries were seen as "verbatim code sections".

Also, one instance of wrong indent fixed.


### What approach did you choose and why?

I pen-edited this on GitHub, using preview to make sure it looked right.

### Anything you want to highlight for special attention from reviewers?

None.