### PR TITLE
Add OpenProject to list of ViewComponent users

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -271,6 +271,7 @@ ViewComponent is built by over a hundred members of the community, including:
 * [Niva](https://www.niva.co/)
 * [OBLSK](https://oblsk.com/)
 * [openSUSE Open Build Service](https://openbuildservice.org/)
+* [OpenProject](https://www.openproject.org/)
 * [Ophelos](https://ophelos.com)
 * [Orbit](https://orbit.love)
 * [PeopleForce](https://peopleforce.io)


### PR DESCRIPTION
OpenProject is an open-source project management platform built with Ruby and Rails. We use a fork of GitHub's Primer design system based on ViewComponents: https://github.com/opf/primer_view_components

