### PR TITLE
Underscore internal methods that are public

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -72,7 +72,7 @@ module ViewComponent
     #
     # @return [String]
     def render_in(view_context, &block)
-      self.class.compile(raise_errors: true)
+      self.class.__vc_compile(raise_errors: true)
 
       @view_context = view_context
       self.__vc_original_view_context ||= view_context
@@ -109,7 +109,7 @@ module ViewComponent
 
       if render?
         rendered_template =
-          if compiler.renders_template_for?(@__vc_variant, request&.format&.to_sym)
+          if __vc_compiler.renders_template_for?(@__vc_variant, request&.format&.to_sym)
             render_template_for(@__vc_variant, request&.format&.to_sym)
           else
             maybe_escape_html(render_template_for(@__vc_variant, request&.format&.to_sym)) do
@@ -351,8 +351,8 @@ module ViewComponent
       end
     end
 
-    def compiler
-      @compiler ||= self.class.compiler
+    def __vc_compiler
+      @compiler ||= self.class.__vc_compiler
     end
 
     # Set the controller used for testing components:
@@ -503,18 +503,18 @@ module ViewComponent
       def inherited(child)
         # Compile so child will inherit compiled `call_*` template methods that
         # `compile` defines
-        compile
+        __vc_compile
 
         # Give the child its own personal #render_template_for to protect against the case when
         # eager loading is disabled and the parent component is rendered before the child. In
         # such a scenario, the parent will override ViewComponent::Base#render_template_for,
         # meaning it will not be called for any children and thus not compile their templates.
-        if !child.instance_methods(false).include?(:render_template_for) && !child.compiled?
+        if !child.instance_methods(false).include?(:render_template_for) && !child.__vc_compiled?
           child.class_eval <<~RUBY, __FILE__, __LINE__ + 1
             def render_template_for(variant = nil, format = nil)
               # Force compilation here so the compiler always redefines render_template_for.
               # This is mostly a safeguard to prevent infinite recursion.
-              self.class.compile(raise_errors: true, force: true)
+              self.class.__vc_compile(raise_errors: true, force: true)
               # .compile replaces this method; call the new one
               render_template_for(variant, format)
             end
@@ -555,22 +555,22 @@ module ViewComponent
       end
 
       # @private
-      def compiled?
-        compiler.compiled?
+      def __vc_compiled?
+        __vc_compiler.compiled?
       end
 
       # @private
-      def ensure_compiled
-        compile unless compiled?
+      def __vc_ensure_compiled
+        __vc_compile unless __vc_compiled?
       end
 
       # @private
-      def compile(raise_errors: false, force: false)
-        compiler.compile(raise_errors: raise_errors, force: force)
+      def __vc_compile(raise_errors: false, force: false)
+        __vc_compiler.compile(raise_errors: raise_errors, force: force)
       end
 
       # @private
-      def compiler
+      def __vc_compiler
         @__vc_compiler ||= Compiler.new(self)
       end
 
@@ -612,8 +612,8 @@ module ViewComponent
       # is accepted, as support for collection
       # rendering is optional.
       # @private TODO: add documentation
-      def validate_collection_parameter!(validate_default: false)
-        parameter = validate_default ? collection_parameter : provided_collection_parameter
+      def __vc_validate_collection_parameter!(validate_default: false)
+        parameter = validate_default ? __vc_collection_parameter : provided_collection_parameter
 
         return unless parameter
         return if initialize_parameter_names.include?(parameter) || splatted_keyword_argument_present?
@@ -632,35 +632,35 @@ module ViewComponent
       # invalid parameters that could override the framework's
       # methods.
       # @private TODO: add documentation
-      def validate_initialization_parameters!
+      def __vc_validate_initialization_parameters!
         return unless initialize_parameter_names.include?(RESERVED_PARAMETER)
 
         raise ReservedParameterError.new(name, RESERVED_PARAMETER)
       end
 
       # @private
-      def collection_parameter
+      def __vc_collection_parameter
         provided_collection_parameter || name && name.demodulize.underscore.chomp("_component").to_sym
       end
 
       # @private
-      def collection_counter_parameter
-        :"#{collection_parameter}_counter"
+      def __vc_collection_counter_parameter
+        :"#{__vc_collection_parameter}_counter"
       end
 
       # @private
-      def counter_argument_present?
-        initialize_parameter_names.include?(collection_counter_parameter)
+      def __vc_counter_argument_present?
+        initialize_parameter_names.include?(__vc_collection_counter_parameter)
       end
 
       # @private
-      def collection_iteration_parameter
-        :"#{collection_parameter}_iteration"
+      def __vc_collection_iteration_parameter
+        :"#{__vc_collection_parameter}_iteration"
       end
 
       # @private
