### PR TITLE
Call maybe_escape_html directly in compiled call method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /test/sandbox/log/*
 /test/tmp/*
 /.yardoc
+.DS_Store
 
 ## Specific to RubyMotion:
 .dat*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Ensure HTML output safety wrapper is used for all inline templates.
+
+    *Joel Hawksley*
+
 ## 3.20.0
 
 * Allow rendering `with_collection` to accept an optional `spacer_component` to be rendered between each item.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -108,14 +108,7 @@ module ViewComponent
       before_render
 
       if render?
-        rendered_template =
-          if compiler.renders_template_for?(@__vc_variant, __vc_request&.format&.to_sym)
-            render_template_for(@__vc_variant, __vc_request&.format&.to_sym)
-          else
-            maybe_escape_html(render_template_for(@__vc_variant, __vc_request&.format&.to_sym)) do
-              Kernel.warn("WARNING: The #{self.class} component rendered HTML-unsafe output. The output will be automatically escaped, but you may want to investigate.")
-            end
-          end.to_s
+        rendered_template = render_template_for(@__vc_variant, __vc_request&.format&.to_sym).to_s
 
         # Avoid allocating new string when output_preamble and output_postamble are blank
         if output_preamble.blank? && output_postamble.blank?

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -351,10 +351,6 @@ module ViewComponent
       end
     end
 
-    def compiler
-      @compiler ||= self.class.compiler
-    end
-
     # Set the controller used for testing components:
     #
     # ```ruby

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -66,9 +66,9 @@ module ViewComponent
 
       method_body =
         if @templates.one?
-          @templates.first.safe_method_name_escaped
+          @templates.first.safe_method_name_call
         elsif (template = @templates.find(&:inline?))
-          template.safe_method_name_escaped
+          template.safe_method_name_call
         else
           branches = []
 
@@ -83,13 +83,13 @@ module ViewComponent
                 ].join(" && ")
               end
 
-            branches << [conditional, template.safe_method_name_escaped]
+            branches << [conditional, template.safe_method_name_call]
           end
 
           out = branches.each_with_object(+"") do |(conditional, branch_body), memo|
             memo << "#{(!memo.present?) ? "if" : "elsif"} #{conditional}\n  #{branch_body}\n"
           end
-          out << "else\n  #{templates.find { _1.variant.nil? && _1.default_format? }.safe_method_name_escaped}\nend"
+          out << "else\n  #{templates.find { _1.variant.nil? && _1.default_format? }.safe_method_name_call}\nend"
         end
 
       @component.silence_redefinition_of_method(:render_template_for)

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -13,7 +13,6 @@ module ViewComponent
     def initialize(component)
       @component = component
       @lock = Mutex.new
-      @rendered_templates = Set.new
     end
 
     def compiled?
@@ -56,10 +55,6 @@ module ViewComponent
       end
     end
 
-    def renders_template_for?(variant, format)
-      @rendered_templates.include?([variant, format])
-    end
-
     private
 
     attr_reader :templates
@@ -71,9 +66,9 @@ module ViewComponent
 
       method_body =
         if @templates.one?
-          @templates.first.safe_method_name
+          @templates.first.safe_method_name_escaped
         elsif (template = @templates.find(&:inline?))
-          template.safe_method_name
+          template.safe_method_name_escaped
         else
           branches = []
 
@@ -88,13 +83,13 @@ module ViewComponent
                 ].join(" && ")
               end
 
-            branches << [conditional, template.safe_method_name]
+            branches << [conditional, template.safe_method_name_escaped]
           end
 
           out = branches.each_with_object(+"") do |(conditional, branch_body), memo|
             memo << "#{(!memo.present?) ? "if" : "elsif"} #{conditional}\n  #{branch_body}\n"
           end
-          out << "else\n  #{templates.find { _1.variant.nil? && _1.default_format? }.safe_method_name}\nend"
+          out << "else\n  #{templates.find { _1.variant.nil? && _1.default_format? }.safe_method_name_escaped}\nend"
         end
 
       @component.silence_redefinition_of_method(:render_template_for)
@@ -195,10 +190,6 @@ module ViewComponent
               this_format: this_format.to_s.split(".").last&.to_sym, # strip locale from this_format, see #2113
               variant: variant
             )
-
-            # TODO: We should consider inlining the HTML output safety logic into the compiled render_template_for
-            # instead of this indirect approach
-            @rendered_templates << [out.variant, out.this_format]
 
             out
           end

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -59,7 +59,7 @@ module ViewComponent
       @component.define_method(safe_method_name, @component.instance_method(@call_method_name))
     end
 
-    def safe_method_name_escaped
+    def safe_method_name_call
       return safe_method_name unless inline_call?
 
       "maybe_escape_html(#{safe_method_name}) " \

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -59,6 +59,14 @@ module ViewComponent
       @component.define_method(safe_method_name, @component.instance_method(@call_method_name))
     end
 
+    def safe_method_name_escaped
+      return safe_method_name unless inline_call?
+
+      "maybe_escape_html(#{safe_method_name}) " \
+      "{ Kernel.warn('WARNING: The #{@component} component rendered HTML-unsafe output. " \
+      "The output will be automatically escaped, but you may want to investigate.') } "
+    end
+
     def requires_compiled_superclass?
       inline_call? && !defined_on_self?
     end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -15,7 +15,7 @@ class RenderingTest < ViewComponent::TestCase
     ViewComponent::CompileCache.cache.delete(MyComponent)
     MyComponent.ensure_compiled
 
-    assert_allocations("3.4.0" => 110, "3.3.5" => 116, "3.3.0" => 129, "3.2.6" => 115, "3.1.6" => 115, "3.0.7" => 125) do
+    assert_allocations("3.4.0" => 110, "3.3.5" => 116, "3.3.0" => 127, "3.2.6" => 115, "3.1.6" => 115, "3.0.7" => 125) do
       render_inline(MyComponent.new)
     end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -15,7 +15,7 @@ class RenderingTest < ViewComponent::TestCase
     ViewComponent::CompileCache.cache.delete(MyComponent)
     MyComponent.ensure_compiled
 
-    assert_allocations("3.4.0" => 110, "3.3.5" => 116, "3.3.0" => 127, "3.2.6" => 115, "3.1.6" => 115, "3.0.7" => 125) do
+    assert_allocations("3.4.0" => 109, "3.3.5" => 115, "3.3.0" => 127, "3.2.6" => 114, "3.1.6" => 114, "3.0.7" => 123) do
       render_inline(MyComponent.new)
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR refactors the logic for calling `maybe_escape_html` to be embedded in the template call method instead when necessary instead of the existing roundabout approach of trying to determine whether it should be called at runtime.
