### PR TITLE
Fix Rails main in CI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ nav_order: 5
 
     *Reegan Viljoen*
 
-* Fixed Ci for Rails main.
+* Fixed CI for Rails main.
 
     *Reegan Viljoen*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ nav_order: 5
 
     *Reegan Viljoen*
 
+* Fixed Ci for Rails main.
+
+    *Reegan Viljoen*
+
 ## 3.12.1
 
 * Ensure content is rendered correctly for forwarded slots.

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -563,7 +563,7 @@ class RenderingTest < ViewComponent::TestCase
         render_inline(ExceptionInTemplateComponent.new)
       end
 
-    component_error_index = Rails::VERSION::STRING < '8.0' ? 0 : 1
+    component_error_index = (Rails::VERSION::STRING < "8.0") ? 0 : 1
     assert_match %r{app/components/exception_in_template_component\.html\.erb:2}, error.backtrace[component_error_index]
   end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -562,8 +562,8 @@ class RenderingTest < ViewComponent::TestCase
       assert_raises NameError do
         render_inline(ExceptionInTemplateComponent.new)
       end
-
-    assert_match %r{app/components/exception_in_template_component\.html\.erb:2}, error.backtrace[0]
+    component_error_index = Rails::VERSION::STRING > '7.1' ? 1 : 0
+    assert_match %r{app/components/exception_in_template_component\.html\.erb:2}, error.backtrace[component_error_index]
   end
 
   def test_render_collection

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -562,7 +562,7 @@ class RenderingTest < ViewComponent::TestCase
       assert_raises NameError do
         render_inline(ExceptionInTemplateComponent.new)
       end
-    component_error_index = Rails::VERSION::STRING > '7.1' ? 1 : 0
+    component_error_index = Rails::VERSION::STRING >= '7.1' ? 1 : 0
     assert_match %r{app/components/exception_in_template_component\.html\.erb:2}, error.backtrace[component_error_index]
   end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -562,7 +562,8 @@ class RenderingTest < ViewComponent::TestCase
       assert_raises NameError do
         render_inline(ExceptionInTemplateComponent.new)
       end
-    component_error_index = Rails::VERSION::STRING >= '7.1' ? 1 : 0
+
+    component_error_index = Rails::VERSION::STRING < '8.0' ? 0 : 1
     assert_match %r{app/components/exception_in_template_component\.html\.erb:2}, error.backtrace[component_error_index]
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fix the failing Rails main CI tests

### What approach did you choose and why?

Rails added an extra entry in the first position of the `error.backtrace array`
here is an example of the error in the first position of teh array
```
/bundler/gems/rails/railties/lib/rails/engine/route_set.rb:26:in `method_missing’”
```