### PR TITLE
Refactor compiler to use ActionView's partial sorting algorithm

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,17 @@ nav_order: 5
 
     *Stephen Nelson*
 
+* BREAKING: Use ActionView's `lookup_context` for picking templates instead of the request format.
+
+  3.15 added support for using templates that match the request format, i.e. if `/resource.csv` is requested then
+  ViewComponents would pick `_component.csv.erb` over `_component.html.erb`.
+
+  With this release, the request format is no longer considered and instead ViewComponent will use the Rails logic
+  for picking the most appropriate template type, i.e. the csv template will be used if it matches the `Accept` header
+  or because the controller uses a `respond_to` block to pick the response format.
+
+    *Stephen Nelson*
+
 * Ensure HTML output safety wrapper is used for all inline templates.
 
     *Joel Hawksley*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -9,6 +9,7 @@ require "view_component/config"
 require "view_component/errors"
 require "view_component/inline_template"
 require "view_component/preview"
+require "view_component/request_details"
 require "view_component/slotable"
 require "view_component/slotable_default"
 require "view_component/template"
@@ -63,6 +64,8 @@ module ViewComponent
       self.__vc_original_view_context = view_context
     end
 
+    using RequestDetails
+
     # Entrypoint for rendering components.
     #
     # - `view_context`: ActionView context from calling view
@@ -90,13 +93,12 @@ module ViewComponent
       # For i18n
       @virtual_path ||= virtual_path
 
-      # For template variants (+phone, +desktop, etc.)
-      @__vc_variant ||= @lookup_context.variants.first
+      # Describes the inferred request constraints (locales, formats, variants)
+      @__vc_requested_details ||= @lookup_context.vc_requested_details
 
       # For caching, such as #cache_if
       @current_template = nil unless defined?(@current_template)
       old_current_template = @current_template
-      @current_template = self
 
       if block && defined?(@__vc_content_set_by_with_content)
         raise DuplicateContentError.new(self.class.name)
@@ -108,7 +110,7 @@ module ViewComponent
       before_render
 
       if render?
-        rendered_template = render_template_for(@__vc_variant, __vc_request&.format&.to_sym).to_s
+        rendered_template = render_template_for(@__vc_requested_details).to_s
 
         # Avoid allocating new string when output_preamble and output_postamble are blank
         if output_preamble.blank? && output_postamble.blank?
@@ -156,7 +158,7 @@ module ViewComponent
         target_render = self.class.instance_variable_get(:@__vc_ancestor_calls)[@__vc_parent_render_level]
         @__vc_parent_render_level += 1
 
-        target_render.bind_call(self, @__vc_variant)
+        target_render.bind_call(self, @__vc_requested_details)
       ensure
         @__vc_parent_render_level -= 1
       end
@@ -267,11 +269,10 @@ module ViewComponent
       []
     end
 
-    # For caching, such as #cache_if
-    #
-    # @private
+    # Rails expects us to define `format` on all renderables,
+    # but we do not know the `format` of a ViewComponent until runtime.
     def format
-      @__vc_variant if defined?(@__vc_variant)
+      nil
     end
 
     # The current request. Use sparingly as doing so introduces coupling that
@@ -328,7 +329,7 @@ module ViewComponent
     end
 
     def maybe_escape_html(text)
-      return text if __vc_request && !__vc_request.format.html?
+      return text if @current_template && !@current_template.html?
       return text if text.blank?
 
       if text.html_safe?
@@ -517,12 +518,12 @@ module ViewComponent
         # meaning it will not be called for any children and thus not compile their templates.
         if !child.instance_methods(false).include?(:render_template_for) && !child.compiled?
           child.class_eval <<~RUBY, __FILE__, __LINE__ + 1
-            def render_template_for(variant = nil, format = nil)
+            def render_template_for(requested_details)
               # Force compilation here so the compiler always redefines render_template_for.
               # This is mostly a safeguard to prevent infinite recursion.
               self.class.compile(raise_errors: true, force: true)
               # .compile replaces this method; call the new one
-              render_template_for(variant, format)
+              render_template_for(requested_details)
             end
           RUBY
         end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -55,6 +55,23 @@ module ViewComponent
       end
     end
 
