### PR TITLE
Add slot methods to a module instead of the component class itself

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Allow overridden slot methods to use `super` to call the standard implementation.
+* Allow overridden slot methods to use `super`.
 
     *Andrew Schwartz*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Allow overridden slot methods to use `super` to call the standard implementation.
+
+    *Andrew Schwartz*
+
 * Defer to built-in caching for language environment setup, rather than manually using `actions/cache` in CI.
 
     *Simon Fish*

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -42,14 +42,15 @@ The codespace environment includes a minimal Rails app with ViewComponent instal
 ## Submitting a pull request
 
 1. [Fork](https://github.com/viewcomponent/view_component/fork) and clone the repository.
-1. Configure and install the dependencies: `bundle exec appraisal install`.
-2. Make sure the tests pass: `bundle exec appraisal rake` (see below for specific cases).
-3. Create a new branch: `git checkout -b my-branch-name`.
-4. Add tests, make the change, and make sure the tests still pass.
-5. Add an entry to the top of `docs/CHANGELOG.md` for the changes, no matter how small.
-6. If it's your first time contributing, add yourself to `docs/index.md`.
-7. Push to the fork and [submit a pull request](https://github.com/viewcomponent/view_component/compare).
-8. Wait for the pull request to be reviewed and merged.
+1. Configure and install local dependencies: `bundle install`.
+1. Configure and install testing dependencies: `bundle exec appraisal install`.
+1. Make sure the tests pass: `bundle exec appraisal rake` (see below for specific cases).
+1. Create a new branch: `git checkout -b my-branch-name`.
+1. Add tests, make the change, and make sure the tests still pass.
+1. Add an entry to the top of `docs/CHANGELOG.md` for the changes, no matter how small.
+1. If it's your first time contributing, add yourself to `docs/index.md`.
+1. Push to the fork and [submit a pull request](https://github.com/viewcomponent/view_component/compare).
+1. Wait for the pull request to be reviewed and merged.
 
 ### Running a subset of tests
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -42,15 +42,14 @@ The codespace environment includes a minimal Rails app with ViewComponent instal
 ## Submitting a pull request
 
 1. [Fork](https://github.com/viewcomponent/view_component/fork) and clone the repository.
-1. Configure and install local dependencies: `bundle install`.
-1. Configure and install testing dependencies: `bundle exec appraisal install`.
-1. Make sure the tests pass: `bundle exec appraisal rake` (see below for specific cases).
-1. Create a new branch: `git checkout -b my-branch-name`.
-1. Add tests, make the change, and make sure the tests still pass.
-1. Add an entry to the top of `docs/CHANGELOG.md` for the changes, no matter how small.
-1. If it's your first time contributing, add yourself to `docs/index.md`.
-1. Push to the fork and [submit a pull request](https://github.com/viewcomponent/view_component/compare).
-1. Wait for the pull request to be reviewed and merged.
+1. Configure and install the dependencies: `bundle exec appraisal install`.
+2. Make sure the tests pass: `bundle exec appraisal rake` (see below for specific cases).
+3. Create a new branch: `git checkout -b my-branch-name`.
+4. Add tests, make the change, and make sure the tests still pass.
+5. Add an entry to the top of `docs/CHANGELOG.md` for the changes, no matter how small.
+6. If it's your first time contributing, add yourself to `docs/index.md`.
+7. Push to the fork and [submit a pull request](https://github.com/viewcomponent/view_component/compare).
+8. Wait for the pull request to be reviewed and merged.
 
 ### Running a subset of tests
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -182,6 +182,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/nicolas-brousse?s=64" alt="nicolas-brousse" width="32" />
 <img src="https://avatars.githubusercontent.com/nielsslot?s=64" alt="nshki" width="32" />
 <img src="https://avatars.githubusercontent.com/nshki?s=64" alt="nshki" width="32" />
+<img src="https://avatars.githubusercontent.com/ozydingo?s=64" alt="ozydingo" width="32" />
 <img src="https://avatars.githubusercontent.com/patrickarnett?s=64" alt="patrickarnett" width="32" />
 <img src="https://avatars.githubusercontent.com/rainerborene?s=64" alt="rainerborene" width="32" />
 <img src="https://avatars.githubusercontent.com/rdavid1099?s=64" alt="rdavid1099" width="32" />

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -89,11 +89,11 @@ module ViewComponent
           end
           ruby2_keywords(setter_method_name) if respond_to?(:ruby2_keywords, true)
 
-          define_method slot_name do
+          self::GeneratedSlotMethods.define_method slot_name do
             get_slot(slot_name)
           end
 
-          define_method :"#{slot_name}?" do
+          self::GeneratedSlotMethods.define_method :"#{slot_name}?" do
             get_slot(slot_name).present?
           end
 
@@ -176,11 +176,11 @@ module ViewComponent
             end
           end
 
-          define_method slot_name do
+          self::GeneratedSlotMethods.define_method slot_name do
             get_slot(slot_name)
           end
 
-          define_method :"#{slot_name}?" do
+          self::GeneratedSlotMethods.define_method :"#{slot_name}?" do
             get_slot(slot_name).present?
           end
 
@@ -199,19 +199,28 @@ module ViewComponent
         end
       end
 
-      # Clone slot configuration into child class
-      # see #test_slots_pollution
       def inherited(child)
+        # Clone slot configuration into child class
+        # see #test_slots_pollution
         child.registered_slots = registered_slots.clone
+
+        # Add a module for slot methods, allowing them to be overriden by the component class
+        # see #test_slot_name_can_be_overriden
+        unless child.const_defined?(:GeneratedSlotMethods, false)
+          generated_slot_methods = Module.new
+          child.const_set(:GeneratedSlotMethods, generated_slot_methods)
+          child.include generated_slot_methods
+        end
+
         super
       end
 
       def register_polymorphic_slot(slot_name, types, collection:)
-        define_method(slot_name) do
+        self::GeneratedSlotMethods.define_method(slot_name) do
           get_slot(slot_name)
         end
 
-        define_method(:"#{slot_name}?") do
+        self::GeneratedSlotMethods.define_method(:"#{slot_name}?") do
           get_slot(slot_name).present?
         end
 

--- a/test/sandbox/app/components/slot_name_override_component.html.erb
+++ b/test/sandbox/app/components/slot_name_override_component.html.erb
@@ -1,0 +1,7 @@
+<div class="card <%= @classes %>">
+  <% if title? %>
+  <div class="title">
+    <%= title %>
+  </div>
+  <% end %>
+</div>

--- a/test/sandbox/app/components/slot_name_override_component.rb
+++ b/test/sandbox/app/components/slot_name_override_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class SlotNameOverrideComponent < ViewComponent::Base
+  renders_one :title
+
+  def initialize(title: nil)
+    @title = title
+  end
+
+  def title
+    @title || super
+  end
+
+  def title?
+    @title.present? || super
+  end
+end
+
+class SlotNameOverrideComponent::OtherComponent < ViewComponent::Base
+  renders_one :title
+end
+
+class SlotNameOverrideComponent::SubComponent < SlotNameOverrideComponent
+  def title
+    super.upcase
+  end
+end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -785,4 +785,38 @@ class SlotableTest < ViewComponent::TestCase
 
     assert_text "hello,world!", count: 1
   end
+
+  def test_slot_name_can_be_overriden
+    # Uses overridden `title` slot method
+    render_inline(SlotNameOverrideComponent.new(title: "Simple Title"))
+
+    assert_selector(".title", text: "Simple Title")
+  end
+
+  def test_slot_name_override_can_use_super
+    # Uses standard `title` slot method via `super`
+    render_inline(SlotNameOverrideComponent.new) do |component|
+      component.with_title do
+        "Block Title with More Complexity"
+      end
+    end
+
+    assert_selector(".title", text: "Block Title with More Complexity")
+  end
+
+  def overriden_slot_name_predicate_returns_false_when_not_set
+    render_inline(SlotNameOverrideComponent.new)
+
+    refute_selector(".title")
+  end
+
+  def test_overridden_slot_name_can_be_inherited
+    render_inline(SlotNameOverrideComponent::SubComponent.new(title: "lowercase"))
+
+    assert_selector(".title", text: "LOWERCASE")
+  end
+
+  def test_slot_name_methods_are_not_shared_accross_components
+    assert_not_equal SlotsComponent.instance_method(:title).owner, SlotNameOverrideComponent::OtherComponent.instance_method(:title).owner
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Addresses #2027:

- Define slot methods in a dynamic module so that slot name methods can be overridden with ability to call `super`

### What approach did you choose and why?

- Inspired by ActiveRecord's naming of `GeneratedAttributeMethods`, I am choosing the name `GeneratedSlotMethods`
- Define a new module and set it to the const `self::GeneratedSlotMethods` in the `inherited` hook defined by `ViewComponent::Slotable`, similar to how ActiveRecord creates `<model>::GeneratedAttributeMethods`.
- include `self::GeneratedSlotMethods` in the same inherited hook
- define the `<slot>` and `<slot>?` methods on the module

### TODO

- [x] FIX: Use the `inherited` hook and not the `included` hook; `ViewComponent::Slotable` is included only once by `ViewComponent::Base`
- [x] Add test to make sure independent components do not share methods
- [x] Ensure component subclasses that define their own slots also inherit superclass slot methods
- [x] Investigate other slottable dynamic methods (currently commented out)

### Anything you want to highlight for special attention from reviewers?

- ~Added a step in CONTRIBUTING to `bundle install`, with the goal of installing appraisal (otherwise `bundle exec appraisal install` would fail)~
- Running `bundle exec appraisal install` modified the gemfiles and I'm not sure why. I have no experience with appraisal. I imagine I will need to revert these changes, ~but I'm keeping them on the branch for now since if I revert I can't run tests, and also to ask about it.~