### PR TITLE
Use struct instead openstruct in lib code

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Use struct instead openstruct in lib code.
+
+    *Oleksii Vasyliev*
+
 * Fix bug where stimulus controller was not added to ERB when stimulus was activated by default.
 
     *Denis Pasin*

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -1,7 +1,10 @@
-require "ostruct"
+# frozen_string_literal: true
 
 module ViewComponent
   class Template
+    DataWithSource = Struct.new(:format, :identifier, :short_identifier, :type, keyword_init: true)
+    DataNoSource = Struct.new(:source, :identifier, :type, keyword_init: true)
+
     attr_reader :variant, :this_format, :type
 
     def initialize(
@@ -109,13 +112,13 @@ module ViewComponent
 
       if handler.method(:call).parameters.length > 1
         handler.call(
-          OpenStruct.new(format: @this_format, identifier: @path, short_identifier: short_identifier, type: type),
+          DataWithSource.new(format: @this_format, identifier: @path, short_identifier: short_identifier, type: type),
           this_source
         )
       # :nocov:
       # TODO: Remove in v4
       else
-        handler.call(OpenStruct.new(source: this_source, identifier: @path, type: type))
+        handler.call(DataNoSource.new(source: this_source, identifier: @path, type: type))
       end
       # :nocov:
     end

--- a/test/sandbox/app/controllers/application_controller.rb
+++ b/test/sandbox/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
+require "ostruct"
+
 class ApplicationController < ActionController::Base
 end


### PR DESCRIPTION
### What are you trying to accomplish?

 - Fix showdown by using OpenStruct, especially with YJIT
   - https://github.com/ruby/ruby/blob/master/doc/yjit/yjit.md#code-optimization-tips
   - https://www.reddit.com/r/ruby/comments/11wem2c/question_does_anyone_know_why_openstruct_with/
 - Should eat less memory and be fast
 
![Screenshot 2024-10-06 at 23 30 35](https://github.com/user-attachments/assets/f69651fa-1336-4c27-82a5-a3d0d6428be2)

### What approach did you choose and why?

 - Use Struct, because it is implemented on C, while OpenStruct implemented on Ruby


### Anything you want to highlight for special attention from reviewers?

 - I am fine to use OpenStruct in tests (that is why nothing changed in its) - it more about convenience for developers to quickly make some tests data