### PR TITLE
Support treat turbo_stream the same as html

### DIFF
--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -78,7 +78,7 @@ module ViewComponent
                 "variant&.to_sym == #{template.variant.inspect}"
               else
                 [
-                  template.default_format? ? "(format == #{ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT.inspect} || format.nil?)" : "format == #{template.format.inspect}",
+                  template.default_format? ? "(format == #{ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT.inspect} || format == :turbo_stream || format.nil?)" : "format == #{template.format.inspect}",
                   template.variant.nil? ? "variant.nil?" : "variant&.to_sym == #{template.variant.inspect}"
                 ].join(" && ")
               end
@@ -95,6 +95,7 @@ module ViewComponent
       @component.silence_redefinition_of_method(:render_template_for)
       @component.class_eval <<-RUBY, __FILE__, __LINE__ + 1
       def render_template_for(variant = nil, format = nil)
+        Rails.logger.info("Rendering template for variant: \#{variant}, format: \#{format}")
         #{method_body}
       end
       RUBY

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -80,7 +80,7 @@ module ViewComponent
     end
 
     def default_format?
-      @this_format == ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT
+      @this_format == ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT || @this_format == :turbo_stream
     end
 
     def format


### PR DESCRIPTION
### What are you trying to accomplish?

Rails sets the format for `turbo_stream` responses to `turbo_stream`, which then falls back to the `html` format. ViewComponents need to do the same so that variants are correctly selected.

### What approach did you choose and why?

This is a hack to unblock us from using ViewComponents with variants in production, so it's pretty hacky at the moment.

### Anything you want to highlight for special attention from reviewers?

I hope this sparks further discussion from maintainers who are more familiar with best practices for what's going on here.