### PR TITLE
Add eagerworks to the list of projects/companies that use ViewComponents

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,10 @@ nav_order: 5
 
     *Reegan Viljoen*
 
+* Add HomeStyler AI to list of companies using ViewComponent.
+
+    *JP Balarini*
+
 ## 3.21.0
 
 * Updates testing docs to include an example of how to use with RSpec.

--- a/docs/index.md
+++ b/docs/index.md
@@ -261,6 +261,7 @@ ViewComponent is built by over a hundred members of the community, including:
 * [GitHub](https://github.com/) (900+ components used 15k+ times)
 * [GitLab](https://gitlab.com/)
 * [HappyCo](https://happy.co)
+* [HomeStyler AI](https://homestyler.ai)
 * [Keenly](https://www.keenly.so) (100+ components)
 * [Kicksite](https://kicksite.com/)
 * [Krystal](https://krystal.uk)


### PR DESCRIPTION
Add HomeStyler AI to the list of projects/companies that use ViewComponents.

### What are you trying to accomplish?

Update the list of projects/companies that currently use ViewComponents.

### What approach did you choose and why?

Update the list directly.

### Anything you want to highlight for special attention from reviewers?

Thanks for creating such an awesome library!