### PR TITLE
WIP: Extract strict_helpers_enabled? to component-local config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -95,7 +95,7 @@ namespace :docs do
     require "rails"
     require "action_controller"
     require "view_component"
-    ViewComponent::Base.config.view_component_path = "view_component"
+    ViewComponent::GlobalConfig.view_component_path = "view_component"
     require "view_component/docs_builder_component"
 
     error_keys = registry.keys.select { |key| key.to_s.include?("Error::MESSAGE") }.map(&:to_s)

--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -47,12 +47,12 @@ module ViewComponent
 
     # :doc:
     def default_preview_layout
-      ViewComponent::Base.config.default_preview_layout
+      GlobalConfig.default_preview_layout
     end
 
     # :doc:
     def show_previews?
-      ViewComponent::Base.config.show_previews
+      GlobalConfig.show_previews
     end
 
     # :doc:
@@ -95,7 +95,7 @@ module ViewComponent
     end
 
     def prepend_preview_examples_view_path
-      prepend_view_path(ViewComponent::Base.preview_paths)
+      prepend_view_path(GlobalConfig.preview_paths)
     end
   end
 end

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -35,7 +35,7 @@ module PreviewHelper
       # Fetch template source via finding it through preview paths
       # to accomodate source view when exclusively using templates
       # for previews for Rails < 6.1.
-      all_template_paths = ViewComponent::Base.config.preview_paths.map do |preview_path|
+      all_template_paths = ViewComponent::GlobalConfig.preview_paths.map do |preview_path|
         Dir.glob("#{preview_path}/**/*")
       end.flatten
 
@@ -80,6 +80,6 @@ module PreviewHelper
   # :nocov:
 
   def serve_static_preview_assets?
-    ViewComponent::Base.config.show_previews && Rails.application.config.public_file_server.enabled
+    ViewComponent::GlobalConfig.show_previews && Rails.application.config.public_file_server.enabled
   end
 end

--- a/app/views/view_components/preview.html.erb
+++ b/app/views/view_components/preview.html.erb
@@ -1,5 +1,5 @@
 <% if @render_args[:component] %>
-  <% if ViewComponent::Base.config.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 %>
+  <% if ViewComponent::GlobalConfig.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 %>
     <%= render(@render_args[:component], @render_args[:args], &@render_args[:block]) %>
   <% else %>
     <%= render_component(@render_args[:component], &@render_args[:block]) %>
@@ -8,6 +8,6 @@
   <%= render template: @render_args[:template], locals: @render_args[:locals] || {} %>
 <% end %>
 
-<% if ViewComponent::Base.config.show_previews_source %>
+<% if ViewComponent::GlobalConfig.show_previews_source %>
   <%= preview_source %>
 <% end %>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Add Strict helpers mode.
+* Add `helpers_enabled` config.
 
     *Reegan Viljoen*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ nav_order: 5
 
 ## main
 
+* Make accommodations for component-local config to be introduced in future.
+
+  BREAKING: Assigning to `ViewComponent::Base.config` will no longer work. Instead, assign to `Rails.application.config`.
+
+    *Simon Fish*
+
 * Use struct instead openstruct in lib code.
 
     *Oleksii Vasyliev*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ nav_order: 5
 
     *Reegan Viljoen*
 
-* Make `use_helpers` a default method for all components
+* Include ViewComponent::UseHelpers by default.
 
     *Reegan Viljoen*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add Strict helpers mode.
+
+    *Reegan Viljoen*
+
 * Make `use_helpers` a default method for all components
 
     *Reegan Viljoen*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Make `use_helpers` a default method for all components
+
+    *Reegan Viljoen*
+
 * Make accommodations for component-local config to be introduced in future.
 
   BREAKING: Assigning to `ViewComponent::Base.config` will no longer work. Instead, assign to `Rails.application.config`.

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -55,7 +55,7 @@ end
 
 By default, ViewComponents don't have access to helper methods defined externally. The `use_helpers` method allows external helpers to be called from the component.
 
-`use_helpers` defines the helper on the component, similar to `delegate`:
+`use_helpers` defines the helper on the component and is similar in use to using `delegate` on helpers.
 
 ```ruby
 class UseHelpersComponent < ViewComponent::Base

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -55,7 +55,7 @@ end
 
 By default, ViewComponents don't have access to helper methods defined externally. The `use_helpers` method allows external helpers to be called from the component.
 
-`use_helpers` defines the helper on the component and is similar in use to using `delegate` on helpers.
+`use_helpers` defines the helper on the component, similar to `delegate`:
 
 ```ruby
 class UseHelpersComponent < ViewComponent::Base

