### PR TITLE
Add configuration to treat content as a slot

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -135,7 +135,7 @@ module ViewComponent
       @__vc_content_evaluated = false
       @__vc_render_in_block = block
 
-      if self.class.send(:__vc_content_is_a_slot?)
+      if self.class.__vc_content_is_a_slot?
         @__vc_content_evaluated = true
         if __vc_render_in_block_provided?
           view_context.capture(self, &@__vc_render_in_block)
@@ -676,6 +676,11 @@ module ViewComponent
         __vc_initialize_parameter_names.include?(__vc_collection_iteration_parameter)
       end
 
+      # @private
+      def __vc_content_is_a_slot?
+        defined?(@__vc_content_is_a_slot) && @__vc_content_is_a_slot
+      end
+
       private
 
       def __vc_splatted_keyword_argument_present?
@@ -697,10 +702,6 @@ module ViewComponent
 
       def __vc_provided_collection_parameter
         @__vc_provided_collection_parameter ||= nil
-      end
-
-      def __vc_content_is_a_slot?
-        defined?(@__vc_content_is_a_slot) && @__vc_content_is_a_slot
       end
 
       def content_is_a_slot!

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -135,6 +135,13 @@ module ViewComponent
       @__vc_content_evaluated = false
       @__vc_render_in_block = block
 
+      if self.class.send(:__vc_content_is_a_slot?)
+        @__vc_content_evaluated = true
+        if __vc_render_in_block_provided?
+          view_context.capture(self, &@__vc_render_in_block)
+        end
+      end
+
       before_render
 
       if render?
@@ -565,6 +572,10 @@ module ViewComponent
           child.instance_variable_set(:@__vc_ancestor_calls, vc_ancestor_calls)
         end
 
+        if defined?(@__vc_content_is_a_slot)
+          child.instance_variable_set(:@__vc_content_is_a_slot, @__vc_content_is_a_slot)
+        end
+
         super
       end
 
@@ -686,6 +697,19 @@ module ViewComponent
 
       def __vc_provided_collection_parameter
         @__vc_provided_collection_parameter ||= nil
+      end
+
+      def __vc_content_is_a_slot?
+        defined?(@__vc_content_is_a_slot) && @__vc_content_is_a_slot
+      end
+
+      def content_is_a_slot!
+        @__vc_content_is_a_slot = true
+        renders_one :content
+      end
+
+      def do_not_use_content_as_a_slot!
+        @__vc_content_is_a_slot = false
       end
     end
 

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -304,8 +304,10 @@ module ViewComponent
       end
 
       def __vc_validate_plural_slot_name(slot_name)
-        if RESERVED_NAMES[:plural].include?(slot_name.to_sym)
-          raise ReservedPluralSlotNameError.new(name, slot_name)
+        if slot_name.to_sym == :contents && !__vc_content_is_a_slot?
+          if RESERVED_NAMES[:plural].include?(slot_name.to_sym)
+            raise ReservedPluralSlotNameError.new(name, slot_name)
+          end
         end
 
         __vc_raise_if_slot_name_uncountable(slot_name)
@@ -315,12 +317,12 @@ module ViewComponent
       end
 
       def __vc_validate_singular_slot_name(slot_name)
-        if slot_name.to_sym == :content
+        if slot_name.to_sym == :content && !__vc_content_is_a_slot?
           raise ContentSlotNameError.new(name)
-        end
-
-        if RESERVED_NAMES[:singular].include?(slot_name.to_sym)
-          raise ReservedSingularSlotNameError.new(name, slot_name)
+        elsif !__vc_content_is_a_slot?
+          if RESERVED_NAMES[:singular].include?(slot_name.to_sym)
+            raise ReservedSingularSlotNameError.new(name, slot_name)
+          end
         end
 
         __vc_raise_if_slot_conflicts_with_call(slot_name)

--- a/test/sandbox/app/components/content_as_slot_component.html.erb
+++ b/test/sandbox/app/components/content_as_slot_component.html.erb
@@ -1,0 +1,5 @@
+<div>
+  <% if content? %>
+    <%= content %>
+  <% end %>
+</div>

--- a/test/sandbox/app/components/content_as_slot_component.rb
+++ b/test/sandbox/app/components/content_as_slot_component.rb
@@ -1,0 +1,3 @@
+class ContentAsSlotComponent < ViewComponent::Base
+  content_is_a_slot!
+end

--- a/test/sandbox/app/components/content_not_a_slot_component.rb
+++ b/test/sandbox/app/components/content_not_a_slot_component.rb
@@ -1,0 +1,3 @@
+class ContentNotASlotComponent < ViewComponent::Base
+  do_not_use_content_as_a_slot!
+end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -831,4 +831,62 @@ class SlotableTest < ViewComponent::TestCase
 
     assert_selector(".breadcrumb.active")
   end
+
+  def test_content_as_a_slot_component
+    component = ContentAsSlotComponent.new
+    render_inline(component) do |c|
+      c.with_content do
+        "The truth is out there"
+      end
+    end
+
+    assert component.content?
+    assert_selector "div", text: "The truth is out there"
+  end
+
+  def test_content_as_a_slot_component_with_content
+    component = ContentAsSlotComponent.new
+    component.with_content do
+      "The truth is out there"
+    end
+    render_inline(component)
+
+    assert component.content?
+    assert_selector "div", text: "The truth is out there"
+  end
+
+  def test_content_as_a_slot_inheritance
+    new_component_class = Class.new(ContentAsSlotComponent)
+    assert new_component_class.send(:__vc_content_is_a_slot?)
+  end
+
+  def test_content_is_not_a_slot
+    new_component_class = Class.new(SlotsComponent) do
+      do_not_use_content_as_a_slot!
+    end
+    refute new_component_class.send(:__vc_content_is_a_slot?)
+
+    render_inline(SlotsComponent.new) do |component|
+      component.with_title do
+        "This is my title!"
+      end
+
+      component.with_subtitle do
+        "This is my subtitle!"
+      end
+
+      component.with_footer do
+        "This is the footer"
+      end
+    end
+
+    assert_text "No tabs provided"
+    assert_text "No items provided"
+  end
+
+  def test_content_is_not_a_slot_inheritance
+    refute ContentNotASlotComponent.send(:__vc_content_is_a_slot?)
+    new_component_class = Class.new(ContentNotASlotComponent)
+    refute new_component_class.send(:__vc_content_is_a_slot?)
+  end
 end


### PR DESCRIPTION
Like discussed many times before, this adds content as a slot to
ViewComponent so that we can begin separating the block provided when
rendering from content for performance and ergonomic reasons.

This adds two new methods:

* `content_is_a_slot!` - This makes the component _and its descendants_
  treat `content` as a slot, and the block provided to render calls _is
  always executed_.
* `do_not_use_content_as_a_slot!` - This keeps the existing behavior
  where `content` is lazily evaluated and is used to return content.

There's likely more implications from this change that need to be walked
through (like how slots are used, and easily setting content) before
this can be merged.