+    # @return all matching compiled templates, in priority order based on the requested details from LookupContext
+    #
+    # @param [ActionView::TemplateDetails::Requested] requested_details i.e. locales, formats, variants
+    def find_templates_for(requested_details)
+      filtered_templates = @templates.select do |template|
+        template.details.matches?(requested_details)
+      end
+
+      if filtered_templates.count > 1
+        filtered_templates.sort_by! do |template|
+          template.details.sort_key_for(requested_details)
+        end
+      end
+
+      filtered_templates
+    end
+
     private
 
     attr_reader :templates
@@ -64,40 +81,25 @@ module ViewComponent
         template.compile_to_component
       end
 
-      method_body =
-        if @templates.one?
-          @templates.first.safe_method_name_call
-        elsif (template = @templates.find(&:inline?))
-          template.safe_method_name_call
-        else
-          branches = []
-
-          @templates.each do |template|
-            conditional =
-              if template.inline_call?
-                "variant&.to_sym == #{template.variant.inspect}"
-              else
-                [
-                  template.default_format? ? "(format == #{ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT.inspect} || format.nil?)" : "format == #{template.format.inspect}",
-                  template.variant.nil? ? "variant.nil?" : "variant&.to_sym == #{template.variant.inspect}"
-                ].join(" && ")
-              end
-
-            branches << [conditional, template.safe_method_name_call]
-          end
-
-          out = branches.each_with_object(+"") do |(conditional, branch_body), memo|
-            memo << "#{(!memo.present?) ? "if" : "elsif"} #{conditional}\n  #{branch_body}\n"
-          end
-          out << "else\n  #{templates.find { _1.variant.nil? && _1.default_format? }.safe_method_name_call}\nend"
-        end
-
       @component.silence_redefinition_of_method(:render_template_for)
-      @component.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-      def render_template_for(variant = nil, format = nil)
-        #{method_body}
+
+      if @templates.one?
+        template = @templates.first
+        safe_call = template.safe_method_name_call
+        @component.define_method(:render_template_for) do |_|
+          @current_template = template
+          instance_exec(&safe_call)
+        end
+      else
+        compiler = self
+        @component.define_method(:render_template_for) do |details|
+          if (@current_template = compiler.find_templates_for(details).first)
+            instance_exec(&@current_template.safe_method_name_call)
+          else
+            raise MissingTemplateError.new(self.class.name, details)
+          end
+        end
       end
-      RUBY
     end
 
     def template_errors
@@ -168,15 +170,18 @@ module ViewComponent
 
     def gather_templates
       @templates ||=
-        begin
+        if @component.inline_template.present?
+          [Template::Inline.new(
+            component: @component,
+            inline_template: @component.inline_template
+          )]
+        else
           path_parser = ActionView::Resolver::PathParser.new
           templates = @component.sidecar_files(
             ActionView::Template.template_handler_extensions
           ).map do |path|
             details = path_parser.parse(path).details
-            out = Template::File.new(component: @component, path: path, details: details)
-
-            out
+            Template::File.new(component: @component, path: path, details: details)
           end
 
           component_instance_methods_on_self = @component.instance_methods(false)
@@ -186,17 +191,10 @@ module ViewComponent
           ).flat_map { |ancestor| ancestor.instance_methods(false).grep(/^call(_|$)/) }
             .uniq
             .each do |method_name|