-      def iteration_argument_present?
-        initialize_parameter_names.include?(collection_iteration_parameter)
+      def __vc_iteration_argument_present?
+        initialize_parameter_names.include?(__vc_collection_iteration_parameter)
       end
 
       private

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -27,7 +27,7 @@ module ViewComponent
 
       iterator = ActionView::PartialIteration.new(@collection.size)
 
-      component.validate_collection_parameter!(validate_default: true)
+      component.__vc_validate_collection_parameter!(validate_default: true)
 
       @components = @collection.map do |item|
         component.new(**component_options(item, iterator)).tap do |component|
@@ -63,9 +63,9 @@ module ViewComponent
     end
 
     def component_options(item, iterator)
-      item_options = {component.collection_parameter => item}
-      item_options[component.collection_counter_parameter] = iterator.index if component.counter_argument_present?
-      item_options[component.collection_iteration_parameter] = iterator.dup if component.iteration_argument_present?
+      item_options = {component.__vc_collection_parameter => item}
+      item_options[component.__vc_collection_counter_parameter] = iterator.index if component.__vc_counter_argument_present?
+      item_options[component.__vc_collection_iteration_parameter] = iterator.dup if component.__vc_iteration_argument_present?
 
       @options.merge(item_options)
     end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -27,20 +27,20 @@ module ViewComponent
       gather_templates
 
       if self.class.development_mode && @templates.any?(&:requires_compiled_superclass?)
-        @component.superclass.compile(raise_errors: raise_errors)
+        @component.superclass.__vc_compile(raise_errors: raise_errors)
       end
 
       return if gather_template_errors(raise_errors).any?
 
       if raise_errors
-        @component.validate_initialization_parameters!
-        @component.validate_collection_parameter!
+        @component.__vc_validate_initialization_parameters!
+        @component.__vc_validate_collection_parameter!
       end
 
       define_render_template_for
 
-      @component.register_default_slots
-      @component.build_i18n_backend
+      @component.__vc_register_default_slots
+      @component.__vc_build_i18n_backend
 
       CompileCache.register(@component)
     end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -81,7 +81,7 @@ module ViewComponent
 
     initializer "view_component.eager_load_actions" do
       ActiveSupport.on_load(:after_initialize) do
-        ViewComponent::Base.descendants.each(&:compile) if Rails.application.config.eager_load
+        ViewComponent::Base.descendants.each(&:__vc_compile) if Rails.application.config.eager_load
       end
     end
 

--- a/lib/view_component/slotable_default.rb
+++ b/lib/view_component/slotable_default.rb
@@ -3,7 +3,7 @@ module ViewComponent
     def get_slot(slot_name)
       @__vc_set_slots ||= {}
 
-      return super unless !@__vc_set_slots[slot_name] && (default_method = registered_slots[slot_name][:default_method])
+      return super unless !@__vc_set_slots[slot_name] && (default_method = __vc_registered_slots[slot_name][:default_method])
 
       renderable_value = send(default_method)
       slot = Slot.new(self)

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -111,7 +111,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       assert_select "div", "hello world"
       assert_response :success
 
-      compile_method_lines = UncompilableComponent.method(:compile).source.split("\n")
+      compile_method_lines = UncompilableComponent.method(:__vc_compile).source.split("\n")
       compile_method_lines.insert(1, 'raise "this should not happen" if self.name == "UncompilableComponent"')
       UncompilableComponent.instance_eval compile_method_lines.join("\n")
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -79,12 +79,14 @@ class RenderingTest < ViewComponent::TestCase
   def test_render_without_template
     render_inline(InlineComponent.new)
 
+    assert_predicate InlineComponent, :__vc_compiled?
     assert_selector("input[type='text'][name='name']")
   end
 
   def test_render_child_without_template
     render_inline(InlineChildComponent.new)
 
+    assert_predicate InlineChildComponent, :__vc_compiled?
     assert_selector("input[type='text'][name='name']")
   end
 
@@ -205,6 +207,7 @@ class RenderingTest < ViewComponent::TestCase
     with_variant :inline_variant do
       render_inline(InlineVariantComponent.new)
 
+      assert_predicate InlineVariantComponent, :__vc_compiled?
       assert_selector("input[type='text'][name='inline_variant']")
     end
   end
@@ -213,6 +216,7 @@ class RenderingTest < ViewComponent::TestCase
     with_variant :inline_variant do
       render_inline(InlineVariantChildComponent.new)
 
+      assert_predicate InlineVariantChildComponent, :__vc_compiled?
       assert_selector("input[type='text'][name='inline_variant']")
     end
   end
