### PR TITLE
Remove exception for Rails 8

### DIFF
--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -563,8 +563,7 @@ class RenderingTest < ViewComponent::TestCase
         render_inline(ExceptionInTemplateComponent.new)
       end
 
-    component_error_index = (Rails::VERSION::STRING < "8.0") ? 0 : 1
-    assert_match %r{app/components/exception_in_template_component\.html\.erb:2}, error.backtrace[component_error_index]
+    assert_match %r{app/components/exception_in_template_component\.html\.erb:2}, error.backtrace.first
   end
 
   def test_render_collection


### PR DESCRIPTION
It appears as though the change in backtrace behavior we were working around in this test has been removed, so we are OK to revert the test back to its single mode.