### PR TITLE
Re-add `@private`, undocumented `.identifier` method that was only me…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Re-add `@private`, undocumented `.identifier` method that was only meant for internal framework use but was used by some downstream consumers. This method will be removed in a coming minor release.
+
+    *Joel Hawksley*
+
 ## 3.15.0
 
 * Add basic internal testing for memory allocations.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -576,9 +576,11 @@ module ViewComponent
 
       # @private
       def identifier
+        # :nocov:
         Kernel.warn("WARNING: The #{self.class}.identifier is undocumented and was meant for internal framework usage only. As it is no longer used by the framework it will be removed in a coming non-breaking ViewComponent release.")
 
         source_location
+        # :nocov:
       end
 
       # Set the parameter name used when rendering elements of a collection ([documentation](/guide/collections)):

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -574,6 +574,13 @@ module ViewComponent
         @__vc_compiler ||= Compiler.new(self)
       end
 
+      # @private
+      def identifier
+        Kernel.warn("WARNING: The #{self.class}.identifier is undocumented and was meant for internal framework usage only. As it is no longer used by the framework it will be removed in a coming non-breaking ViewComponent release.")
+
+        source_location
+      end
+
       # Set the parameter name used when rendering elements of a collection ([documentation](/guide/collections)):
       #
       # ```ruby


### PR DESCRIPTION
…ant for internal framework use but was used by some downstream consumers. This method will be removed in a coming minor release.