### PR TITLE
Add template information to multiple template error messages.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add template information to multiple template error messages.
+
+    *Joel Hawksley*
+
 * Add `ostruct` to gemspec file to suppress stdlib removal warning.
 
     *Jonathan Underwood*

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -159,7 +159,7 @@ module ViewComponent
         errors << "Colliding templates #{variant_names.sort.map { |v| "'#{v}'" }.to_sentence} found in #{@component}."
       end
 
-      raise TemplateError.new(errors) if errors.any? && raise_errors
+      raise TemplateError.new(errors, @templates) if errors.any? && raise_errors
 
       errors
     end

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -22,7 +22,7 @@ module ViewComponent
 
       if templates
         message << "\n"
-        message << "Templates:"
+        message << "Templates:\n"
         message << templates.map(&:inspect).join("\n")
       end
 

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -17,8 +17,16 @@ module ViewComponent
   end
 
   class TemplateError < StandardError
-    def initialize(errors)
-      super(errors.join("\n"))
+    def initialize(errors, templates = nil)
+      message = errors.join("\n")
+
+      if templates
+        message << "\n"
+        message << "Templates:"
+        message << templates.map(&:inspect).join("\n")
+      end
+
+      super(message)
     end
   end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -514,6 +514,11 @@ class RenderingTest < ViewComponent::TestCase
 
     assert_includes(
       error.message,
+      "ViewComponent::Template:"
+    )
+
+    assert_includes(
+      error.message,
       "Template file and inline render method found for variant 'phone' in " \
       "VariantTemplateAndInlineVariantTemplateComponent."
     )


### PR DESCRIPTION
In service of helping debug https://github.com/ViewComponent/view_component/issues/2114, this change fleshes out the template error messages to include the current list of templates.