### PR TITLE
Make accommodations for component-local config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -95,7 +95,7 @@ namespace :docs do
     require "rails"
     require "action_controller"
     require "view_component"
-    ViewComponent::Base.config.view_component_path = "view_component"
+    ViewComponent::GlobalConfig.view_component_path = "view_component"
     require "view_component/docs_builder_component"
 
     error_keys = registry.keys.select { |key| key.to_s.include?("Error::MESSAGE") }.map(&:to_s)

--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -54,12 +54,12 @@ module ViewComponent
 
     # :doc:
     def default_preview_layout
-      ViewComponent::Base.config.default_preview_layout
+      GlobalConfig.default_preview_layout
     end
 
     # :doc:
     def show_previews?
-      ViewComponent::Base.config.show_previews
+      GlobalConfig.show_previews
     end
 
     # :doc:
@@ -102,7 +102,7 @@ module ViewComponent
     end
 
     def prepend_preview_examples_view_path
-      prepend_view_path(ViewComponent::Base.preview_paths)
+      prepend_view_path(GlobalConfig.preview_paths)
     end
   end
 end

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -35,7 +35,7 @@ module PreviewHelper
       # Fetch template source via finding it through preview paths
       # to accomodate source view when exclusively using templates
       # for previews for Rails < 6.1.
-      all_template_paths = ViewComponent::Base.config.preview_paths.map do |preview_path|
+      all_template_paths = ViewComponent::GlobalConfig.preview_paths.map do |preview_path|
         Dir.glob("#{preview_path}/**/*")
       end.flatten
 
@@ -80,6 +80,6 @@ module PreviewHelper
   # :nocov:
 
   def serve_static_preview_assets?
-    ViewComponent::Base.config.show_previews && Rails.application.config.public_file_server.enabled
+    ViewComponent::GlobalConfig.show_previews && Rails.application.config.public_file_server.enabled
   end
 end

--- a/app/views/view_components/preview.html.erb
+++ b/app/views/view_components/preview.html.erb
@@ -1,5 +1,5 @@
 <% if @render_args[:component] %>
-  <% if ViewComponent::Base.config.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 %>
+  <% if ViewComponent::GlobalConfig.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 %>
     <%= render(@render_args[:component], @render_args[:args], &@render_args[:block]) %>
   <% else %>
     <%= render_component(@render_args[:component], &@render_args[:block]) %>
@@ -8,6 +8,6 @@
   <%= render template: @render_args[:template], locals: @render_args[:locals] || {} %>
 <% end %>
 
-<% if ViewComponent::Base.config.show_previews_source %>
+<% if ViewComponent::GlobalConfig.show_previews_source %>
   <%= preview_source %>
 <% end %>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Make accommodations for component-local config to be introduced in future.
+
+    *Simon Fish*
+
 * Remove JS and CSS docs as they proved difficult to maintain and lacked consensus.
 
     *Joel Hawksley*

--- a/lib/rails/generators/abstract_generator.rb
+++ b/lib/rails/generators/abstract_generator.rb
@@ -29,7 +29,7 @@ module ViewComponent
     end
 
     def component_path
-      ViewComponent::Base.config.view_component_path
+      GlobalConfig.view_component_path
     end
 
     def stimulus_controller
@@ -42,15 +42,15 @@ module ViewComponent
     end
 
     def sidecar?
-      options["sidecar"] || ViewComponent::Base.config.generate.sidecar
+      options["sidecar"] || GlobalConfig.generate.sidecar
     end
 
     def stimulus?
-      options["stimulus"] || ViewComponent::Base.config.generate.stimulus_controller
+      options["stimulus"] || GlobalConfig.generate.stimulus_controller
     end
 
     def typescript?
-      options["typescript"] || ViewComponent::Base.config.generate.typescript
+      options["typescript"] || GlobalConfig.generate.typescript
     end
   end
 end

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -13,12 +13,12 @@ module Rails
       check_class_collision suffix: "Component"
 
       class_option :inline, type: :boolean, default: false
-      class_option :locale, type: :boolean, default: ViewComponent::Base.config.generate.locale
+      class_option :locale, type: :boolean, default: ViewComponent::GlobalConfig.generate.locale
       class_option :parent, type: :string, desc: "The parent class for the generated component"
