### PR TITLE
Add ostruct to gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,7 +348,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  ostruct (~> 0.6)
+  ostruct
   pry (~> 0.13)
   puma (~> 6)
   rails (~> 7.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,7 @@ GEM
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
@@ -347,6 +348,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  ostruct (~> 0.6)
   pry (~> 0.13)
   puma (~> 6)
   rails (~> 7.0.0)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ nav_order: 5
 
 * Add `ostruct` to gemspec file to suppress stdlib removal warning.
 
-  *Jonathan Underwood*
+    *Jonathan Underwood*
 
 ## 3.15.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add `ostruct` to gemspec file to suppress stdlib removal warning.
+
+  *Jonathan Underwood*
+
 ## 3.15.0
 
 * Add basic internal testing for memory allocations.

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "jbuilder", "~> 2"
   spec.add_development_dependency "m", "~> 1"
   spec.add_development_dependency "minitest", "~> 5.18"
+  spec.add_development_dependency "ostruct", "~> 0.6"
   spec.add_development_dependency "pry", "~> 0.13"
   spec.add_development_dependency "puma", "~> 6"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -45,7 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "jbuilder", "~> 2"
   spec.add_development_dependency "m", "~> 1"
   spec.add_development_dependency "minitest", "~> 5.18"
-  spec.add_development_dependency "ostruct", "~> 0.6"
   spec.add_development_dependency "pry", "~> 0.13"
   spec.add_development_dependency "puma", "~> 6"
   spec.add_development_dependency "rake", "~> 13.0"
@@ -66,5 +65,9 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency "net-imap"
     spec.add_development_dependency "net-pop"
     spec.add_development_dependency "net-smtp"
+  end
+
+  if RUBY_VERSION >= "3.3"
+    spec.add_development_dependency "ostruct"
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Suppressing a warning in Ruby 3.3.5 about `ostruct` being removed from the standard library in a future release of Ruby (3.5.0). 

### What approach did you choose and why?

Adding `ostruct` to the gemspec will suppress the warning now and future-proof the project when it is removed from the stdlib. 

### Anything you want to highlight for special attention from reviewers?

No.