### PR TITLE
Add basic internal testing for memory allocations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    allocation_stats (0.1.5)
     ansi (1.5.0)
     appraisal (2.5.0)
       bundler
@@ -330,6 +331,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  allocation_stats (~> 0.1.5)
   appraisal (~> 2.4)
   benchmark-ips (~> 2.13.0)
   better_html

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add basic internal testing for memory allocations.
+
+    *Joel Hawksley*
+
 * Add support for request formats.
 
     *Joel Hawksley*

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -11,6 +11,7 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_render_inline_allocations
     assert_allocations("3.4.0" => 107, "3.3.5" => 116, "3.3.0" => 129, "3.2.5" => 115, "3.1.6" => 115, "3.0.7" => 125) do
+      ViewComponent::CompileCache.cache.delete(MyComponent)
       MyComponent.ensure_compiled
 
       render_inline(MyComponent.new)

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -10,10 +10,12 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_inline_allocations
-    assert_allocations("3.4.0" => 107, "3.3.5" => 116, "3.3.0" => 129, "3.2.5" => 115, "3.1.6" => 115, "3.0.7" => 125) do
-      ViewComponent::CompileCache.cache.delete(MyComponent)
-      MyComponent.ensure_compiled
+    # Stabilize compilation status ahead of testing allocations to simulate rendering
+    # performance with compiled component
+    ViewComponent::CompileCache.cache.delete(MyComponent)
+    MyComponent.ensure_compiled
 
+    assert_allocations("3.4.0" => 107, "3.3.5" => 116, "3.3.0" => 129, "3.2.5" => 115, "3.1.6" => 115, "3.0.7" => 125) do
       render_inline(MyComponent.new)
     end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -10,8 +10,10 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_inline_allocations
-    assert_allocations("3.4" => 107, "3.3" => 116, "3.2" => 105, "3.1" => 115, "3.0" => 125) do
-      render_inline(MyComponent.new)
+    assert_allocations("3.4" => 107, "3.3" => 321, "3.2" => 105, "3.1" => 115, "3.0" => 125) do
+      with_new_cache do
+        render_inline(MyComponent.new)
+      end
     end
 
     assert_selector("div", text: "hello,world!")

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -10,7 +10,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_inline_allocations
-    assert_allocations("3.4.0" => 107, "3.3.0" => 129, "3.2.5" => 115, "3.1.6" => 115, "3.0.7" => 125) do
+    assert_allocations("3.4.0" => 107, "3.3.5" => 116, "3.3.0" => 129, "3.2.5" => 115, "3.1.6" => 115, "3.0.7" => 125) do
       MyComponent.ensure_compiled
 
       render_inline(MyComponent.new)

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -725,34 +725,28 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_component_with_invalid_parameter_names
-    old_cache = ViewComponent::CompileCache.cache
-    ViewComponent::CompileCache.cache = Set.new
+    with_new_cache do
+      exception =
+        assert_raises ViewComponent::ReservedParameterError do
+          InvalidParametersComponent.compile(raise_errors: true)
+        end
 
