### PR TITLE
Documentation Update: Add a section for how to add the render_inline helpers to RSpec tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Updates docs/guide/testing.md to include an example of how to use with RSpec
+
+    *Rylan Bowers*
+
 * Add `--skip-suffix` option to component generator.
 
     *KAWAKAMI Moeki*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ## main
 
-* Updates docs/guide/testing.md to include an example of how to use with RSpec
+* Updates testing docs to include an example of how to use with RSpec.
 
     *Rylan Bowers*
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -30,6 +30,21 @@ _Note: `assert_selector` only matches on visible elements by default. To match o
 
 For debugging purposes, the `rendered_content` test helper outputs the rendered HTML.
 
+## Adding Test Helpers (RSpec)
+
+This will allow for helpers like `render_inline` to work in your tests.
+
+```ruby
+# spec/rails_helper.rb
+require 'view_component/test_helpers'
+
+RSpec.configure do |config|
+  # ...
+
+  config.include ViewComponent::TestHelpers, type: :component
+end
+```
+
 ## Testing Slots
 
 ```ruby

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -30,9 +30,9 @@ _Note: `assert_selector` only matches on visible elements by default. To match o
 
 For debugging purposes, the `rendered_content` test helper outputs the rendered HTML.
 
-## Adding Test Helpers (RSpec)
+## Use with RSpec
 
-This will allow for helpers like `render_inline` to work in your tests.
+To enable ViewComponent test helpers in RSpec, add:
 
 ```ruby
 # spec/rails_helper.rb

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -36,7 +36,7 @@ To enable ViewComponent test helpers in RSpec, add:
 
 ```ruby
 # spec/rails_helper.rb
-require 'view_component/test_helpers'
+require "view_component/test_helpers"
 
 RSpec.configure do |config|
   # ...


### PR DESCRIPTION
### What are you trying to accomplish?

While getting started w/ View Component today, I struggled w/ errors like 'Undefined method `render_inline` for ...

### What approach did you choose and why?

I updated the documentation to include a section referencing https://stackoverflow.com/questions/70041733/integrating-viewcomponent-with-rspec and how to add the view component test helpers

I believe that the comment above this section that mentions `(Capybara matchers are available if the gem is installed)` would indicate that adding `require "capybara/rspec"` or `config.include Capybara::RSpecMatchers, type: :component` is not a requirement to use those matchers. There may be some nuance that I don't fully understand to different setups though!

Welcome to any feedback

### Anything you want to highlight for special attention from reviewers?

I'm happy to update for how to do this for minitest in test_helpers.rb, but I'm unsure if the sytnax is similar or not?