### PR TITLE
Add ability to put previews into sidecar directory

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+## 3.13.1
+
+* Look for preview files that end in `preview.rb` rather than `_preview.rb`, so they can be put in the sidecar directory.
+
 ## 3.13.0
 
 * Add ruby head and YJIT to CI.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Look for preview files that end in `preview.rb` rather than `_preview.rb`, so they can be put in the sidecar directory alongside test files.
+* Look for preview files that end in `preview.rb` rather than `_preview.rb` to allow previews to exist in sidecar directory with test files.
 
     *Seth Herr*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,9 +10,9 @@ nav_order: 5
 
 ## main
 
-## 3.13.1
-
 * Look for preview files that end in `preview.rb` rather than `_preview.rb`, so they can be put in the sidecar directory alongside test files.
+
+    *Seth Herr*
 
 ## 3.13.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ nav_order: 5
 
 ## 3.13.1
 
-* Look for preview files that end in `preview.rb` rather than `_preview.rb`, so they can be put in the sidecar directory.
+* Look for preview files that end in `preview.rb` rather than `_preview.rb`, so they can be put in the sidecar directory alongside test files.
 
 ## 3.13.0
 

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -102,7 +102,7 @@ module ViewComponent # :nodoc:
 
       def load_previews
         Array(preview_paths).each do |preview_path|
-          Dir["#{preview_path}/**/*_preview.rb"].sort.each { |file| require_dependency file }
+          Dir["#{preview_path}/**/*preview.rb"].sort.each { |file| require_dependency file }
         end
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Enable putting previews (`preview.rb` files) into the sidecar directory.

Organizing components into subdirectories (AKA sidecar) is a helpful way of organizing view components.

The organizing strategy of [view_component-contrib](https://github.com/palkan/view_component-contrib) puts the previews into the sidecar directory, and organizes an example component like this:

```
components/
  example/
    component.html
    component.rb
    preview.rb
    index.css
    index.js
```

Currently, `view_component-contrib` uses an initializer to enable this behavior - making this change would make it possible without an initializer.

Personally, I think it makes sense to organize the test folder in the same extended sidecar way and put the previews in there:

```
spec/
  components/
    example/
      component_spec.rb
      preview.rb
```

But either way, the previews are named `preview.rb` - so the matcher in `lib/view_component/preview.rb` needs to be updated to no longer have a `_` prefix.

<!-- Provide a description of the changes. Link to any related issues or projects. -->

### What approach did you choose and why?

This doesn't change the behavior of the generators, it only makes it so that if you decide to put the previews in the sidecar directory, it will be found. I wanted to make the smallest possible change that would enable the functionality.

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?