### PR TITLE
Use ActionView::TemplateDetails for handling format and variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 .ruby-version
+.DS_Store
 /.config
 /coverage/assets
 /coverage/index.html

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,10 @@ nav_order: 5
 
     *Joel Hawksley*
 
+* BREAKING: Remove support for variant names containing `.` to be consistent with Rails.
+
+    *Stephen Nelson*
+
 * Ensure HTML output safety wrapper is used for all inline templates.
 
     *Joel Hawksley*

--- a/docs/index.md
+++ b/docs/index.md
@@ -193,6 +193,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/sammyhenningsson?s=64" alt="sammyhenningsson" width="32" />
 <img src="https://avatars.githubusercontent.com/sampart?s=64" alt="sampart" width="32" />
 <img src="https://avatars.githubusercontent.com/seanpdoyle?s=64" alt="seanpdoyle" width="32" />
+<img src="https://avatars.githubusercontent.com/sfnelson?s=64" alt="sfnelson" width="32" />
 <img src="https://avatars.githubusercontent.com/simonrand?s=64" alt="simonrand" width="32" />
 <img src="https://avatars.githubusercontent.com/skryukov?s=64" alt="skryukov" width="32" />
 <img src="https://avatars.githubusercontent.com/smashwilson?s=64" alt="smashwilson" width="32" />

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -172,23 +172,7 @@ module ViewComponent
           templates = @component.sidecar_files(
             ActionView::Template.template_handler_extensions
           ).map do |path|
-            # Extract format and variant from template filename
-            this_format, variant =
-              ::File
-                .basename(path)     # "variants_component.html+mini.watch.erb"
-                .split(".")[1..-2]  # ["html+mini", "watch"]
-                .join(".")          # "html+mini.watch"
-                .split("+")         # ["html", "mini.watch"]
-                .map(&:to_sym)      # [:html, :"mini.watch"]
-
-            out = Template::File.new(
-              component: @component,
-              path: path,
-              lineno: 0,
-              extension: path.split(".").last,
-              this_format: this_format.to_s.split(".").last&.to_sym, # strip locale from this_format, see #2113
-              variant: variant
-            )
+            out = Template::File.new(component: @component, path: path)
 
             out
           end
@@ -202,8 +186,6 @@ module ViewComponent
             .each do |method_name|
               templates << Template::InlineCall.new(
                 component: @component,
-                this_format: ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT,
-                variant: method_name.to_s.include?("call_") ? method_name.to_s.sub("call_", "").to_sym : nil,
                 method_name: method_name,
                 defined_on_self: component_instance_methods_on_self.include?(method_name)
               )
@@ -212,10 +194,7 @@ module ViewComponent
           if @component.inline_template.present?
             templates << Template::Inline.new(
               component: @component,
-              path: @component.inline_template.path,
-              lineno: @component.inline_template.lineno,
-              source: @component.inline_template.source.dup,
-              extension: @component.inline_template.language
+              inline_template: @component.inline_template
             )
           end
 

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -174,16 +174,15 @@ module ViewComponent
           ).map do |path|
             # Extract format and variant from template filename
             this_format, variant =
-              File
+              ::File
                 .basename(path)     # "variants_component.html+mini.watch.erb"
                 .split(".")[1..-2]  # ["html+mini", "watch"]
                 .join(".")          # "html+mini.watch"
                 .split("+")         # ["html", "mini.watch"]
                 .map(&:to_sym)      # [:html, :"mini.watch"]
 
