### PR TITLE
Support rails 8 in v2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     view_component (2.83.0)
-      activesupport (>= 5.2.0, < 8.0)
+      activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Relax ActiveSupport version constraint to allow 8.0.
+
+    *Mohamad Alhaj Rahmoun*
+
 ## 2.83.0
 
 * Ensure HTML output safety.

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_runtime_dependency "activesupport", [">= 5.2.0", "< 8.0"]
+  spec.add_runtime_dependency "activesupport", [">= 5.2.0", "< 8.1"]
   spec.add_runtime_dependency "method_source", "~> 1.0"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_development_dependency "appraisal", "~> 2.4"


### PR DESCRIPTION
### What are you trying to accomplish?

Relax ActiveSupport version constraint for v2 to support applications upgrading to Rails 8.