### PR TITLE
Update 0003-polymorphic-slot-definitions.md

### DIFF
--- a/docs/adrs/0003-polymorphic-slot-definitions.md
+++ b/docs/adrs/0003-polymorphic-slot-definitions.md
@@ -52,7 +52,6 @@ Here's how the `Item` sub-component of the list example above would be implement
 
 ```ruby
 class Item < ViewComponent::Base
-  include ViewComponent::PolymorphicSlots
 
   renders_one :leading_visual, types: {
     icon: IconComponent, avatar: AvatarComponent


### PR DESCRIPTION
Removed `include ViewComponent::PolymorphicSlots` as this is not necessary anymore

### What are you trying to accomplish?

Update documentation to remove unnecessary code in an example

### What approach did you choose and why?

I selected it and hit del key

### Anything you want to highlight for special attention from reviewers?