### PR TITLE
update Rails and Ruby EOL support message

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,7 @@ nav_order: 5
 
     *Joel Hawksley*
 
-* Warn if using Ruby < 3.2 or Rails < 7.1, which will not be supported by ViewComponent v4, to be released no earlier than April 1, 2025.
+* Warn if using Ruby < 3.2 or Rails < 7.1, which won't be supported by ViewComponent v4, to be released no earlier than April 1, 2025.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,7 @@ nav_order: 5
 
     *Joel Hawksley*
 
-* Warn if using Ruby < 3.1 or Rails < 7.0, which will not be supported by ViewComponent v4.
+* Warn if using Ruby < 3.2 or Rails < 7.1, which will not be supported by ViewComponent v4.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,7 @@ nav_order: 5
 
     *Joel Hawksley*
 
-* Warn if using Ruby < 3.2 or Rails < 7.1, which will not be supported by ViewComponent v4.
+* Warn if using Ruby < 3.2 or Rails < 7.1, which will not be supported by ViewComponent v4, to be released no earlier than April 1, 2025.
 
     *Joel Hawksley*
 

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -21,10 +21,6 @@ module ViewComponent
   autoload :TestCase
   autoload :SystemTestCase
   autoload :Translatable
-
-  if defined?(Rails) && Rails.version < "7.1"
-    Kernel.warn("ViewComponent v4 will drop support for Rails < 7.1 no earlier than April 1, 2025.")
-  end
 end
 
 require "view_component/engine" if defined?(Rails::Engine)

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -22,8 +22,8 @@ module ViewComponent
   autoload :SystemTestCase
   autoload :Translatable
 
-  if defined?(Rails) && Rails.version < "7.0"
-    Kernel.warn("ViewComponent v4 will drop support for Rails < 7.0 in 2025.")
+  if defined?(Rails) && Rails.version < "7.1"
+    Kernel.warn("ViewComponent v4 will drop support for Rails < 7.1 no earlier than April 1, 2025.")
   end
 end
 

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -169,12 +169,12 @@ module ViewComponent
       end
 
       # :nocov:
-      if RUBY_VERSION < "3.0.0"
-        ViewComponent::Deprecation.deprecation_warning("Support for Ruby versions < 3.0.0", "ViewComponent 4.0 will remove support for Ruby versions < 3.0.0 ")
+      if RUBY_VERSION < "3.2.0"
+        ViewComponent::Deprecation.deprecation_warning("Support for Ruby versions < 3.2.0", "ViewComponent v4 will remove support for Ruby versions < 3.2.0 no earlier than April 1, 2025")
       end
 
-      if Rails.version.to_f < 6.1
-        ViewComponent::Deprecation.deprecation_warning("Support for Rails versions < 6.1", "ViewComponent 4.0 will remove support for Rails versions < 6.1 ")
+      if Rails.version.to_f < 7.1
+        ViewComponent::Deprecation.deprecation_warning("Support for Rails versions < 7.1", "ViewComponent v4 will remove support for Rails versions < 7.1 no earlier than April 1, 2025")
       end
       # :nocov:
 

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -66,8 +66,4 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency "net-pop"
     spec.add_development_dependency "net-smtp"
   end
-
-  unless RUBY_VERSION >= "3.2"
-    spec.post_install_message = "ViewComponent v4 will drop support for Ruby < 3.2 no earlier than April 1, 2025."
-  end
 end

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -65,7 +65,9 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency "net-imap"
     spec.add_development_dependency "net-pop"
     spec.add_development_dependency "net-smtp"
-  else
-    spec.post_install_message = "ViewComponent v4 will drop support for Ruby < 3.1 in 2025."
+  end
+
+  unless RUBY_VERSION >= "3.2"
+    spec.post_install_message = "ViewComponent v4 will drop support for Ruby < 3.2 no earlier than April 1, 2025."
   end
 end


### PR DESCRIPTION
In concert with the work going on to [prep for v4](https://github.com/ViewComponent/view_component/pull/2085), this change clarifies the messaging in `main` around changing support for Ruby and Rails versions.