-    exception =
-      assert_raises ViewComponent::ReservedParameterError do
-        InvalidParametersComponent.compile(raise_errors: true)
-      end
-
-    assert_match(/InvalidParametersComponent initializer can't accept the parameter/, exception.message)
-  ensure
-    ViewComponent::CompileCache.cache = old_cache
+      assert_match(/InvalidParametersComponent initializer can't accept the parameter/, exception.message)
+    end
   end
 
   def test_component_with_invalid_named_parameter_names
-    old_cache = ViewComponent::CompileCache.cache
-    ViewComponent::CompileCache.cache = Set.new
+    with_new_cache do
+      exception =
+        assert_raises ViewComponent::ReservedParameterError do
+          InvalidNamedParametersComponent.compile(raise_errors: true)
+        end
 
-    exception =
-      assert_raises ViewComponent::ReservedParameterError do
-        InvalidNamedParametersComponent.compile(raise_errors: true)
-      end
-
-    assert_match(
-      /InvalidNamedParametersComponent initializer can't accept the parameter `content`/,
-      exception.message
-    )
-  ensure
-    ViewComponent::CompileCache.cache = old_cache
+      assert_match(
+        /InvalidNamedParametersComponent initializer can't accept the parameter `content`/,
+        exception.message
+      )
+    end
   end
 
   def test_collection_component_with_trailing_comma_attr_reader

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -10,7 +10,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_inline_allocations
-    assert_allocations("3.3" => 116, "3.2" => 115, "3.1" => 115, "3.0" => 125) do
+    assert_allocations("3.4" => 107, "3.3" => 116, "3.2" => 105, "3.1" => 115, "3.0" => 125) do
       render_inline(MyComponent.new)
     end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -10,10 +10,10 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_inline_allocations
-    assert_allocations("3.4" => 107, "3.3" => 321, "3.2" => 105, "3.1" => 115, "3.0" => 125) do
-      with_new_cache do
-        render_inline(MyComponent.new)
-      end
+    assert_allocations("3.4.0" => 107, "3.3.0" => 129, "3.2" => 105, "3.1" => 115, "3.0" => 125) do
+      MyComponent.ensure_compiled
+
+      render_inline(MyComponent.new)
     end
 
     assert_selector("div", text: "hello,world!")

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -10,7 +10,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_inline_allocations
-    assert_allocations("3.4.0" => 107, "3.3.0" => 129, "3.2" => 105, "3.1" => 115, "3.0" => 125) do
+    assert_allocations("3.4.0" => 107, "3.3.0" => 129, "3.2.5" => 115, "3.1.6" => 115, "3.0.7" => 125) do
       MyComponent.ensure_compiled
 
       render_inline(MyComponent.new)

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -10,7 +10,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_inline_allocations
-    assert_allocations("3.3" => 129, "3.2" => 129, "3.1" => 129, "3.0" => 129) do
+    assert_allocations("3.3" => 116, "3.2" => 115, "3.1" => 115, "3.0" => 125) do
       render_inline(MyComponent.new)
     end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -9,6 +9,14 @@ class RenderingTest < ViewComponent::TestCase
     assert_selector("div", text: "hello,world!")
   end
 
+  def test_render_inline_allocations
+    assert_allocations("3.3" => 129, "3.2" => 129, "3.1" => 129, "3.0" => 129) do
+      render_inline(MyComponent.new)
+    end
+
+    assert_selector("div", text: "hello,world!")
+  end
+
   def test_render_in_view_context
     render_in_view_context { render(MyComponent.new) }
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -187,3 +187,12 @@ def capture_warnings(&block)
     end
   end
 end
+require "allocation_stats"
+
+def assert_allocations(count_map, &block)
+  trace = AllocationStats.trace(&block)
+  total = trace.allocations.all.size
+  count = count_map[RUBY_VERSION.split(".").take(2).join(".")]
+
+  assert_equal count, total, "Expected #{count} allocations, got #{total} allocations"
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -194,5 +194,5 @@ def assert_allocations(count_map, &block)
   total = trace.allocations.all.size
   count = count_map[RUBY_VERSION.split(".").take(2).join(".")]
 
-  assert_equal count, total, "Expected #{count} allocations, got #{total} allocations"
+  assert_equal count, total, "Expected #{count} allocations, got #{total} allocations for Ruby #{RUBY_VERSION}"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "allocation_stats"
 require "simplecov"
 require "simplecov-console"
 require "rails/version"
@@ -187,7 +188,6 @@ def capture_warnings(&block)
     end
   end
 end
-require "allocation_stats"
 
 def assert_allocations(count_map, &block)
   trace = AllocationStats.trace(&block)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -192,7 +192,7 @@ require "allocation_stats"
 def assert_allocations(count_map, &block)
   trace = AllocationStats.trace(&block)
   total = trace.allocations.all.size
-  count = count_map[RUBY_VERSION.split(".").take(2).join(".")]
+  count = count_map[RUBY_VERSION]
 
   assert_equal count, total, "Expected #{count} allocations, got #{total} allocations for Ruby #{RUBY_VERSION}"
 end

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport", [">= 5.2.0", "< 8.0"]
   spec.add_runtime_dependency "method_source", "~> 1.0"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
+  spec.add_development_dependency "allocation_stats", "~> 0.1.5"
   spec.add_development_dependency "appraisal", "~> 2.4"
   spec.add_development_dependency "benchmark-ips", "~> 2.13.0"
   spec.add_development_dependency "better_html"


### PR DESCRIPTION
### What are you trying to accomplish?

This PR adds basic internal testing tooling for memory allocations, giving us a starting point for optimizing memory usage in the project.

### What approach did you choose and why?

I copied the `assert_allocations` helper from Primer ViewComponents, but modified it to target specific Ruby versions to remove ambiguity.