--- a/lib/rails/generators/abstract_generator.rb
+++ b/lib/rails/generators/abstract_generator.rb
@@ -29,7 +29,7 @@ module ViewComponent
     end
 
     def component_path
-      ViewComponent::Base.config.view_component_path
+      GlobalConfig.view_component_path
     end
 
     def stimulus_controller
@@ -42,15 +42,15 @@ module ViewComponent
     end
 
     def sidecar?
-      options["sidecar"] || ViewComponent::Base.config.generate.sidecar
+      options["sidecar"] || GlobalConfig.generate.sidecar
     end
 
     def stimulus?
-      options["stimulus"] || ViewComponent::Base.config.generate.stimulus_controller
+      options["stimulus"] || GlobalConfig.generate.stimulus_controller
     end
 
     def typescript?
-      options["typescript"] || ViewComponent::Base.config.generate.typescript
+      options["typescript"] || GlobalConfig.generate.typescript
     end
   end
 end

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -13,12 +13,12 @@ module Rails
       check_class_collision suffix: "Component"
 
       class_option :inline, type: :boolean, default: false
-      class_option :locale, type: :boolean, default: ViewComponent::Base.config.generate.locale
+      class_option :locale, type: :boolean, default: ViewComponent::GlobalConfig.generate.locale
       class_option :parent, type: :string, desc: "The parent class for the generated component"
-      class_option :preview, type: :boolean, default: ViewComponent::Base.config.generate.preview
+      class_option :preview, type: :boolean, default: ViewComponent::GlobalConfig.generate.preview
       class_option :sidecar, type: :boolean, default: false
       class_option :stimulus, type: :boolean,
-        default: ViewComponent::Base.config.generate.stimulus_controller
+        default: ViewComponent::GlobalConfig.generate.stimulus_controller
 
       def create_component_file
         template "component.rb", File.join(component_path, class_path, "#{file_name}_component.rb")
@@ -41,7 +41,7 @@ module Rails
       def parent_class
         return options[:parent] if options[:parent]
 
-        ViewComponent::Base.config.component_parent_class || default_parent_class
+        ViewComponent::GlobalConfig.component_parent_class || default_parent_class
       end
 
       def initialize_signature

--- a/lib/rails/generators/locale/component_generator.rb
+++ b/lib/rails/generators/locale/component_generator.rb
@@ -12,7 +12,7 @@ module Locale
       class_option :sidecar, type: :boolean, default: false
 
       def create_locale_file
-        if ViewComponent::Base.config.generate.distinct_locale_files
+        if ViewComponent::GlobalConfig.generate.distinct_locale_files
           I18n.available_locales.each do |locale|
             create_file destination(locale), translations_hash([locale]).to_yaml
           end

--- a/lib/rails/generators/preview/component_generator.rb
+++ b/lib/rails/generators/preview/component_generator.rb
@@ -4,13 +4,13 @@ module Preview
   module Generators
     class ComponentGenerator < ::Rails::Generators::NamedBase
       source_root File.expand_path("templates", __dir__)
-      class_option :preview_path, type: :string, desc: "Path for previews, required when multiple preview paths are configured", default: ViewComponent::Base.config.generate.preview_path
+      class_option :preview_path, type: :string, desc: "Path for previews, required when multiple preview paths are configured", default: ViewComponent::GlobalConfig.generate.preview_path
 
       argument :attributes, type: :array, default: [], banner: "attribute"
       check_class_collision suffix: "ComponentPreview"
 
       def create_preview_file
-        preview_paths = ViewComponent::Base.config.preview_paths
+        preview_paths = ViewComponent::GlobalConfig.preview_paths
         optional_path = options[:preview_path]
         return if preview_paths.count > 1 && optional_path.blank?
 

--- a/lib/rails/generators/rspec/component_generator.rb
+++ b/lib/rails/generators/rspec/component_generator.rb
@@ -16,7 +16,7 @@ module Rspec
       private
 
       def spec_component_path
-        return "spec/components" unless ViewComponent::Base.config.generate.use_component_path_for_rspec_tests
+        return "spec/components" unless ViewComponent::GlobalConfig.generate.use_component_path_for_rspec_tests
 
         configured_component_path = component_path
         if configured_component_path.start_with?("app#{File::SEPARATOR}")

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -13,6 +13,7 @@ module ViewComponent
   autoload :ComponentError
   autoload :Config
   autoload :Deprecation
