### PR TITLE
Test against `turbo-rails ~> 2`

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -8,19 +8,16 @@ appraise "rails-6.1" do
   gem "net-smtp", require: false
   gem "net-imap", require: false
   gem "net-pop", require: false
-  gem "turbo-rails", "~> 1"
 end
 
 appraise "rails-7.0" do
   gem "rails", "~> 7.0"
   gem "tailwindcss-rails", "~> 2.0"
-  gem "turbo-rails", "~> 1"
 end
 
 appraise "rails-7.1" do
   gem "rails", "~> 7.1"
   gem "tailwindcss-rails", "~> 2.0"
-  gem "turbo-rails", "~> 1"
 end
 
 appraise "rails-7.2" do
@@ -31,5 +28,4 @@ end
 appraise "rails-main" do
   gem "rails", github: "rails/rails", branch: "main"
   gem "tailwindcss-rails", "~> 2.0"
-  gem "turbo-rails", "~> 1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,7 +306,7 @@ GEM
     thor (1.3.2)
     tilt (2.4.0)
     timeout (0.4.1)
-    turbo-rails (1.5.0)
+    turbo-rails (2.0.7)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
@@ -357,7 +357,7 @@ DEPENDENCIES
   slim (~> 5.1)
   sprockets-rails (~> 3.4.2)
   standard (~> 1)
-  turbo-rails (~> 1)
+  turbo-rails (~> 2)
   view_component!
   warning
   yard (~> 0.9.34)

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -7,6 +7,5 @@ gem "tailwindcss-rails", "~> 2.0"
 gem "net-smtp", require: false
 gem "net-imap", require: false
 gem "net-pop", require: false
-gem "turbo-rails", "~> 1"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -4,6 +4,5 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.0"
 gem "tailwindcss-rails", "~> 2.0"
-gem "turbo-rails", "~> 1"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -4,6 +4,5 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.1"
 gem "tailwindcss-rails", "~> 2.0"
-gem "turbo-rails", "~> 1"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,25 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "capybara", "~> 3"
 gem "rails", "~> 7.2"
-gem "rspec-rails", "~> 5"
-gem "net-imap", require: false
-gem "net-pop", require: false
-gem "net-smtp", require: false
-gem "debug"
-
 gem "tailwindcss-rails", "~> 2.0"
-
-group :test do
-  gem "cuprite", "~> 0.15"
-  gem "puma", "~> 6"
-  gem "warning"
-  gem "selenium-webdriver", "4.9.0"
-end
-
-group :development, :test do
-  gem "appraisal", "~> 2.5"
-end
 
 gemspec path: "../"

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -4,6 +4,5 @@ source "https://rubygems.org"
 
 gem "rails", github: "rails/rails", branch: "main"
 gem "tailwindcss-rails", "~> 2.0"
-gem "turbo-rails", "~> 1"
 
 gemspec path: "../"

--- a/test/sandbox/config/cable.yml
+++ b/test/sandbox/config/cable.yml
@@ -1,0 +1,2 @@
+test:
+  adapter: test

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov-console", "~> 0.9.1"
   spec.add_development_dependency "slim", "~> 5.1"
   spec.add_development_dependency "sprockets-rails", "~> 3.4.2"
-  spec.add_development_dependency "turbo-rails", "~> 1"
+  spec.add_development_dependency "turbo-rails", "~> 2"
   spec.add_development_dependency "warning"
   spec.add_development_dependency "yard", "~> 0.9.34"
   spec.add_development_dependency "yard-activesupport-concern", "~> 0.0.1"


### PR DESCRIPTION
https://github.com/hotwired/turbo-rails/issues/294 was closed, which prompted me to check that the issue had been fixed. It's been closed as stale, but this puts us on the latest `turbo-rails` for testing this incompatibility.

Since we're no longer testing against a version of Rails that's incompatible with `turbo-rails`, I've made it a development dependency.