### PR TITLE
Remove OpenStruct from codebase

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,6 @@ GEM
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
@@ -355,7 +354,6 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  ostruct
   pry (~> 0.13)
   puma (~> 6)
   rails (~> 7.0.0)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Remove OpenStruct from codebase
+* Remove OpenStruct from codebase.
 
     *Oleksii Vasyliev*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Remove OpenStruct from codebase
+
+    *Oleksii Vasyliev*
+
 ## 3.19.0
 
 * Relax Active Support version constraint in gemspec.

--- a/test/sandbox/app/components/partial_component.html.erb
+++ b/test/sandbox/app/components/partial_component.html.erb
@@ -1,3 +1,3 @@
 <%= render partial: "test_partial" %>
 <%= render "test_partial" %>
-<%= render OpenStruct.new(to_partial_path: "test_partial") %>
+<%= render PartialModel.new(to_partial_path: "test_partial") %>

--- a/test/sandbox/app/controllers/application_controller.rb
+++ b/test/sandbox/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
-require "ostruct"
-
 class ApplicationController < ActionController::Base
 end

--- a/test/sandbox/app/controllers/integration_examples_controller.rb
+++ b/test/sandbox/app/controllers/integration_examples_controller.rb
@@ -43,11 +43,11 @@ class IntegrationExamplesController < ActionController::Base
   end
 
   def products
-    @products = [OpenStruct.new(name: "Radio clock"), OpenStruct.new(name: "Mints")]
+    @products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
   end
 
   def inline_products
-    products = [OpenStruct.new(name: "Radio clock"), OpenStruct.new(name: "Mints")]
+    products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
 
     render(ProductComponent.with_collection(products, notice: "Today only"))
   end

--- a/test/sandbox/app/models/coupon.rb
+++ b/test/sandbox/app/models/coupon.rb
@@ -1,0 +1,1 @@
+Coupon = Struct.new(:percent_off, keyword_init: true)

--- a/test/sandbox/app/models/partial_model.rb
+++ b/test/sandbox/app/models/partial_model.rb
@@ -1,0 +1,1 @@
+PartialModel = Struct.new(:to_partial_path, keyword_init: true)

--- a/test/sandbox/app/models/photo.rb
+++ b/test/sandbox/app/models/photo.rb
@@ -1,0 +1,1 @@
+Photo = Struct.new(:title, :caption, :url, keyword_init: true)

--- a/test/sandbox/app/models/product.rb
+++ b/test/sandbox/app/models/product.rb
@@ -1,0 +1,1 @@
+Product = Struct.new(:name, keyword_init: true)

--- a/test/sandbox/test/collection_test.rb
+++ b/test/sandbox/test/collection_test.rb
@@ -17,7 +17,7 @@ module ViewComponent
     end
 
     def setup
-      @products = [OpenStruct.new(name: "Radio clock"), OpenStruct.new(name: "Mints")]
+      @products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
       @collection = ProductComponent.with_collection(@products, notice: "secondhand")
     end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -587,7 +587,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_collection
-    products = [OpenStruct.new(name: "Radio clock"), OpenStruct.new(name: "Mints")]
+    products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
     render_inline(ProductComponent.with_collection(products, notice: "On sale"))
 
     assert_selector("h1", text: "Product", count: 2)
@@ -599,7 +599,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_collection_custom_collection_parameter_name
-    coupons = [OpenStruct.new(percent_off: 20), OpenStruct.new(percent_off: 50)]
+    coupons = [Coupon.new(percent_off: 20), Coupon.new(percent_off: 50)]
     render_inline(ProductCouponComponent.with_collection(coupons))
 
     assert_selector("h3", text: "20%")
@@ -608,8 +608,8 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_render_collection_custom_collection_parameter_name_counter
     photos = [
-      OpenStruct.new(title: "Flowers", caption: "Yellow flowers", url: "https://example.com/flowers.jpg"),
-      OpenStruct.new(title: "Mountains", caption: "Mountains at sunset", url: "https://example.com/mountains.jpg")
+      Photo.new(title: "Flowers", caption: "Yellow flowers", url: "https://example.com/flowers.jpg"),
+      Photo.new(title: "Mountains", caption: "Mountains at sunset", url: "https://example.com/mountains.jpg")
     ]
     render_inline(CollectionCounterComponent.with_collection(photos))
 