-      class_option :preview, type: :boolean, default: ViewComponent::Base.config.generate.preview
+      class_option :preview, type: :boolean, default: ViewComponent::GlobalConfig.generate.preview
       class_option :sidecar, type: :boolean, default: false
       class_option :stimulus, type: :boolean,
-        default: ViewComponent::Base.config.generate.stimulus_controller
+        default: ViewComponent::GlobalConfig.generate.stimulus_controller
       class_option :skip_suffix, type: :boolean, default: false
 
       def create_component_file
@@ -42,7 +42,7 @@ module Rails
       def parent_class
         return options[:parent] if options[:parent]
 
-        ViewComponent::Base.config.component_parent_class || default_parent_class
+        ViewComponent::GlobalConfig.component_parent_class || default_parent_class
       end
 
       def initialize_signature

--- a/lib/rails/generators/locale/component_generator.rb
+++ b/lib/rails/generators/locale/component_generator.rb
@@ -12,7 +12,7 @@ module Locale
       class_option :sidecar, type: :boolean, default: false
 
       def create_locale_file
-        if ViewComponent::Base.config.generate.distinct_locale_files
+        if ViewComponent::GlobalConfig.generate.distinct_locale_files
           I18n.available_locales.each do |locale|
             create_file destination(locale), translations_hash([locale]).to_yaml
           end

--- a/lib/rails/generators/preview/component_generator.rb
+++ b/lib/rails/generators/preview/component_generator.rb
@@ -4,13 +4,13 @@ module Preview
   module Generators
     class ComponentGenerator < ::Rails::Generators::NamedBase
       source_root File.expand_path("templates", __dir__)
-      class_option :preview_path, type: :string, desc: "Path for previews, required when multiple preview paths are configured", default: ViewComponent::Base.config.generate.preview_path
+      class_option :preview_path, type: :string, desc: "Path for previews, required when multiple preview paths are configured", default: ViewComponent::GlobalConfig.generate.preview_path
 
       argument :attributes, type: :array, default: [], banner: "attribute"
       check_class_collision suffix: "ComponentPreview"
 
       def create_preview_file
-        preview_paths = ViewComponent::Base.config.preview_paths
+        preview_paths = ViewComponent::GlobalConfig.preview_paths
         optional_path = options[:preview_path]
         return if preview_paths.count > 1 && optional_path.blank?
 

--- a/lib/rails/generators/rspec/component_generator.rb
+++ b/lib/rails/generators/rspec/component_generator.rb
@@ -16,7 +16,7 @@ module Rspec
       private
 
       def spec_component_path
-        return "spec/components" unless ViewComponent::Base.config.generate.use_component_path_for_rspec_tests
+        return "spec/components" unless ViewComponent::GlobalConfig.generate.use_component_path_for_rspec_tests
 
         configured_component_path = component_path
         if configured_component_path.start_with?("app#{File::SEPARATOR}")

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -13,6 +13,7 @@ module ViewComponent
   autoload :ComponentError
   autoload :Config
   autoload :Deprecation
+  autoload :GlobalConfig
   autoload :InlineTemplate
   autoload :Instrumentation
   autoload :Preview

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -11,7 +11,7 @@ module ViewComponent
       alias_method :default, :new
 
       def defaults
