### PR TITLE
Update committers list and guidance

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -107,11 +107,11 @@ The triagers team is @reeganviljoen.
 
 ### Commit
 
-ViewComponent committers have `write` access, enabling them to push directly to the repository and merge pull requests, thus removing the need to contribute via a fork. Committers often have implicit (or even explicit, via CODEOWNERS) ownership over a particular area of the project, such as previews, generators, or translations.
+ViewComponent committers have `write` access, enabling them to push directly to the repository and merge pull requests, thus removing the need to contribute via a fork.
 
 Triagers are welcome to request commit access by opening a pull request to update this list:
 
-The committers team is @elia, @jonspalmer, @juanmanuelramallo, @rmacklin, and @dylanatsmith.
+There are currently no committers.
 
 ### Maintain
 


### PR DESCRIPTION
This PR removes inactive committers from the project and simplifies the `committer` guidelines. Thank you for your contributions over the years @elia, @jonspalmer, @juanmanuelramallo, @rmacklin, and @dylanatsmith ❤️ 