@@ -622,8 +622,8 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_render_collection_custom_collection_parameter_name_iteration
     photos = [
-      OpenStruct.new(title: "Flowers", caption: "Yellow flowers", url: "https://example.com/flowers.jpg"),
-      OpenStruct.new(title: "Mountains", caption: "Mountains at sunset", url: "https://example.com/mountains.jpg")
+      Photo.new(title: "Flowers", caption: "Yellow flowers", url: "https://example.com/flowers.jpg"),
+      Photo.new(title: "Mountains", caption: "Mountains at sunset", url: "https://example.com/mountains.jpg")
     ]
     render_inline(CollectionIterationComponent.with_collection(photos))
 
@@ -636,8 +636,8 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_render_collection_custom_collection_parameter_name_iteration_extend_other_component
     photos = [
-      OpenStruct.new(title: "Flowers", caption: "Yellow flowers", url: "https://example.com/flowers.jpg"),
-      OpenStruct.new(title: "Mountains", caption: "Mountains at sunset", url: "https://example.com/mountains.jpg")
+      Photo.new(title: "Flowers", caption: "Yellow flowers", url: "https://example.com/flowers.jpg"),
+      Photo.new(title: "Mountains", caption: "Mountains at sunset", url: "https://example.com/mountains.jpg")
     ]
     render_inline(CollectionIterationExtendComponent.with_collection(photos))
 
@@ -650,8 +650,8 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_render_collection_custom_collection_parameter_name_iteration_extend_other_component_override
     photos = [
-      OpenStruct.new(title: "Flowers", caption: "Yellow flowers", url: "https://example.com/flowers.jpg"),
-      OpenStruct.new(title: "Mountains", caption: "Mountains at sunset", url: "https://example.com/mountains.jpg")
+      Photo.new(title: "Flowers", caption: "Yellow flowers", url: "https://example.com/flowers.jpg"),
+      Photo.new(title: "Mountains", caption: "Mountains at sunset", url: "https://example.com/mountains.jpg")
     ]
     render_inline(CollectionIterationExtendOverrideComponent.with_collection(photos))
 
@@ -680,7 +680,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_collection_missing_arg
-    products = [OpenStruct.new(name: "Radio clock"), OpenStruct.new(name: "Mints")]
+    products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
     exception =
       assert_raises ArgumentError do
         render_inline(ProductComponent.with_collection(products))
@@ -691,7 +691,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_single_item_from_collection
-    product = OpenStruct.new(name: "Mints")
+    product = Product.new(name: "Mints")
     render_inline(ProductComponent.new(product: product, notice: "On sale"))
 
     assert_selector("h1", text: "Product", count: 1)
@@ -708,7 +708,7 @@ class RenderingTest < ViewComponent::TestCase
   def test_collection_component_missing_default_parameter_name
     assert_raises ViewComponent::MissingCollectionArgumentError do
       render_inline(
-        MissingDefaultCollectionParameterComponent.with_collection([OpenStruct.new(name: "Mints")])
+        MissingDefaultCollectionParameterComponent.with_collection([Product.new(name: "Mints")])
       )
     end
   end
@@ -716,7 +716,7 @@ class RenderingTest < ViewComponent::TestCase
   def test_collection_component_missing_custom_parameter_name_with_activemodel
     assert_raises ViewComponent::MissingCollectionArgumentError do
       render_inline(
-        MissingCollectionParameterWithActiveModelComponent.with_collection([OpenStruct.new(name: "Mints")])
+        MissingCollectionParameterWithActiveModelComponent.with_collection([Product.new(name: "Mints")])
       )
     end
   end
@@ -724,7 +724,7 @@ class RenderingTest < ViewComponent::TestCase
   def test_collection_component_present_custom_parameter_name_with_activemodel
     assert_nothing_raised do
       render_inline(
-        CollectionParameterWithActiveModelComponent.with_collection([OpenStruct.new(name: "Mints")])
+        CollectionParameterWithActiveModelComponent.with_collection([Product.new(name: "Mints")])
       )
     end
   end

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -72,6 +72,5 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency "bigdecimal"
     spec.add_development_dependency "drb"
     spec.add_development_dependency "mutex_m"
-    spec.add_development_dependency "ostruct"
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Continue cleanup for OpenStruct - https://github.com/ViewComponent/view_component/pull/2123

### What approach did you choose and why?

Replaced OpenStruct to Struct in tests

### Anything you want to highlight for special attention from reviewers?