+  autoload :GlobalConfig
   autoload :InlineTemplate
   autoload :Instrumentation
   autoload :Preview

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -37,9 +37,8 @@ module ViewComponent
     RESERVED_PARAMETER = :content
     VC_INTERNAL_DEFAULT_FORMAT = :html
 
-    use_helpers :form_authenticity_token, :protect_against_forgery?, :config, :content_security_policy_nonce
-
     # For CSRF authenticity tokens in forms and Content Security Policy nonces
+    use_helpers :form_authenticity_token, :protect_against_forgery?, :config, :content_security_policy_nonce
 
     # Config option that strips trailing whitespace in templates before compiling them.
     class_attribute :__vc_strip_trailing_whitespace, instance_accessor: false, instance_predicate: false

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -37,6 +37,8 @@ module ViewComponent
     RESERVED_PARAMETER = :content
     VC_INTERNAL_DEFAULT_FORMAT = :html
 
+    use_helpers :form_authenticity_token, :protect_against_forgery?, :config, :content_security_policy_nonce
+
     # For CSRF authenticity tokens in forms and Content Security Policy nonces
 
     # Config option that strips trailing whitespace in templates before compiling them.
@@ -70,19 +72,7 @@ module ViewComponent
     # @return [String]
     def render_in(view_context, &block)
       self.class.compile(raise_errors: true)
-      if ViewComponent::Base.config.strict_helpers_enabled
-        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-          use_helpers :form_authenticity_token, :protect_against_forgery?, :config, :content_security_policy_nonce
-        RUBY
-      else
-        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-          # For CSRF authenticity tokens in forms
-          delegate :form_authenticity_token, :protect_against_forgery?, :config, to: :helpers
 
-          # For Content Security Policy nonces
-          delegate :content_security_policy_nonce, to: :helpers
-        RUBY
-      end
       @view_context = view_context
       self.__vc_original_view_context ||= view_context
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -513,6 +513,18 @@ module ViewComponent
         # `compile` defines
         compile
 
+        child.include ActiveSupport::Configurable
+
+        if child.superclass == ViewComponent::Base
+          child.define_singleton_method(:config) do
+            @@config ||= Rails.application.config.view_component.inheritable_copy
+          end
+        else
+          child.define_singleton_method(:config) do
+            @@config ||= superclass.config.inheritable_copy
+          end
+        end
+
         # Give the child its own personal #render_template_for to protect against the case when
         # eager loading is disabled and the parent component is rendered before the child. In
         # such a scenario, the parent will override ViewComponent::Base#render_template_for,

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -513,16 +513,6 @@ module ViewComponent
         # `compile` defines
         compile
 
-        if child.superclass == ViewComponent::Base
-          child.define_singleton_method(:component_config) do
-            @@component_config ||= Rails.application.config.view_component.inheritable_copy
-          end
-        else
-          child.define_singleton_method(:component_config) do
-            @@component_config ||= superclass.component_config.inheritable_copy
-          end
-        end
-
         # Give the child its own personal #render_template_for to protect against the case when
         # eager loading is disabled and the parent component is rendered before the child. In
         # such a scenario, the parent will override ViewComponent::Base#render_template_for,

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -250,18 +250,18 @@ module ViewComponent
       rescue => e # rubocop:disable Style/RescueStandardError
         e.set_backtrace e.backtrace.tap(&:shift)
         if ViewComponent::Base.strict_helpers_enabled
-          raise e, <<~MESSAGE.chomp if view_context && e.is_a?(NameError) && (__vc_original_view_context.respond_to?(method_name)|| controller.view_context.respond_to?(method_name))
-          #{e.message}
+          raise e, <<~MESSAGE.chomp if view_context && e.is_a?(NameError) && (__vc_original_view_context.respond_to?(method_name) || controller.view_context.respond_to?(method_name))
+            #{e.message}
 
-            You may be trying to call a method provided as a view helper. To use it try decalring it using use_helpers :#{method_name}'?
+              You may be trying to call a method provided as a view helper. To use it try decalring it using use_helpers :#{method_name}'?
           MESSAGE
