### PR TITLE
Fix #vc_test_request example

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ nav_order: 5
 
     *Denis Pasin*
 
+* Fix the example of #vc_test_request in the API reference to use the correct method name.
+
+    *Alberto Rocha*
+
 ## 3.16.0
 
 * Add template information to multiple template error messages.

--- a/docs/api.md
+++ b/docs/api.md
@@ -343,7 +343,7 @@ Access the request used by `render_inline`:
 
 ```ruby
 test "component does not render in Firefox" do
-  request.env["HTTP_USER_AGENT"] = "Mozilla/5.0"
+  vc_test_request.env["HTTP_USER_AGENT"] = "Mozilla/5.0"
   render_inline(NoFirefoxComponent.new)
   refute_component_rendered
 end


### PR DESCRIPTION
This PR aims to fix the example provided for #vc_test_request to use "vc_test_request" instead of "request".

### What are you trying to accomplish?

This PR fixes a documentation issue, updating  `docs/api.md ` to reflect the correct usage of the #vc_test_request method.

### What approach did you choose and why?

Simple documentation fix.

### Anything you want to highlight for special attention from reviewers?

Check for other references where `request` should be changed to `vc_test_request`.