### PR TITLE
Streamline CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.3
     - uses: actions/cache@v4
       with:
         path: vendor/bundle
-        key: gems-build-rails-main-ruby-2.7-${{ hashFiles('**/Gemfile.lock') }}
+        key: gems-build-rails-main-ruby-3.3-${{ hashFiles('**/Gemfile.lock') }}
     - name: Run benchmarks
       run: |
         bundle config path vendor/bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,13 +143,13 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.3
     - name: Download coverage results
       uses: actions/download-artifact@v3
     - uses: actions/cache@v4
       with:
         path: vendor/bundle
-        key: gems-build-rails-main-ruby-2.7-${{ hashFiles('**/Gemfile.lock') }}
+        key: gems-build-rails-main-ruby-3.3-${{ hashFiles('**/Gemfile.lock') }}
     - name: Collate simplecov
       run: |
         bundle config path vendor/bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails_version: ["6.1", "7.0", "7.1", "main"]
-        ruby_version: ["3.1", "3.2", "3.3", "head"]
-        mode: ["capture_patch_enabled", "capture_patch_disabled"]
-        yjit_mode: ['1', '0']
         include:
-          # Run against all previously supported Rails versions for Ruby 3.0
           - ruby_version: "3.0"
             rails_version: "6.1"
             mode: "capture_patch_enabled"
@@ -45,64 +40,38 @@ jobs:
             rails_version: "6.1"
             mode: "capture_patch_disabled"
             yjit_mode: '0'
-          - ruby_version: "3.0"
+          - ruby_version: "3.1"
             rails_version: "7.0"
             mode: "capture_patch_enabled"
-            yjit_mode: '0'
-          - ruby_version: "3.0"
+            yjit_mode: '1'
+          - ruby_version: "3.1"
             rails_version: "7.0"
             mode: "capture_patch_disabled"
             yjit_mode: '0'
-          - ruby_version: "3.0"
+          - ruby_version: "3.2"
             rails_version: "7.1"
             mode: "capture_patch_enabled"
             yjit_mode: '0'
-          - ruby_version: "3.0"
+          - ruby_version: "3.2"
             rails_version: "7.1"
             mode: "capture_patch_disabled"
-            yjit_mode: '0'
-        exclude:
-          # Dont run YJIT and Ruby head against Rails 6.1
-          - rails_version: "6.1"
-            ruby_version: "3.1"
+            yjit_mode: '1'
+          - ruby_version: "3.3"
+            rails_version: "7.1"
             mode: "capture_patch_enabled"
             yjit_mode: '1'
-          - rails_version: "6.1"
-            ruby_version: "3.1"
+          - ruby_version: "3.3"
+            rails_version: "7.1"
             mode: "capture_patch_disabled"
             yjit_mode: '1'
-          - rails_version: "6.1"
-            ruby_version: "3.2"
+          - ruby_version: "head"
+            rails_version: "main"
+            mode: "capture_patch_disabled"
+            yjit_mode: '1'
+          - ruby_version: "head"
+            rails_version: "main"
             mode: "capture_patch_enabled"
             yjit_mode: '1'
-          - rails_version: "6.1"
-            ruby_version: "3.2"
-            mode: "capture_patch_disabled"
-            yjit_mode: '1'
-          - rails_version: "6.1"
-            ruby_version: "3.3"
-            mode: "capture_patch_enabled"
-            yjit_mode: '1'
-          - rails_version: "6.1"
-            ruby_version: "3.3"
-            mode: "capture_patch_disabled"
-            yjit_mode: '1'
-          - rails_version: "6.1"
-            ruby_version: "head"
-            mode: "capture_patch_enabled"
-            yjit_mode: '1'
-          - rails_version: "6.1"
-            ruby_version: "head"
-            mode: "capture_patch_enabled"
-            yjit_mode: '0'
-          - rails_version: "6.1"
-            ruby_version: "head"
-            mode: "capture_patch_disabled"
-            yjit_mode: '1'
-          - rails_version: "6.1"
-            ruby_version: "head"
-            mode: "capture_patch_disabled"
-            yjit_mode: '0'
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails_version }}.gemfile
     steps:


### PR DESCRIPTION
In our experience, it's not been useful to have so many permutations
of rails/ruby/etc tested in CI. Let's pare things down to a few
representative combinations <3

https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs

I also took the liberty of bumping the Ruby version we use for benchmarks/coverage to 3.3.