### PR TITLE
use Struct instead of OpenStruct

### DIFF
--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -107,13 +107,13 @@ module ViewComponent
 
       if handler.method(:call).parameters.length > 1
         handler.call(
-          OpenStruct.new(format: @this_format, identifier: @path, short_identifier: short_identifier, type: type),
+          Struct.new(format: @this_format, identifier: @path, short_identifier: short_identifier, type: type),
           this_source
         )
       # :nocov:
       # TODO: Remove in v4
       else
-        handler.call(OpenStruct.new(source: this_source, identifier: @path, type: type))
+        handler.call(Struct.new(source: this_source, identifier: @path, type: type))
       end
       # :nocov:
     end


### PR DESCRIPTION
I'm guessing that we're seeing failures referencing OpenStruct here now that Template is in its own class instead of in Compiler, which includes concurrent-ruby.

As it turns out, we don't even need OpenStruct! We know what attributes we need at the point of instantiation, so we can just use Struct, which uses less memory anyways <3