### PR TITLE
Remove respond_to? check

### DIFF
--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -10,7 +10,7 @@ module ViewComponent
       around_action :set_locale, only: :previews
       before_action :require_local!, unless: :show_previews?
 
-      content_security_policy(false) if respond_to?(:content_security_policy)
+      content_security_policy(false)
 
       # Including helpers here ensures that we're loading the
       # latest version of helpers if code-reloading is enabled

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,10 @@ nav_order: 5
 
     *Reegan Viljoen*
 
+* Removed `respond_to?` methods from three files.
+
+    *Tiago Menegaz*
+
 ## 3.21.0
 
 * Updates testing docs to include an example of how to use with RSpec.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -246,7 +246,7 @@ module ViewComponent
         super
       rescue => e # rubocop:disable Style/RescueStandardError
         e.set_backtrace e.backtrace.tap(&:shift)
-        raise e, <<~MESSAGE.chomp if view_context && e.is_a?(NameError) && helpers.respond_to?(method_name)
+        raise e, <<~MESSAGE.chomp if view_context && e.is_a?(NameError) && helpers.methods.include?(method_name.to_sym)
           #{e.message}
 
           You may be trying to call a method provided as a view helper. Did you mean `helpers.#{method_name}'?

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -287,7 +287,9 @@ module ViewComponent
     #
     # @private
     def __vc_request
-      @__vc_request ||= controller.request if controller.respond_to?(:request)
+      @__vc_request ||= controller.request
+    rescue NoMethodError
+      nil
     end
 
     # The content passed to the component instance as a block.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -680,7 +680,7 @@ module ViewComponent
       end
 
       def initialize_parameter_names
-        return attribute_names.map(&:to_sym) if respond_to?(:attribute_names)
+        return attribute_names.map(&:to_sym) if method_defined?(:attribute_names)
 
         initialize_parameters.map(&:last)
       end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -289,7 +289,6 @@ module ViewComponent
     def __vc_request
       @__vc_request ||= controller.request
     rescue NoMethodError
-      nil
     end
 
     # The content passed to the component instance as a block.

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -56,7 +56,7 @@ module ViewComponent
     end
 
     def collection_variable(object)
-      if object.respond_to?(:to_ary)
+      if object.class.method_defined?(:to_ary)
         object.to_ary
       else
         raise InvalidCollectionArgumentError

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -168,7 +168,7 @@ module ViewComponent
 
           define_method :"with_#{slot_name}" do |collection_args = nil, &block|
             collection_args.map do |args|
-              if args.respond_to?(:to_hash)
+              if args.class.method_defined?(:to_hash)
                 set_slot(slot_name, nil, **args, &block)
               else
                 set_slot(slot_name, nil, *args, &block)

--- a/lib/view_component/slotable_default.rb
+++ b/lib/view_component/slotable_default.rb
@@ -8,7 +8,7 @@ module ViewComponent
       renderable_value = send(default_method)
       slot = Slot.new(self)
 
-      if renderable_value.respond_to?(:render_in)
+      if renderable_value.class.method_defined?(:render_in)
         slot.__vc_component_instance = renderable_value
       else
         slot.__vc_content = renderable_value

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -127,7 +127,7 @@ module ViewComponent
     private
 
     def html_safe_translation(translation)
-      if translation.respond_to?(:map)
+      if translation.class.method_defined?(:map)
         translation.map { |element| html_safe_translation(element) }
       else
         # It's assumed here that objects loaded by the i18n backend will respond to `#html_safe?`.

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,7 +16,7 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 104, "3.4.1" => 104, "3.3.7" => 108} :
+      {"3.5.0" => 102, "3.4.1" => 104, "3.3.7" => 108} :
       {"3.3.7" => 107, "3.3.0" => 120, "3.2.7" => 105, "3.1.6" => 118, "3.0.7" => 127}
 
     assert_allocations(**allocations) do

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -17,7 +17,7 @@ class RenderingTest < ViewComponent::TestCase
 
     allocations = (Rails.version.to_f >= 8.0) ?
       {"3.5.0" => 102, "3.4.1" => 104, "3.3.7" => 108} :
-      {"3.3.7" => 175, "3.3.0" => 120, "3.2.7" => 105, "3.1.6" => 118, "3.0.7" => 127}
+      {"3.3.7" => 107, "3.3.0" => 120, "3.2.7" => 105, "3.1.6" => 118, "3.0.7" => 127}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -17,7 +17,7 @@ class RenderingTest < ViewComponent::TestCase
 
     allocations = (Rails.version.to_f >= 8.0) ?
       {"3.5.0" => 102, "3.4.1" => 104, "3.3.7" => 108} :
-      {"3.3.7" => 107, "3.3.0" => 120, "3.2.7" => 105, "3.1.6" => 118, "3.0.7" => 127}
+      {"3.3.7" => 175, "3.3.0" => 120, "3.2.7" => 105, "3.1.6" => 118, "3.0.7" => 127}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -194,7 +194,7 @@ class SlotableTest < ViewComponent::TestCase
       end
     end
 
-    assert component.items.first.respond_to?(:classes)
+    assert_not_nil component.items.first.classes
   end
 
   def test_slot_forwards_kwargs_to_component

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -13,16 +13,9 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://viewcomponent.org"
   spec.license = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "https://rubygems.org"
-    spec.metadata["source_code_uri"] = "https://github.com/viewcomponent/view_component"
-    spec.metadata["changelog_uri"] = "https://github.com/ViewComponent/view_component/blob/main/docs/CHANGELOG.md"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
+  spec.metadata["source_code_uri"] = "https://github.com/viewcomponent/view_component"
+  spec.metadata["changelog_uri"] = "https://github.com/ViewComponent/view_component/blob/main/docs/CHANGELOG.md"
 
   spec.files = Dir["LICENSE.txt", "README.md", "app/**/*", "docs/CHANGELOG.md", "lib/**/*"]
   spec.require_paths = ["lib"]


### PR DESCRIPTION
### What are you trying to accomplish?

This PR removes `respond_to?` from the following files:

- `app/controllers/concerns/view_component/preview_actions.rb`
- `lib/view_component/base.rb`
- `lib/view_component/collection.rb`
- `lib/view_component/slotable.rb`
- `lib/view_component/slotable_default.rb`
- `lib/view_component/translatable.rb`
- `test/sandbox/test/rendering_test.rb`
- `test/sandbox/test/slotable_test.rb`
- `view_component.gemspec`

Most of the changes were done by refactoring `respond_to?` to `class.method_defined` which is an alternative to that method. Please feel free to discuss these changes. 

### What approach did you choose and why?

Some checks aren't necessary because we don't support discontinued Ruby versions and the code can be written without `respond_to?`.

### Anything you want to highlight for special attention from reviewers?

I noticed that some `respond_to?` are being used to support `ruby2_keywords`. I'm assuming it exists because we want to support old ruby versions. However, based on the gemfile - `ruby_version = (ENV["RUBY_VERSION"] || "~> 3.4").to_s` - we don't support Ruby 2 anymore. I'll address these keywords in a different PR.