-              templates << Template::InlineCall.new(
-                component: @component,
-                method_name: method_name,
-                defined_on_self: component_instance_methods_on_self.include?(method_name)
-              )
-            end
-
-          if @component.inline_template.present?
-            templates << Template::Inline.new(
+            templates << Template::InlineCall.new(
               component: @component,
-              inline_template: @component.inline_template
+              method_name: method_name,
+              defined_on_self: component_instance_methods_on_self.include?(method_name)
             )
           end
 

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -38,6 +38,22 @@ module ViewComponent
     end
   end
 
+  class MissingTemplateError < StandardError
+    MESSAGE =
+      "No templates for COMPONENT match the request DETAIL.\n\n" \
+      "To fix this issue, provide a suitable template."
+
+    def initialize(component, request_detail)
+      detail = {
+        locale: request_detail.locale,
+        formats: request_detail.formats,
+        variants: request_detail.variants,
+        handlers: request_detail.handlers
+      }
+      super(MESSAGE.gsub("COMPONENT", component).gsub("DETAIL", detail.inspect))
+    end
+  end
+
   class DuplicateContentError < StandardError
     MESSAGE =
       "It looks like a block was provided after calling `with_content` on COMPONENT, " \

--- a/lib/view_component/request_details.rb
+++ b/lib/view_component/request_details.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  # LookupContext computes and encapsulates @details for each request
+  # so that it doesn't need to be recomputed on each partial render.
+  # This data is wrapped in ActionView::TemplateDetails::Requested and
+  # used by instances of ActionView::Resolver to choose which template
+  # best matches the request.
+  #
+  # ActionView considers this logic internal to template/partial resolution.
+  # We're exposing it to the compiler via `refine` so that ViewComponent
+  # can match Rails' template picking logic.
+  module RequestDetails
+    refine ActionView::LookupContext do
+      # Return an abstraction for matching and sorting available templates
+      # based on the current lookup context details.
+      #
+      # @return ActionView::TemplateDetails::Requested
+      # @see ActionView::LookupContext#detail_args_for
+      # @see ActionView::FileSystemResolver#_find_all
+      def vc_requested_details(user_details = {})
+        # The hash `user_details` would normally be the standard arguments that
+        # `render` accepts, but there's currently no mechanism for users to
+        # provide these when calling render on a ViewComponent.
+        details, cached = detail_args_for(user_details)
+        cached || ActionView::TemplateDetails::Requested.new(**details)
+      end
+    end
+  end
+end

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -127,11 +127,11 @@ module ViewComponent
     # end
     # ```
     #
-    # @param variant [Symbol] The variant to be set for the provided block.
-    def with_variant(variant)
+    # @param variants [Symbol[]] The variants to be set for the provided block.
+    def with_variant(*variants)
       old_variants = vc_test_controller.view_context.lookup_context.variants
 
-      vc_test_controller.view_context.lookup_context.variants = variant
+      vc_test_controller.view_context.lookup_context.variants += variants
       yield
     ensure
       vc_test_controller.view_context.lookup_context.variants = old_variants
@@ -164,9 +164,14 @@ module ViewComponent
     # end
     # ```
     #
-    # @param format [Symbol] The format to be set for the provided block.
-    def with_format(format)
-      with_request_url("/", format: format) { yield }
+    # @param formats [Symbol[]] The format(s) to be set for the provided block.
+    def with_format(*formats)
+      old_formats = vc_test_controller.view_context.lookup_context.formats
+
+      vc_test_controller.view_context.lookup_context.formats = formats
+      yield
+    ensure
+      vc_test_controller.view_context.lookup_context.formats = old_formats
     end
 
     # Set the URL of the current request (such as when using request-dependent path helpers):
@@ -196,7 +201,7 @@ module ViewComponent
     # @param full_path [String] The path to set for the current request.
     # @param host [String] The host to set for the current request.
     # @param method [String] The request method to set for the current request.
-    def with_request_url(full_path, host: nil, method: nil, format: ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT)
+    def with_request_url(full_path, host: nil, method: nil)
       old_request_host = vc_test_request.host
       old_request_method = vc_test_request.request_method
       old_request_path_info = vc_test_request.path_info
@@ -216,7 +221,6 @@ module ViewComponent
       vc_test_request.set_header("action_dispatch.request.query_parameters",
         Rack::Utils.parse_nested_query(query).with_indifferent_access)
       vc_test_request.set_header(Rack::QUERY_STRING, query)
-      vc_test_request.format = format
       yield
     ensure
       vc_test_request.host = old_request_host

--- a/test/sandbox/app/components/turbo_stream_format_component.html+custom.erb
+++ b/test/sandbox/app/components/turbo_stream_format_component.html+custom.erb
@@ -1,0 +1,1 @@
+Hi turbo stream custom!

--- a/test/sandbox/app/components/turbo_stream_format_component.html.erb
+++ b/test/sandbox/app/components/turbo_stream_format_component.html.erb
@@ -1,0 +1,1 @@
+Hi turbo stream!

--- a/test/sandbox/app/components/turbo_stream_format_component.rb
+++ b/test/sandbox/app/components/turbo_stream_format_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class TurboStreamFormatComponent < ViewComponent::Base
+end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -15,7 +15,7 @@ class RenderingTest < ViewComponent::TestCase
     ViewComponent::CompileCache.cache.delete(MyComponent)
     MyComponent.ensure_compiled
 
-    assert_allocations("3.4.0" => 109, "3.3.6" => 115, "3.3.0" => 124, "3.2.6" => 114) do
+    assert_allocations("3.5.0" => 104, "3.4.1" => 107, "3.3.6" => 107, "3.2.6" => 105) do
       render_inline(MyComponent.new)
     end
 
@@ -184,6 +184,14 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_renders_component_with_variant
     with_variant :phone do
+      render_inline(VariantsComponent.new)
+
+      assert_text("Phone")
+    end
+  end
+
+  def test_renders_component_with_multiple_variants
+    with_variant :app, :phone do
       render_inline(VariantsComponent.new)
 
       assert_text("Phone")
@@ -1198,6 +1206,20 @@ class RenderingTest < ViewComponent::TestCase
     end
   end
 
+  def test_with_format_missing
+    with_format(:xml) do
+      exception =
+        assert_raises ViewComponent::MissingTemplateError do
+          render_inline(MultipleFormatsComponent.new)
+        end
+
+      assert_includes(
+        exception.message,
+        "No templates for MultipleFormatsComponent match the request"
+      )
+    end
+  end
+
   def test_localised_component
     render_inline(LocalisedComponent.new)
 
@@ -1208,5 +1230,15 @@ class RenderingTest < ViewComponent::TestCase
     render_inline(RequestParamComponent.new(request: "foo"))
 
     assert_text("foo")
+  end
+
+  def test_turbo_stream_format_custom_variant
+    with_format(:turbo_stream, :html) do
+      with_variant(:custom) do
+        render_inline(TurboStreamFormatComponent.new)
+
+        assert_text("Hi turbo stream custom!")
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Rails uses `ActionView::TemplateDetails::Requested` to sort available templates to find the best match for a given `LookupContext`, taking in to account the acceptable content types, variants, locale, and handlers available. ViewComponent implements a subset of this logic that leaves some gaps, i.e. https://github.com/ViewComponent/view_component/issues/2154 https://github.com/ViewComponent/view_component/issues/2128

This PR aims to bring the ViewComponent template selection logic in line with how Rails chooses a partial, and ensure that it won't drift in the future by using Rails' internal structures for the calculation.

### What approach did you choose and why?

1. I'm using `refine` to provide access to Rails' internal `@details` ivar from `LookupContext` that memoizes details about the rendering context for use in partial/template resolution. Using the Rails internal logic for template resolution ensures that ViewComponents will resolve templates in a consistent way and remain consistent in the future.
2. I'm using Procs instead of methods to compile `render_template_for`. This approach allows closing over the templates available to the component, which would not be possible with a compiled method body as a string.  The benefit of this approach is that the code is easy to read and maintain, and it's equivalent or slightly faster to render components. An alternative approach would be to generate constants that hold the data required for the template selection and refer to them in the method body, but I think the code would be harder to read and maintain.

I have run the included benchmarks and the CPU performance is marginally better vs v4. See attached.

[v4.benchmark.txt](https://github.com/user-attachments/files/17640916/v4.benchmark.txt)
[2128-variant.benchmark.txt](https://github.com/user-attachments/files/17673230/2128-variant.benchmark.txt)

The number of allocated objects per render is slightly better than v4 because it's using the LookupContext cached resolve structures instead of storing its own format and variants. There is some additional memory retained per component as the `Template` objects remain in scope after compilation, but the Template objects are small and the overhead is proportional to the number of component templates, it won't grow during application lifecycle.

My team has added this code to one of our larger projects and it will go to production in the next launch. I'll provide feedback, if any, once we have it.

### Anything you want to highlight for special attention from reviewers?

I intend that this change has minimal impact on the observable API of ViewComponents. The benefits would be better alignment with Rails' behaviour, in line with the goal of seamless integration.

I've discussed this approach with @joelhawksley but I'm keen for feedback from other members of the community.