### PR TITLE
Add Buildkite to list of organizations that use ViewComponent.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -239,6 +239,7 @@ ViewComponent is built by over a hundred members of the community, including:
 * [Avo Admin for Rails](https://avohq.io/rails-admin)
 * [Bearer](https://www.bearer.com/) (70+ components)
 * [Brightline](https://hellobrightline.com)
+* [Buildkite](https://buildkite.com)
 * [Bump.sh](https://bump.sh)
 * [Causey](https://www.causey.app/) (100+ components)
 * [CharlieHR](https://www.charliehr.com/)


### PR DESCRIPTION
Hello!

We have been using ViewComponent for a while now for a growing number of our components, so thought I should add us to the list of orgs.

Cheers
Steve