### PR TITLE
BREAKING: v4 minimum Ruby version should not be EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby_version: "3.0"
+          - ruby_version: "3.1"
             rails_version: "6.1"
             mode: "capture_patch_enabled"
-          - ruby_version: "3.0"
+          - ruby_version: "3.1"
             rails_version: "6.1"
             mode: "capture_patch_disabled"
           - ruby_version: "3.1"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ nav_order: 5
 
 ## 4.0.0
 
+* BREAKING: Require [non-EOL](https://www.ruby-lang.org/en/downloads/branches/) Ruby (`>= 3.1.0`).
+
+  * Joel Hawksley*
+
 * Add Kicksite to list of companies using ViewComponent.
 
    *Adil Lari*

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["LICENSE.txt", "README.md", "app/**/*", "docs/CHANGELOG.md", "lib/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_runtime_dependency "activesupport", [">= 5.2.0", "< 8.0"]
   spec.add_runtime_dependency "method_source", "~> 1.0"
@@ -60,9 +60,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard", "~> 0.9.34"
   spec.add_development_dependency "yard-activesupport-concern", "~> 0.0.1"
 
-  if RUBY_VERSION >= "3.1"
-    spec.add_development_dependency "net-imap"
-    spec.add_development_dependency "net-pop"
-    spec.add_development_dependency "net-smtp"
-  end
+  spec.add_development_dependency "net-imap"
+  spec.add_development_dependency "net-pop"
+  spec.add_development_dependency "net-smtp"
 end


### PR DESCRIPTION
**This PR targets the v4 feature branch**

### What are you trying to accomplish?

As time marches on, older versions of Ruby are EOL'd. We should align ourselves with this schedule to ensure our tooling can function properly. For example, we cannot use `dependabot` properly until we make this change.