@@ -775,6 +779,7 @@ class RenderingTest < ViewComponent::TestCase
   def test_inherited_inline_component_inherits_inline_method
     render_inline(InlineInheritedComponent.new)
 
+    assert_predicate InlineInheritedComponent, :__vc_compiled?
     assert_selector("input[type='text'][name='name']")
   end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -79,14 +79,12 @@ class RenderingTest < ViewComponent::TestCase
   def test_render_without_template
     render_inline(InlineComponent.new)
 
-    assert_predicate InlineComponent, :compiled?
     assert_selector("input[type='text'][name='name']")
   end
 
   def test_render_child_without_template
     render_inline(InlineChildComponent.new)
 
-    assert_predicate InlineChildComponent, :compiled?
     assert_selector("input[type='text'][name='name']")
   end
 
@@ -207,7 +205,6 @@ class RenderingTest < ViewComponent::TestCase
     with_variant :inline_variant do
       render_inline(InlineVariantComponent.new)
 
-      assert_predicate InlineVariantComponent, :compiled?
       assert_selector("input[type='text'][name='inline_variant']")
     end
   end
@@ -216,7 +213,6 @@ class RenderingTest < ViewComponent::TestCase
     with_variant :inline_variant do
       render_inline(InlineVariantChildComponent.new)
 
-      assert_predicate InlineVariantChildComponent, :compiled?
       assert_selector("input[type='text'][name='inline_variant']")
     end
   end
@@ -424,7 +420,7 @@ class RenderingTest < ViewComponent::TestCase
     # but that might have been thrown away if code-reloading is enabled
     skip unless Rails.env.cache_classes?
 
-    assert UnreferencedComponent.compiled?
+    assert UnreferencedComponent.__vc_compiled?
   end
 
   def test_compiles_components_without_initializers
@@ -432,7 +428,7 @@ class RenderingTest < ViewComponent::TestCase
     # but that might have been thrown away if code-reloading is enabled
     skip unless Rails.env.cache_classes?
 
-    assert MissingInitializerComponent.compiled?
+    assert MissingInitializerComponent.__vc_compiled?
   end
 
   def test_renders_when_initializer_is_not_defined
@@ -722,7 +718,7 @@ class RenderingTest < ViewComponent::TestCase
 
     exception =
       assert_raises ViewComponent::ReservedParameterError do
-        InvalidParametersComponent.compile(raise_errors: true)
+        InvalidParametersComponent.__vc_compile(raise_errors: true)
       end
 
     assert_match(/InvalidParametersComponent initializer can't accept the parameter/, exception.message)
@@ -736,7 +732,7 @@ class RenderingTest < ViewComponent::TestCase
 
     exception =
       assert_raises ViewComponent::ReservedParameterError do
-        InvalidNamedParametersComponent.compile(raise_errors: true)
+        InvalidNamedParametersComponent.__vc_compile(raise_errors: true)
       end
 
     assert_match(
@@ -779,7 +775,6 @@ class RenderingTest < ViewComponent::TestCase
   def test_inherited_inline_component_inherits_inline_method
     render_inline(InlineInheritedComponent.new)
 
-    assert_predicate InlineInheritedComponent, :compiled?
     assert_selector("input[type='text'][name='name']")
   end
 

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -250,7 +250,7 @@ class SlotableTest < ViewComponent::TestCase
     new_component_class = Class.new(ViewComponent::Base)
     # this returned:
     # [SlotsComponent::Subtitle, SlotsComponent::Tab...]
-    assert_empty new_component_class.registered_slots
+    assert_empty new_component_class.__vc_registered_slots
   end
 
   def test_renders_slots_with_before_render_hook

--- a/test/sandbox/test/translatable_test.rb
+++ b/test/sandbox/test/translatable_test.rb
@@ -95,7 +95,7 @@ class TranslatableTest < ViewComponent::TestCase
     ) do
       assert_equal "MISSING", translate(".hello", default: "MISSING")
       assert_equal "Hello from Rails translations!", translate("hello")
-      assert_nil TranslatableComponent.i18n_backend
+      assert_nil TranslatableComponent.__vc_i18n_backend
     end
   ensure
     ViewComponent::CompileCache.invalidate_class!(TranslatableComponent)


### PR DESCRIPTION
We have plenty of internal methods that are not meant to be used externally, often tagged @private. In a recent office hours, @camertron, @blakewilliams and I noted that we should better indicate when an internal method should not be dependended on. I've done so here by adding a `__vc_` prefix as is convention in other parts of the codebase already.

As a separate exercise, we should probably re-evaluate our public API surface area and see if we can make any public methods private.