### PR TITLE
Component generator: warn new users to restart Rails after they create their first component

### DIFF
--- a/lib/rails/generators/abstract_generator.rb
+++ b/lib/rails/generators/abstract_generator.rb
@@ -29,6 +29,10 @@ module ViewComponent
     end
 
     def component_path
+      if !File.exist?(ViewComponent::Base.config.view_component_path)
+        warning_text = "The folder '#{ViewComponent::Base.config.view_component_path}' does not exist and it will be created now.\nPlease note that you will need to restart your Rails server before Rails can load your new component."
+        puts "\e[33m#{warning_text}\e[0m"
+      end
       ViewComponent::Base.config.view_component_path
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

New users can encounter an Uninitialized Constant after they create their first component, as Zeitwerk (current Rails autoloader) will not have `app/components` in the known paths until the Rails server is restarted. Thanks to @Insti for the help debugging this and @Spone for introducing me to view components in BalticRuby.

This is the expected output:

![Screenshot_20240615_075124](https://github.com/ViewComponent/view_component/assets/452823/cfd66b9c-fd7f-4ae1-aec7-2f9704e7c70b)


### What approach did you choose and why?

Our first idea was to use Zeitwerk's `push_dir` to add the dir to the known folders, but we realized that the running Rails server is completely separate from the generator.

We also thought about making Zeitwerk check for new folders, but it seems like that would clash with their design philosophy.

So we decided to try printing a warning if the folder does not exist and it's about to be created.

### Anything you want to highlight for special attention from reviewers?

I'm not sure this is the best place to print this warning, but I couldn't find the exact place where the first app/components file is created.