### PR TITLE
Register tests directory for rails stats

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Register tests directory for rails stats
+
+    *Javier Aranda*
+
 * Fix `preview_paths` in docs.
 
     *Javier Aranda*

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -15,8 +15,14 @@ module ViewComponent
     else
       initializer "view_component.stats_directories" do |app|
         require "rails/code_statistics"
-        dir = ViewComponent::Base.view_component_path
-        Rails::CodeStatistics.register_directory("ViewComponents", dir)
+
+        if Rails.root.join(ViewComponent::Base.view_component_path).directory?
+          Rails::CodeStatistics.register_directory("ViewComponents", ViewComponent::Base.view_component_path)
+        end
+
+        if Rails.root.join("test/components").directory?
+          Rails::CodeStatistics.register_directory("ViewComponent tests", "test/components", test_directory: true)
+        end
       end
     end
 

--- a/lib/view_component/rails/tasks/view_component.rake
+++ b/lib/view_component/rails/tasks/view_component.rake
@@ -7,8 +7,14 @@ namespace :view_component do
     # :nocov:
     require "rails/code_statistics"
 
-    dir = ViewComponent::Base.view_component_path
-    ::STATS_DIRECTORIES << ["ViewComponents", dir] if File.directory?(Rails.root + dir)
+    if Rails.root.join(ViewComponent::Base.view_component_path).directory?
+      ::STATS_DIRECTORIES << ["ViewComponents", ViewComponent::Base.view_component_path]
+    end
+
+    if Rails.root.join("test/components").directory?
+      ::STATS_DIRECTORIES << ["ViewComponent tests", "test/components"]
+      CodeStatistics::TEST_TYPES << "ViewComponent tests"
+    end
     # :nocov:
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

After the introduction of PR #2081, the tests directory was missing in rails stats.