### PR TITLE
BREAKING: v4 minimum Rails version should not be EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,6 @@ jobs:
       matrix:
         include:
           - ruby_version: "3.1"
-            rails_version: "6.1"
-            mode: "capture_patch_enabled"
-          - ruby_version: "3.1"
-            rails_version: "6.1"
-            mode: "capture_patch_disabled"
-          - ruby_version: "3.1"
             rails_version: "7.0"
             mode: "capture_patch_enabled"
           - ruby_version: "3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     view_component (3.14.0)
-      activesupport (>= 5.2.0, < 8.0)
+      activesupport (>= 7.0.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,13 +12,17 @@ nav_order: 5
 
 ## 4.0.0
 
+* BREAKING: Require [non-EOL](https://endoflife.date/rails) Rails (`>= 7.0.0`).
+
+    *Joel Hawksley*
+
 * BREAKING: Require [non-EOL](https://www.ruby-lang.org/en/downloads/branches/) Ruby (`>= 3.1.0`).
 
-  * Joel Hawksley*
+    *Joel Hawksley*
 
 * Add Kicksite to list of companies using ViewComponent.
 
-   *Adil Lari*
+    *Adil Lari*
 
 * Allow overridden slot methods to use `super`.
 

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.1.0"
 
-  spec.add_runtime_dependency "activesupport", [">= 5.2.0", "< 8.0"]
+  spec.add_runtime_dependency "activesupport", [">= 7.0.0", "< 8.0"]
   spec.add_runtime_dependency "method_source", "~> 1.0"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_development_dependency "appraisal", "~> 2.4"


### PR DESCRIPTION
Same as https://github.com/ViewComponent/view_component/pull/2086, but for Rails.