-        else
-          raise e, <<~MESSAGE.chomp if view_context && e.is_a?(NameError) && helpers.respond_to?(method_name)
+        elsif view_context && e.is_a?(NameError) && helpers.respond_to?(method_name)
+          raise e, <<~MESSAGE.chomp
+end
             #{e.message}
 
             You may be trying to call a method provided as a view helper. Did you mean `helpers.#{method_name}'?
           MESSAGE
-        end
 
         raise
       end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -474,6 +474,7 @@ module ViewComponent
         # view files in a directory named like the component
         directory = File.dirname(source_location)
         filename = File.basename(source_location, ".rb")
+        return [] if name.blank?
         component_name = name.demodulize.underscore
 
         # Add support for nested components defined in the same file.
@@ -518,6 +519,11 @@ module ViewComponent
         # Compile so child will inherit compiled `call_*` template methods that
         # `compile` defines
         compile
+
+        # Set strict_helpers_enabled from global config
+        if child.superclass == ViewComponent::Base
+          child.__vc_strict_helpers_enabled = Rails.application.config.view_component.strict_helpers_enabled
+        end
 
         # Give the child its own personal #render_template_for to protect against the case when
         # eager loading is disabled and the parent component is rendered before the child. In
@@ -627,6 +633,15 @@ module ViewComponent
       # @return [Boolean]
       def strip_trailing_whitespace?
         __vc_strip_trailing_whitespace
+      end
+
+      # TODO
+      def strict_helpers_enabled=(value = true)
+        self.__vc_strict_helpers_enabled = value
+      end
+
+      def strict_helpers_enabled?
+        __vc_strict_helpers_enabled
       end
 
       # Ensure the component initializer accepts the

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -233,7 +233,7 @@ module ViewComponent
     # @return [ActionView::Base]
     def helpers
       raise HelpersCalledBeforeRenderError if view_context.nil?
-      raise StrictHelperError if ViewComponent::Base.config.strict_helpers_enabled
+      raise StrictHelperError unless ViewComponent::Base.config.helpers_enabled
       # Attempt to re-use the original view_context passed to the first
       # component rendered in the rendering pipeline. This prevents the
       # instantiation of a new view_context via `controller.view_context` which
@@ -250,7 +250,7 @@ module ViewComponent
         super
       rescue => e # rubocop:disable Style/RescueStandardError
         e.set_backtrace e.backtrace.tap(&:shift)
-        if ViewComponent::Base.config.strict_helpers_enabled
+        if !ViewComponent::Base.config.helpers_enabled
           raise e, <<~MESSAGE.chomp if view_context && e.is_a?(NameError) && (__vc_original_view_context.respond_to?(method_name) || controller.view_context.respond_to?(method_name))
             #{e.message}
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -520,9 +520,16 @@ module ViewComponent
         # `compile` defines
         compile
 
-        # Set strict_helpers_enabled from global config
+        child.include ActiveSupport::Configurable
+
         if child.superclass == ViewComponent::Base
-          child.__vc_strict_helpers_enabled = Rails.application.config.view_component.strict_helpers_enabled
+          child.define_singleton_method(:config) do
+            @@config ||= Rails.application.config.view_component.inheritable_copy
+          end
+        else
+          child.define_singleton_method(:config) do
+            @@config ||= superclass.config.inheritable_copy
+          end
         end
 
         # Give the child its own personal #render_template_for to protect against the case when
@@ -633,15 +640,6 @@ module ViewComponent
       # @return [Boolean]
       def strip_trailing_whitespace?
         __vc_strip_trailing_whitespace
-      end
-
-      # TODO
-      def strict_helpers_enabled=(value = true)
-        self.__vc_strict_helpers_enabled = value
-      end
-
-      def strict_helpers_enabled?
-        __vc_strict_helpers_enabled
       end
 
       # Ensure the component initializer accepts the

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -26,7 +26,7 @@ module ViewComponent
           test_controller: "ApplicationController",
           default_preview_layout: nil,
           capture_compatibility_patch_enabled: false,
-          strict_helpers_enabled: false
+          helpers_enabled: true
         })
       end
 
@@ -174,10 +174,10 @@ module ViewComponent
       # previews.
       # Defaults to `false`.
 
-      # @!attribute strict_helpers_enabled
+      # @!attribute helpers_enabled
       # @return [Boolean]
-      # Enables the experimental strict helpers mode wich throws ViewComponent::StrictHelperError when helpers is used
-      # Defaults to `false`.
+      # Enables the use of #helpers
+      # Defaults to `True`.
 
       def default_preview_paths
         (default_rails_preview_paths + default_rails_engines_preview_paths).uniq

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -11,7 +11,7 @@ module ViewComponent
       alias_method :default, :new
 
       def defaults
-        ActiveSupport::OrderedOptions.new.merge!({
+        ActiveSupport::InheritableOptions.new({
           generate: default_generate_options,
           preview_controller: "ViewComponentsController",
           preview_route: "/rails/view_components",

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -25,7 +25,8 @@ module ViewComponent
           preview_paths: default_preview_paths,
           test_controller: "ApplicationController",
           default_preview_layout: nil,
-          capture_compatibility_patch_enabled: false
+          capture_compatibility_patch_enabled: false,
+          strict_helpers_enabled: false
         })
       end
 
@@ -171,6 +172,11 @@ module ViewComponent
       # Enables the experimental capture compatibility patch that makes ViewComponent
       # compatible with forms, capture, and other built-ins.
       # previews.
+      # Defaults to `false`.
+
+      # @!attribute strict_helpers_enabled
+      # @return [Boolean]
+      # Enables the experimental strict helpers mode wich throws ViewComponent::StrictHelperError when helpers is used
       # Defaults to `false`.
 
       def default_preview_paths

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -26,7 +26,8 @@ module ViewComponent
           test_controller: "ApplicationController",
           default_preview_layout: nil,
           capture_compatibility_patch_enabled: false,
-          helpers_enabled: true
+          helpers_enabled: true,
+          strict_helpers_enabled?: false
         })
       end
 

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -6,7 +6,7 @@ require "view_component/deprecation"
 
 module ViewComponent
   class Engine < Rails::Engine # :nodoc:
-    config.view_component = ViewComponent::Config.current
+    config.view_component = ViewComponent::Config.defaults
 
     if Rails.version.to_f < 8.0
       rake_tasks do

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -23,7 +23,7 @@ module ViewComponent
     initializer "view_component.set_configs" do |app|
       options = app.config.view_component
 
-      %i[generate preview_controller preview_route show_previews_source].each do |config_option|
+      %i[generate preview_controller preview_route].each do |config_option|
         options[config_option] ||= ViewComponent::Base.public_send(config_option)
       end
       options.instrumentation_enabled = false if options.instrumentation_enabled.nil?

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -15,7 +15,7 @@ module ViewComponent
     else
       initializer "view_component.stats_directories" do |app|
         require "rails/code_statistics"
-        dir = ViewComponent::Base.view_component_path
+        dir = GlobalConfig.view_component_path
         Rails::CodeStatistics.register_directory("ViewComponents", dir)
       end
     end

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -234,6 +234,10 @@ module ViewComponent
     MESSAGE = "ViewComponent SystemTest controller attempted to load a file outside of the expected directory."
   end
 
+  class StrictHelperError < BaseError
+    MESSAGE = "ViewComponent strict helper mode is enbaled so #helpers is disabled."
+  end
+
   class AlreadyDefinedPolymorphicSlotSetterError < StandardError
     MESSAGE =
       "A method called 'SETTER_METHOD_NAME' already exists and would be overwritten by the 'SETTER_NAME' polymorphic " \

--- a/lib/view_component/global_config.rb
+++ b/lib/view_component/global_config.rb
@@ -1,0 +1,3 @@
+module ViewComponent
+  GlobalConfig = defined?(Rails) ? Rails.application.config.view_component : Base.config
+end

--- a/lib/view_component/global_config.rb
+++ b/lib/view_component/global_config.rb
@@ -1,3 +1,3 @@
 module ViewComponent
-  GlobalConfig = defined?(Rails) && Rails.application ? Rails.application.config.view_component : Base.config
+  GlobalConfig = (defined?(Rails) && Rails.application) ? Rails.application.config.view_component : Base.config # standard:disable Naming/ConstantName
 end

--- a/lib/view_component/global_config.rb
+++ b/lib/view_component/global_config.rb
@@ -1,3 +1,3 @@
 module ViewComponent
-  GlobalConfig = defined?(Rails) ? Rails.application.config.view_component : Base.config
+  GlobalConfig = defined?(Rails) && Rails.application ? Rails.application.config.view_component : Base.config
 end

--- a/lib/view_component/instrumentation.rb
+++ b/lib/view_component/instrumentation.rb
@@ -23,7 +23,7 @@ module ViewComponent # :nodoc:
     private
 
     def notification_name
-      return "!render.view_component" if ViewComponent::Base.config.use_deprecated_instrumentation_name
+      return "!render.view_component" if GlobalConfig.use_deprecated_instrumentation_name
 
       "render.view_component"
     end

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -109,7 +109,7 @@ module ViewComponent # :nodoc:
       private
 
       def preview_paths
-        Base.preview_paths
+        ViewComponent::GlobalConfig.preview_paths
       end
     end
   end

--- a/lib/view_component/rails/tasks/view_component.rake
+++ b/lib/view_component/rails/tasks/view_component.rake
@@ -7,7 +7,7 @@ namespace :view_component do
     # :nocov:
     require "rails/code_statistics"
 
-    dir = ViewComponent::Base.view_component_path
+    dir = ViewComponent::GlobalConfig.view_component_path
     ::STATS_DIRECTORIES << ["ViewComponents", dir] if File.directory?(Rails.root + dir)
     # :nocov:
   end

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -250,7 +250,8 @@ module ViewComponent
     #
     # @return [ActionController::Base]
     def vc_test_controller
-      @vc_test_controller ||= __vc_test_helpers_build_controller(Base.test_controller.constantize)
+      config_source = defined?(Rails) ? Rails.application.config.view_component : ViewComponent::Base
+      @vc_test_controller ||= __vc_test_helpers_build_controller(config_source.test_controller.constantize)
     end
 
     # Access the request used by `render_inline`:

--- a/lib/view_component/use_helpers.rb
+++ b/lib/view_component/use_helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "view_component/errors"
+
 module ViewComponent::UseHelpers
   extend ActiveSupport::Concern
 
@@ -13,7 +15,7 @@ module ViewComponent::UseHelpers
 
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
         def #{helper_method_name}(*args, &block)
-          raise HelpersCalledBeforeRenderError if view_context.nil?
+          raise ::ViewComponent::HelpersCalledBeforeRenderError if view_context.nil?
 
           #{define_helper(helper_method: helper_method, source: from)}
         end

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -122,6 +122,18 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     assert !exception_message_regex.match?(exception.message)
   end
 
+  def test_no_heleprs_error_if_helpers_disabled
+    with_helpers_enabled_config(false) do
+      exception = assert_raises(NoMethodError) { Class.new(ViewComponent::Base).new.current_user }
+      exception_message_regex = Regexp.new <<~MESSAGE.chomp, Regexp::MULTILINE
+        undefined method `current_user' for .*
+
+        You may be trying to call a method provided as a view helper. To use it try decalring it using use_helpers :current_user'?
+      MESSAGE
+      assert !exception_message_regex.match?(exception.message)
+    end
+  end
+
   def test_no_method_error_references_helper_if_view_context_present
     view_context = ActionController::Base.new.view_context
     view_context.instance_eval {

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -157,18 +157,18 @@ class ViewComponent::Base::UnitTest < Minitest::Test
 
   def test_strict_helpers_enabled
     with_config_option(:strict_helpers_enabled, false) do
-      refute ViewComponent::Base.strict_helpers_enabled?, ".strict_helpers_enabled? should be false by default"
-      refute ViewComponent::Base.new.strict_helpers_enabled?, "#strict_helpers_enabled? should be false by default"
-      Rails.application.config.view_component.strict_helpers_enabled = true
-      refute ViewComponent::Base.strict_helpers_enabled?, ".strict_helpers_enabled? should not be changed by global config for ViewComponent::Base"
-      refute ViewComponent::Base.new.strict_helpers_enabled?, "#strict_helpers_enabled? should not be changed by global config for ViewComponent::Base"
       top_level_component_class = Class.new(ViewComponent::Base)
-      assert top_level_component_class.strict_helpers_enabled?, ".strict_helpers_enabled? should inherit from global config"
-      assert top_level_component_class.new.strict_helpers_enabled?, "#strict_helpers_enabled? should inherit from global config"
-      top_level_component_class.strict_helpers_enabled = false
+      refute ViewComponent::Base.config.strict_helpers_enabled?, ".strict_helpers_enabled? should be false by default"
+      # refute ViewComponent::Base.new.config.strict_helpers_enabled?, "#strict_helpers_enabled? should be false by default"
+      Rails.application.config.view_component[:strict_helpers_enabled?] = true
+      refute ViewComponent::Base.config.strict_helpers_enabled?, ".strict_helpers_enabled? should not be changed by global config for ViewComponent::Base"
+      # refute ViewComponent::Base.new.config.strict_helpers_enabled?, "#strict_helpers_enabled? should not be changed by global config for ViewComponent::Base"
+      assert top_level_component_class.config.strict_helpers_enabled?, ".strict_helpers_enabled? should inherit from global config"
+      assert top_level_component_class.new.config.strict_helpers_enabled?, "#strict_helpers_enabled? should inherit from global config"
       inherited_component_class = Class.new(top_level_component_class)
-      refute inherited_component_class.strict_helpers_enabled?, ".strict_helpers_enabled? should inherit from its parent"
-      refute inherited_component_class.new.strict_helpers_enabled?, "#strict_helpers_enabled? should inherit from its parent"
+      top_level_component_class.config[:strict_helpers_enabled?] = false
+      refute inherited_component_class.config.strict_helpers_enabled?, ".strict_helpers_enabled? should inherit from its parent"
+      refute inherited_component_class.new.config.strict_helpers_enabled?, "#strict_helpers_enabled? should inherit from its parent"
     end
   end
 end

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -154,4 +154,21 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     MESSAGE
     assert !exception_message_regex.match?(exception.message)
   end
+
+  def test_strict_helpers_enabled
+    with_config_option(:strict_helpers_enabled, false) do
+      refute ViewComponent::Base.strict_helpers_enabled?, ".strict_helpers_enabled? should be false by default"
+      refute ViewComponent::Base.new.strict_helpers_enabled?, "#strict_helpers_enabled? should be false by default"
+      Rails.application.config.view_component.strict_helpers_enabled = true
+      refute ViewComponent::Base.strict_helpers_enabled?, ".strict_helpers_enabled? should not be changed by global config for ViewComponent::Base"
+      refute ViewComponent::Base.new.strict_helpers_enabled?, "#strict_helpers_enabled? should not be changed by global config for ViewComponent::Base"
+      top_level_component_class = Class.new(ViewComponent::Base)
+      assert top_level_component_class.strict_helpers_enabled?, ".strict_helpers_enabled? should inherit from global config"
+      assert top_level_component_class.new.strict_helpers_enabled?, "#strict_helpers_enabled? should inherit from global config"
+      top_level_component_class.strict_helpers_enabled = false
+      inherited_component_class = Class.new(top_level_component_class)
+      refute inherited_component_class.strict_helpers_enabled?, ".strict_helpers_enabled? should inherit from its parent"
+      refute inherited_component_class.new.strict_helpers_enabled?, "#strict_helpers_enabled? should inherit from its parent"
+    end
+  end
 end

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -163,12 +163,12 @@ class ViewComponent::Base::UnitTest < Minitest::Test
       Rails.application.config.view_component[:strict_helpers_enabled?] = true
       refute ViewComponent::Base.config.strict_helpers_enabled?, ".strict_helpers_enabled? should not be changed by global config for ViewComponent::Base"
       # refute ViewComponent::Base.new.config.strict_helpers_enabled?, "#strict_helpers_enabled? should not be changed by global config for ViewComponent::Base"
-      assert top_level_component_class.config.strict_helpers_enabled?, ".strict_helpers_enabled? should inherit from global config"
-      assert top_level_component_class.new.config.strict_helpers_enabled?, "#strict_helpers_enabled? should inherit from global config"
+      assert top_level_component_class.component_config.strict_helpers_enabled?, ".strict_helpers_enabled? should inherit from global config"
+      assert top_level_component_class.new.component_config.strict_helpers_enabled?, "#strict_helpers_enabled? should inherit from global config"
       inherited_component_class = Class.new(top_level_component_class)
-      top_level_component_class.config[:strict_helpers_enabled?] = false
-      refute inherited_component_class.config.strict_helpers_enabled?, ".strict_helpers_enabled? should inherit from its parent"
-      refute inherited_component_class.new.config.strict_helpers_enabled?, "#strict_helpers_enabled? should inherit from its parent"
+      top_level_component_class.component_config[:strict_helpers_enabled?] = false
+      refute inherited_component_class.component_config.strict_helpers_enabled?, ".strict_helpers_enabled? should inherit from its parent"
+      refute inherited_component_class.new.component_config.strict_helpers_enabled?, "#strict_helpers_enabled? should inherit from its parent"
     end
   end
 end

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -579,7 +579,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       expected_response_body = <<~TURBOSTREAM
         <turbo-stream action="update" target="area1"><template><span>Hello, world!</span></template></turbo-stream>
       TURBOSTREAM
-      if ViewComponent::Base.config.capture_compatibility_patch_enabled
+      if ViewComponent::GlobalConfig.capture_compatibility_patch_enabled
         assert_equal expected_response_body, response.body
       else
         assert_not_equal expected_response_body, response.body
@@ -716,8 +716,8 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     Rails.cache.clear
   end
 
-  def test_config_options_shared_between_base_and_engine
-    config_entrypoints = [Rails.application.config.view_component, ViewComponent::Base.config]
+  def test_globalconfig_is_proxy_for_rails_app_config
+    config_entrypoints = [Rails.application.config.view_component, ViewComponent::GlobalConfig]
     2.times do
       config_entrypoints.first.yield_self do |config|
         {

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -15,7 +15,7 @@ class RenderingTest < ViewComponent::TestCase
     ViewComponent::CompileCache.cache.delete(MyComponent)
     MyComponent.ensure_compiled
 
-    assert_allocations("3.4.0" => 107, "3.3.5" => 116, "3.3.0" => 129, "3.2.5" => 115, "3.1.6" => 115, "3.0.7" => 125) do
+    assert_allocations("3.4.0" => 108, "3.3.5" => 116, "3.3.0" => 129, "3.2.5" => 115, "3.1.6" => 115, "3.0.7" => 125) do
       render_inline(MyComponent.new)
     end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -185,7 +185,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_renders_button_to_component_with_strict_helpers
-    with_strict_helpers_config(true) do
+    with_helpers_enabled_config(false) do
       old_value = ActionController::Base.allow_forgery_protection
       ActionController::Base.allow_forgery_protection = true
 
@@ -357,7 +357,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_renders_component_with_asset_url_with_strict_helpers
-    with_strict_helpers_config(true) do
+    with_helpers_enabled_config(false) do
       component = AssetComponent.new
       assert_match(%r{http://assets.example.com/assets/application-\w+.css}, render_inline(component).text)
 
@@ -807,7 +807,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_renders_component_using_rails_config_with_strict_helpers
-    with_strict_helpers_config(true) do
+    with_helpers_enabled_config(false) do
       render_inline(RailsConfigComponent.new)
 
       assert_text("http://assets.example.com")
@@ -1167,7 +1167,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_content_security_policy_nonce_with_strict_helpers
-    with_strict_helpers_config(true) do
+    with_helpers_enabled_config(false) do
       render_inline(ContentSecurityPolicyNonceComponent.new)
 
       assert_selector("script", text: "\n//<![CDATA[\n  \"alert('hello')\"\n\n//]]>\n", visible: :hidden)
@@ -1268,7 +1268,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_strict_helpers
-    with_strict_helpers_config(true) do
+    with_helpers_enabled_config(false) do
       assert_raises ViewComponent::StrictHelperError do
         render_inline(HelpersProxyComponent.new)
       end

--- a/test/test_engine/test_helper.rb
+++ b/test/test_engine/test_helper.rb
@@ -22,7 +22,7 @@ require "view_component"
 
 Rails::Generators.namespace = TestEngine
 
-def with_config_option(option_name, new_value, config_entrypoint: TestEngine::Engine.config.view_component)
+def with_config_option(option_name, new_value, config_entrypoint: ViewComponent::GlobalConfig)
   old_value = config_entrypoint.public_send(option_name)
   config_entrypoint.public_send(:"#{option_name}=", new_value)
   yield

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -182,6 +182,10 @@ def with_strict_helpers_config(enabled, &block)
   with_config_option(:strict_helpers_enabled, enabled, &block)
 end
 
+def with_helpers_enabled_config(enabled, &block)
+  with_config_option(:helpers_enabled, enabled, &block)
+end
+
 def with_compiler_mode(mode)
   previous_mode = ViewComponent::Compiler.mode
   ViewComponent::Compiler.mode = mode

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -176,6 +176,15 @@ end
 def with_compiler_development_mode(mode)
   previous_mode = ViewComponent::Compiler.development_mode
   ViewComponent::Compiler.development_mode = mode
+end
+
+def with_strict_helpers_config(enabled, &block)
+  with_config_option(:strict_helpers_enabled, enabled, &block)
+end
+
+def with_compiler_mode(mode)
+  previous_mode = ViewComponent::Compiler.mode
+  ViewComponent::Compiler.mode = mode
   yield
 ensure
   ViewComponent::Compiler.development_mode = previous_mode


### PR DESCRIPTION
Based on #1987 

Aims to have `strict_helpers_enabled?` able to be set at an application level by `Rails.application.config.view_component` without affecting the base value for the setting stored on `ViewComponent::Base`, which may be consumed by gems.