### PR TITLE
Update `with_controller_class` type documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,10 @@ nav_order: 5
 
     *Petrik de Heus*
 
+* Fixed type declaration for `ViewComponent::TestHelpers.with_controller_class` parameter.
+
+    *Graham Rogers*
+
 ## 3.14.0
 
 * Defer to built-in caching for language environment setup, rather than manually using `actions/cache` in CI.

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -155,7 +155,7 @@ module ViewComponent
     # end
     # ```
     #
-    # @param klass [ActionController::Base] The controller to be used.
+    # @param klass [Class<ActionController::Base>] The controller to be used.
     def with_controller_class(klass)
       old_controller = defined?(@vc_test_controller) && @vc_test_controller
 


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide a description of the changes. Link to any related issues or projects. -->

In Yard `[ActionController::Base]` means "an instance of `ActionController::Base`, but this method actually wants a subclass. Tools such as RubyMine complain that the expected type is incorrect when that's not true.

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

Fixed the doc to use `[Class<ActionController::Base>]` which is the correct type signatire for this meythod.

### Anything you want to highlight for special attention from reviewers?

No