-        ActiveSupport::OrderedOptions.new.merge!({
+        ActiveSupport::InheritableOptions.new({
           generate: default_generate_options,
           preview_controller: "ViewComponentsController",
           preview_route: "/rails/view_components",

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -6,7 +6,7 @@ require "view_component/deprecation"
 
 module ViewComponent
   class Engine < Rails::Engine # :nodoc:
-    config.view_component = ViewComponent::Config.current
+    config.view_component = ViewComponent::Config.defaults
 
     if Rails.version.to_f < 8.0
       rake_tasks do
@@ -16,8 +16,8 @@ module ViewComponent
       initializer "view_component.stats_directories" do |app|
         require "rails/code_statistics"
 
-        if Rails.root.join(ViewComponent::Base.view_component_path).directory?
-          Rails::CodeStatistics.register_directory("ViewComponents", ViewComponent::Base.view_component_path)
+        if Rails.root.join(GlobalConfig.view_component_path).directory?
+          Rails::CodeStatistics.register_directory("ViewComponents", GlobalConfig.view_component_path)
         end
 
         if Rails.root.join("test/components").directory?
@@ -29,7 +29,7 @@ module ViewComponent
     initializer "view_component.set_configs" do |app|
       options = app.config.view_component
 
-      %i[generate preview_controller preview_route show_previews_source].each do |config_option|
+      %i[generate preview_controller preview_route].each do |config_option|
         options[config_option] ||= ViewComponent::Base.public_send(config_option)
       end
       options.instrumentation_enabled = false if options.instrumentation_enabled.nil?

--- a/lib/view_component/global_config.rb
+++ b/lib/view_component/global_config.rb
@@ -1,0 +1,3 @@
+module ViewComponent
+  GlobalConfig = (defined?(Rails) && Rails.application) ? Rails.application.config.view_component : Config.defaults # standard:disable Naming/ConstantName
+end

--- a/lib/view_component/instrumentation.rb
+++ b/lib/view_component/instrumentation.rb
@@ -23,7 +23,7 @@ module ViewComponent # :nodoc:
     private
 
     def notification_name
-      return "!render.view_component" if ViewComponent::Base.config.use_deprecated_instrumentation_name
+      return "!render.view_component" if GlobalConfig.use_deprecated_instrumentation_name
 
       "render.view_component"
     end

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -109,7 +109,7 @@ module ViewComponent # :nodoc:
       private
 
       def preview_paths
-        Base.preview_paths
+        ViewComponent::GlobalConfig.preview_paths
       end
     end
   end

--- a/lib/view_component/rails/tasks/view_component.rake
+++ b/lib/view_component/rails/tasks/view_component.rake
@@ -7,8 +7,8 @@ namespace :view_component do
     # :nocov:
     require "rails/code_statistics"
 
-    if Rails.root.join(ViewComponent::Base.view_component_path).directory?
-      ::STATS_DIRECTORIES << ["ViewComponents", ViewComponent::Base.view_component_path]
+    if Rails.root.join(ViewComponent::GlobalConfig.view_component_path).directory?
+      ::STATS_DIRECTORIES << ["ViewComponents", ViewComponent::GlobalConfig.view_component_path]
     end
 
     if Rails.root.join("test/components").directory?

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -250,7 +250,7 @@ module ViewComponent
     #
     # @return [ActionController::Base]
     def vc_test_controller
-      @vc_test_controller ||= __vc_test_helpers_build_controller(Base.test_controller.constantize)
+      @vc_test_controller ||= __vc_test_helpers_build_controller(GlobalConfig.test_controller.constantize)
     end
 
     # Access the request used by `render_inline`:

--- a/lib/view_component/use_helpers.rb
+++ b/lib/view_component/use_helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "view_component/errors"
+
 module ViewComponent::UseHelpers
   extend ActiveSupport::Concern
 
@@ -13,7 +15,7 @@ module ViewComponent::UseHelpers
 
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
         def #{helper_method_name}(*args, &block)
-          raise HelpersCalledBeforeRenderError if view_context.nil?
+          raise ::ViewComponent::HelpersCalledBeforeRenderError if view_context.nil?
 
           #{define_helper(helper_method: helper_method, source: from)}
         end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,8 +16,8 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 117, "3.4.1" => 117, "3.3.7" => 129} :
-      {"3.3.7" => 120, "3.3.0" => 120, "3.2.6" => 118, "3.1.6" => 118, "3.0.7" => 127}
+      {"3.5.0" => 117, "3.4.1" => 117, "3.3.7" => 128} :
+      {"3.3.7" => 119, "3.3.0" => 119, "3.2.6" => 117, "3.1.6" => 117, "3.0.7" => 126}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)

--- a/test/test_engine/test_helper.rb
+++ b/test/test_engine/test_helper.rb
@@ -22,7 +22,7 @@ require "view_component"
 
 Rails::Generators.namespace = TestEngine
 
-def with_config_option(option_name, new_value, config_entrypoint: TestEngine::Engine.config.view_component)
+def with_config_option(option_name, new_value, config_entrypoint: ViewComponent::GlobalConfig)
   old_value = config_entrypoint.public_send(option_name)
   config_entrypoint.public_send(:"#{option_name}=", new_value)
   yield


### PR DESCRIPTION
Explicitly declares access to current config as global where necessary, and makes it possible for us to introduce a component-local config that inherits from these global options in future.

Unsure of how this interacts with gems with engines that depend on ViewComponent, but I'm hoping in the long run it's a step in the right direction for them that'll allow them to have their own `ApplicationComponent` equivalents that inherit their config from ViewComponent's own defaults.