### PR TITLE
Support opt-in Nokogiri HTML5 parsing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,10 @@ nav_order: 5
 
     *JP Balarini*
 
+* Support opt-in Nokogiri HTML5 parsing in view components rendered for test
+
+    *Noah Silvera*
+
 ## 3.21.0
 
 * Updates testing docs to include an example of how to use with RSpec.

--- a/docs/api.md
+++ b/docs/api.md
@@ -272,6 +272,11 @@ or are made more publicly available via `"render.view_component"`.
 Will default to `false` in next major version.
 Defaults to `true`.
 
+### `.use_html5_parsing`
+
+Whether `Nokogiri::HTML5` is used for parsing generated view component HTML in test.
+Defaults to `false`.
+
 ### `.view_component_path`
 
 The path in which components, their templates, and their sidecars should

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -25,7 +25,8 @@ module ViewComponent
           preview_paths: default_preview_paths,
           test_controller: "ApplicationController",
           default_preview_layout: nil,
-          capture_compatibility_patch_enabled: false
+          capture_compatibility_patch_enabled: false,
+          use_html5_parsing: false
         })
       end
 
@@ -125,6 +126,11 @@ module ViewComponent
       # or are made more publicly available via `"render.view_component"`.
       # Will default to `false` in next major version.
       # Defaults to `true`.
+
+      # @!attribute use_html5_parsing
+      # @return [Boolean]
+      # Whether `Nokogiri::HTML5` is used for parsing generated view component HTML in test.
+      # Defaults to `false`.
 
       # @!attribute render_monkey_patch_enabled
       # @return [Boolean] Whether the #render method should be monkey patched.

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -60,7 +60,7 @@ module ViewComponent
 
       # :nocov:
 
-      Nokogiri::HTML.fragment(@rendered_content)
+      html_document_class.fragment(@rendered_content)
     end
 
     # `JSON.parse`-d component output.
@@ -107,7 +107,7 @@ module ViewComponent
 
       @rendered_content = result
 
-      Nokogiri::HTML.fragment(@rendered_content)
+      html_document_class.fragment(@rendered_content)
     end
 
     # Execute the given block in the view context (using `instance_exec`).
@@ -124,7 +124,7 @@ module ViewComponent
     def render_in_view_context(*args, &block)
       @page = nil
       @rendered_content = vc_test_controller.view_context.instance_exec(*args, &block)
-      Nokogiri::HTML.fragment(@rendered_content)
+      html_document_class.fragment(@rendered_content)
     end
     ruby2_keywords(:render_in_view_context) if respond_to?(:ruby2_keywords, true)
 
@@ -297,5 +297,13 @@ module ViewComponent
       raise NameError, "`render_preview` expected to find #{result}, but it does not exist."
     end
     # :nocov:
+
+    def html_document_class
+      @html_document_class ||= if Rails.application.config.view_component.use_html5_parsing
+        Nokogiri::HTML5
+      else
+        Nokogiri::HTML4
+      end
+    end
   end
 end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,8 +16,8 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 117, "3.4.1" => 117, "3.3.7" => 129} :
-      {"3.3.7" => 120, "3.3.0" => 120, "3.2.7" => 118, "3.1.6" => 118, "3.0.7" => 127}
+      {"3.5.0" => 117, "3.4.1" => 119, "3.3.7" => 131} :
+      {"3.3.7" => 122, "3.3.0" => 120, "3.2.7" => 120, "3.1.6" => 120, "3.0.7" => 130}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)


### PR DESCRIPTION
### What are you trying to accomplish?

In view components rendered for test, we should allow opt-in Nokogiri::HTML5 parsing

Nokogiri::HTML is just an alias for Nokogiri::HTML4, so this is a non-breaking change.

I was motivated to make this change because in my own app, `Nokogiri::HTML4` was parsing my rendered HTML incorrectly (inserting spaces in the middle of data attributes),  while `Nokogiri::HTML5` parsed it correctly.

Example of the incorrect parsing

![Screenshot 2025-02-13 at 10 43 37 AM](https://github.com/user-attachments/assets/899f1c1c-cb6a-4aa1-8aaf-fd7e3a7185e6)
![Screenshot 2025-02-12 at 5 27 44 PM](https://github.com/user-attachments/assets/90de69da-e3ec-4d17-b0d9-ec15baa3d611)

