### PR TITLE
set default ruby version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
       env:
         RAISE_ON_WARNING: 1
         RAILS_VERSION: ${{ matrix.rails_version }}
+        RUBY_VERSION: ${{ matrix.ruby_version }}
         CAPTURE_PATCH_ENABLED: ${{ matrix.mode == 'capture_patch_enabled' && 'true' || 'false' }}
     - name: Upload coverage results
       uses: actions/upload-artifact@v3.1.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2
+        ruby-version: 3.3
     - uses: actions/cache@v4
       with:
         path: vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ gemspec
 
 rails_version = (ENV["RAILS_VERSION"] || "~> 7.0.0").to_s
 gem "rails", (rails_version == "main") ? {git: "https://github.com/rails/rails", ref: "main"} : rails_version
+
+ruby_version = (ENV["RUBY_VERSION"] || "~> 3.3").to_s
+ruby ruby_version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,5 +365,8 @@ DEPENDENCIES
   yard (~> 0.9.34)
   yard-activesupport-concern (~> 0.0.1)
 
+RUBY VERSION
+   ruby 3.3.0p0
+
 BUNDLED WITH
    2.5.3


### PR DESCRIPTION
While working on resolving some dependabot alerts, I noticed that dependabot could not resolve our Ruby dependency files because it was using Ruby 2.7.6. This PR attempts to set a Ruby version explicitly so that Dependabot does not just use 2.7.6.