-            out = Template.new(
+            out = Template::File.new(
               component: @component,
-              type: :file,
               path: path,
               lineno: 0,
               extension: path.split(".").last,
@@ -201,9 +200,8 @@ module ViewComponent
           ).flat_map { |ancestor| ancestor.instance_methods(false).grep(/^call(_|$)/) }
             .uniq
             .each do |method_name|
-              templates << Template.new(
+              templates << Template::InlineCall.new(
                 component: @component,
-                type: :inline_call,
                 this_format: ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT,
                 variant: method_name.to_s.include?("call_") ? method_name.to_s.sub("call_", "").to_sym : nil,
                 method_name: method_name,
@@ -212,9 +210,8 @@ module ViewComponent
             end
 
           if @component.inline_template.present?
-            templates << Template.new(
+            templates << Template::Inline.new(
               component: @component,
-              type: :inline,
               path: @component.inline_template.path,
               lineno: @component.inline_template.lineno,
               source: @component.inline_template.source.dup,

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -169,10 +169,12 @@ module ViewComponent
     def gather_templates
       @templates ||=
         begin
+          path_parser = ActionView::Resolver::PathParser.new
           templates = @component.sidecar_files(
             ActionView::Template.template_handler_extensions
           ).map do |path|
-            out = Template::File.new(component: @component, path: path)
+            details = path_parser.parse(path).details
+            out = Template::File.new(component: @component, path: path, details: details)
 
             out
           end

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -36,23 +36,14 @@ module ViewComponent
     end
 
     class File < Template
-      def initialize(component:, path:)
-        # Extract format and variant from template filename
-        this_format, variant =
-          ::File
-            .basename(path)     # "variants_component.html+mini.watch.erb"
-            .split(".")[1..-2]  # ["html+mini", "watch"]
-            .join(".")          # "html+mini.watch"
-            .split("+")         # ["html", "mini.watch"]
-            .map(&:to_sym)      # [:html, :"mini.watch"]
-
+      def initialize(component:, path:, details:)
         super(
           component: component,
           path: path,
           lineno: 0,
-          extension: path.split(".").last,
-          this_format: this_format.to_s.split(".").last&.to_sym, # strip locale from this_format, see #2113
-          variant: variant
+          extension: details.handler.to_s,
+          this_format: details.format,
+          variant: details.variant
         )
       end
 
@@ -157,7 +148,7 @@ module ViewComponent
     end
 
     def normalized_variant_name
-      @variant.to_s.gsub("-", "__").gsub(".", "___")
+      @variant.to_s.gsub("-", "__")
     end
 
     private

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -101,20 +101,22 @@ module ViewComponent
       def type
         :inline_call
       end
+
+      def compile_to_component
+        @component.define_method(safe_method_name, @component.instance_method(@call_method_name))
+      end
     end
 
     def compile_to_component
-      if !inline_call?
-        @component.silence_redefinition_of_method(@call_method_name)
+      @component.silence_redefinition_of_method(@call_method_name)
 
-        # rubocop:disable Style/EvalWithLocation
-        @component.class_eval <<-RUBY, @path, @lineno
-        def #{@call_method_name}
-          #{compiled_source}
-        end
-        RUBY
-        # rubocop:enable Style/EvalWithLocation
+      # rubocop:disable Style/EvalWithLocation
+      @component.class_eval <<-RUBY, @path, @lineno
+      def #{@call_method_name}
+        #{compiled_source}
       end
+      RUBY
+      # rubocop:enable Style/EvalWithLocation
 
       @component.define_method(safe_method_name, @component.instance_method(@call_method_name))
     end

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -5,11 +5,10 @@ module ViewComponent
     DataWithSource = Struct.new(:format, :identifier, :short_identifier, :type, keyword_init: true)
     DataNoSource = Struct.new(:source, :identifier, :type, keyword_init: true)
 
-    attr_reader :variant, :this_format, :type
+    attr_reader :variant, :this_format
 
     def initialize(
       component:,
-      type:,
       this_format: nil,
       variant: nil,
       lineno: nil,
@@ -20,7 +19,6 @@ module ViewComponent
       defined_on_self: true
     )
       @component = component
-      @type = type
       @this_format = this_format
       @variant = variant&.to_sym
       @lineno = lineno
@@ -41,6 +39,24 @@ module ViewComponent
           out << "_#{@this_format}" if @this_format.present? && @this_format != ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT
           out
         end
+    end
+
+    class File < Template
+      def type
+        :file
+      end
+    end
+
+    class Inline < Template
+      def type
+        :inline
+      end
+    end
+
+    class InlineCall < Template
+      def type
+        :inline_call
+      end
     end
 
     def compile_to_component
@@ -72,11 +88,11 @@ module ViewComponent
     end
 
     def inline_call?
-      @type == :inline_call
+      type == :inline_call
     end
 
     def inline?
-      @type == :inline
+      type == :inline
     end
 
     def default_format?
@@ -104,7 +120,7 @@ module ViewComponent
     def source
       if @source_originally_nil
         # Load file each time we look up #source in case the file has been modified
-        File.read(@path)
+        ::File.read(@path)
       else
         @source
       end

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -14,8 +14,7 @@ module ViewComponent
       lineno: nil,
       path: nil,
       extension: nil,
-      method_name: nil,
-      defined_on_self: true
+      method_name: nil
     )
       @component = component
       @this_format = this_format
@@ -24,7 +23,6 @@ module ViewComponent
       @path = path
       @extension = extension
       @method_name = method_name
-      @defined_on_self = defined_on_self
 
       @call_method_name =
         if @method_name
@@ -94,8 +92,9 @@ module ViewComponent
           this_format: ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT,
           variant: method_name.to_s.include?("call_") ? method_name.to_s.sub("call_", "").to_sym : nil,
           method_name: method_name,
-          defined_on_self: defined_on_self
         )
+
+        @defined_on_self = defined_on_self
       end
 
       def type
@@ -104,6 +103,10 @@ module ViewComponent
 
       def compile_to_component
         @component.define_method(safe_method_name, @component.instance_method(@call_method_name))
+      end
+
+      def defined_on_self?
+        @defined_on_self
       end
     end
 
@@ -155,10 +158,6 @@ module ViewComponent
 
     def normalized_variant_name
       @variant.to_s.gsub("-", "__").gsub(".", "___")
-    end
-
-    def defined_on_self?
-      @defined_on_self
     end
 
     private

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -5,23 +5,21 @@ module ViewComponent
     DataWithSource = Struct.new(:format, :identifier, :short_identifier, :type, keyword_init: true)
     DataNoSource = Struct.new(:source, :identifier, :type, keyword_init: true)
 
-    attr_reader :variant, :this_format
+    attr_reader :details
+
+    delegate :format, :variant, to: :details
 
     def initialize(
       component:,
-      this_format: nil,
-      variant: nil,
+      details:,
       lineno: nil,
       path: nil,
-      extension: nil,
       method_name: nil
     )
       @component = component
-      @this_format = this_format
-      @variant = variant&.to_sym
+      @details = details
       @lineno = lineno
       @path = path
-      @extension = extension
       @method_name = method_name
 
       @call_method_name =
@@ -29,21 +27,19 @@ module ViewComponent
           @method_name
         else
           out = +"call"
-          out << "_#{normalized_variant_name}" if @variant.present?
-          out << "_#{@this_format}" if @this_format.present? && @this_format != ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT
+          out << "_#{normalized_variant_name}" if variant.present?
+          out << "_#{format}" if format.present? && format != ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT
           out
         end
     end
 
     class File < Template
-      def initialize(component:, path:, details:)
+      def initialize(component:, details:, path:)
         super(
           component: component,
+          details: details,
           path: path,
-          lineno: 0,
-          extension: details.handler.to_s,
-          this_format: details.format,
-          variant: details.variant
+          lineno: 0
         )
       end
 
@@ -61,11 +57,13 @@ module ViewComponent
       attr_reader :source
 
       def initialize(component:, inline_template:)
+        details = ActionView::TemplateDetails.new(nil, inline_template.language.to_sym, nil, nil)
+
         super(
           component: component,
+          details: details,
           path: inline_template.path,
           lineno: inline_template.lineno,
-          extension: inline_template.language
         )
 
         @source = inline_template.source.dup
@@ -78,11 +76,13 @@ module ViewComponent
 
     class InlineCall < Template
       def initialize(component:, method_name:, defined_on_self:)
+        variant = method_name.to_s.include?("call_") ? method_name.to_s.sub("call_", "").to_sym : nil
+        details = ActionView::TemplateDetails.new(nil, nil, nil, variant)
+
         super(
           component: component,
-          this_format: ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT,
-          variant: method_name.to_s.include?("call_") ? method_name.to_s.sub("call_", "").to_sym : nil,
-          method_name: method_name,
+          details: details,
+          method_name: method_name
         )
 
         @defined_on_self = defined_on_self
@@ -136,11 +136,7 @@ module ViewComponent
     end
 
     def default_format?
-      @this_format == ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT
-    end
-
-    def format
-      @this_format
+      format.nil? || format == ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT
     end
 
     def safe_method_name
@@ -148,22 +144,23 @@ module ViewComponent
     end
 
     def normalized_variant_name
-      @variant.to_s.gsub("-", "__")
+      variant.to_s.gsub("-", "__")
     end
 
     private
 
     def compiled_source
-      handler = ActionView::Template.handler_for_extension(@extension)
+      handler = details.handler_class
       this_source = source
       this_source.rstrip! if @component.strip_trailing_whitespace?
 
       short_identifier = defined?(Rails.root) ? @path.sub("#{Rails.root}/", "") : @path
-      type = ActionView::Template::Types[@this_format]
+      format = self.format || ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT
+      type = ActionView::Template::Types[format]
 
       if handler.method(:call).parameters.length > 1
         handler.call(
-          DataWithSource.new(format: @this_format, identifier: @path, short_identifier: short_identifier, type: type),
+          DataWithSource.new(format: format, identifier: @path, short_identifier: short_identifier, type: type),
           this_source
         )
       # :nocov:

--- a/test/sandbox/app/components/variants_component.html+mini.watch.erb
+++ b/test/sandbox/app/components/variants_component.html+mini.watch.erb
@@ -1,1 +1,0 @@
-Mini Watch with dot

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -198,14 +198,6 @@ class RenderingTest < ViewComponent::TestCase
     end
   end
 
-  def test_renders_component_with_variant_containing_a_dot
-    with_variant :"mini.watch" do
-      render_inline(VariantsComponent.new)
-
-      assert_text("Mini Watch with dot")
-    end
-  end
-
   def test_renders_default_template_when_variant_template_is_not_present
     with_variant :variant_without_template do
       render_inline(VariantsComponent.new)


### PR DESCRIPTION
### What are you trying to accomplish?

This change introduces `ActionView::TemplateDetails` as the primary abstraction for parsing and interpreting formats and variants. In a future PR I'll use this to implement template ordering based on the same logic that Rails uses for tie-breaks.

Discussion in https://github.com/ViewComponent/view_component/issues/2128

### What approach did you choose and why?

Rails already has complex and well-used logic for parsing template file names. ViewComponent's differences do not seem intentional, and using the Rails logic should make it easier for ViewComponents to avoid inconsistencies in the future.

I've split up the logic for the three different template types into separate classes. This helps reduce the conditional logic by using polymorphism instead. I've taken small steps and avoided any structural changes, but this lays the groundwork for more significant changes to the compiler logic.

### Anything you want to highlight for special attention from reviewers?

I have broken compatibility with the previously supported `variant.name` feature. Rails explicitly does not allow period characters in variant names.
