### PR TITLE
Expose `.identifier`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Expose `.identifier` method as part of public API.
+
+    *Joel Hawksley*
+
 ## 3.20.0
 
 * Allow rendering `with_collection` to accept an optional `spacer_component` to be rendered between each item.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -457,8 +457,16 @@ module ViewComponent
     #  Defaults to `false`.
 
     class << self
+      # The file path of the component Ruby file.
+      #
+      # @return [String]
+      attr_reader :identifier
+
       # @private
-      attr_accessor :source_location, :virtual_path
+      attr_writer :identifier
+
+      # @private
+      attr_accessor :virtual_path
 
       # Find sidecar files for the given extensions.
       #
@@ -468,13 +476,13 @@ module ViewComponent
       # For example, one might collect sidecar CSS files that need to be compiled.
       # @param extensions [Array<String>] Extensions of which to return matching sidecar files.
       def sidecar_files(extensions)
-        return [] unless source_location
+        return [] unless identifier
 
         extensions = extensions.join(",")
 
         # view files in a directory named like the component
-        directory = File.dirname(source_location)
-        filename = File.basename(source_location, ".rb")
+        directory = File.dirname(identifier)
+        filename = File.basename(identifier, ".rb")
         component_name = name.demodulize.underscore
 
         # Add support for nested components defined in the same file.
@@ -499,7 +507,7 @@ module ViewComponent
 
         sidecar_directory_files = Dir["#{directory}/#{component_name}/#{filename}.*{#{extensions}}"]
 
-        (sidecar_files - [source_location] + sidecar_directory_files + nested_component_files).uniq
+        (sidecar_files - [identifier] + sidecar_directory_files + nested_component_files).uniq
       end
 
       # Render a component for each element in a collection ([documentation](/guide/collections)):
@@ -548,11 +556,11 @@ module ViewComponent
         # has been re-defined by the consuming application, likely in ApplicationComponent.
         # We use `base_label` method here instead of `label` to avoid cases where the method
         # owner is included in a prefix like `ApplicationComponent.inherited`.
-        child.source_location = caller_locations(1, 10).reject { |l| l.base_label == "inherited" }[0].path
+        child.identifier = caller_locations(1, 10).reject { |l| l.base_label == "inherited" }[0].path
 
         # If Rails application is loaded, removes the first part of the path and the extension.
         if defined?(Rails) && Rails.application
-          child.virtual_path = child.source_location.gsub(
+          child.virtual_path = child.identifier.gsub(
             /(.*#{Regexp.quote(ViewComponent::Base.config.view_component_path)})|(\.rb)/, ""
           )
         end
@@ -588,15 +596,6 @@ module ViewComponent
       # @private
       def compiler
         @__vc_compiler ||= Compiler.new(self)
-      end
-
-      # @private
-      def identifier
-        # :nocov:
-        Kernel.warn("WARNING: The #{self.class}.identifier is undocumented and was meant for internal framework usage only. As it is no longer used by the framework it will be removed in a coming non-breaking ViewComponent release.")
-
-        source_location
-        # :nocov:
       end
 
       # Set the parameter name used when rendering elements of a collection ([documentation](/guide/collections)):

--- a/lib/view_component/instrumentation.rb
+++ b/lib/view_component/instrumentation.rb
@@ -13,7 +13,7 @@ module ViewComponent # :nodoc:
         notification_name,
         {
           name: self.class.name,
-          identifier: self.class.source_location
+          identifier: self.class.identifier
         }
       ) do
         super

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -3,6 +3,10 @@
 require "test_helper"
 
 class ViewComponent::Base::UnitTest < Minitest::Test
+  def test_identifier
+    assert(MyComponent.identifier.include?("test/sandbox/app/components/my_component.rb"))
+  end
+
   def skip_templates_parses_all_types_of_paths
     file_path = [
       "/Users/fake.user/path/to.templates/component/test_component.html+phone.erb",


### PR DESCRIPTION
### What are you trying to accomplish?

As a follow-up to https://github.com/ViewComponent/view_component/issues/2106, I'm formally exposing `.source_location` as part of the public API, as it seems New Relic could make good use of this feature. (See their fallback in https://github.com/newrelic/newrelic-ruby-agent/blob/dev/CHANGELOG.md#v9150 💔 )

### What approach did you choose and why?

I made `.identifier` public and used the term internally, as `source_location` is a reserved word in Ruby.
