### PR TITLE
Reorganise configuration across Rails app and component classes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -82,7 +82,7 @@ namespace :docs do
 
     instance_methods_to_document = meths.select { |method| method.scope != :class }
     class_methods_to_document = meths.select { |method| method.scope == :class }
-    configuration_methods_to_document = registry.get("ViewComponent::Config").meths.select(&:reader?)
+    configuration_methods_to_document = registry.get("ViewComponent::ApplicationConfig").meths.select(&:reader?)
     test_helper_methods_to_document = registry
       .get("ViewComponent::TestHelpers")
       .meths

--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -54,12 +54,12 @@ module ViewComponent
 
     # :doc:
     def default_preview_layout
-      Rails.application.config.view_component.default_preview_layout
+      Rails.application.config.view_component.previews.default_layout
     end
 
     # :doc:
     def show_previews?
-      Rails.application.config.view_component.show_previews
+      Rails.application.config.view_component.previews.show
     end
 
     # :doc:

--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -102,7 +102,7 @@ module ViewComponent
     end
 
     def prepend_preview_examples_view_path
-      prepend_view_path(Rails.application.config.view_component.preview_paths)
+      prepend_view_path(Rails.application.config.view_component.previews.paths)
     end
   end
 end

--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -54,12 +54,12 @@ module ViewComponent
 
     # :doc:
     def default_preview_layout
-      ViewComponent::Base.config.default_preview_layout
+      Rails.application.config.view_component.default_preview_layout
     end
 
     # :doc:
     def show_previews?
-      ViewComponent::Base.config.show_previews
+      Rails.application.config.view_component.show_previews
     end
 
     # :doc:
@@ -102,7 +102,7 @@ module ViewComponent
     end
 
     def prepend_preview_examples_view_path
-      prepend_view_path(ViewComponent::Base.preview_paths)
+      prepend_view_path(Rails.application.config.view_component.preview_paths)
     end
   end
 end

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -48,6 +48,6 @@ module PreviewHelper
   # :nocov:
 
   def serve_static_preview_assets?
-    ViewComponent::Base.config.show_previews && Rails.application.config.public_file_server.enabled
+    Rails.application.config.view_component.show_previews && Rails.application.config.public_file_server.enabled
   end
 end

--- a/app/views/view_components/preview.html.erb
+++ b/app/views/view_components/preview.html.erb
@@ -4,6 +4,6 @@
   <%= render template: @render_args[:template], locals: @render_args[:locals] || {} %>
 <% end %>
 
-<% if Rails.application.config.view_component.show_previews_source %>
+<% if Rails.application.config.view_component.previews.show_source %>
   <%= preview_source %>
 <% end %>

--- a/app/views/view_components/preview.html.erb
+++ b/app/views/view_components/preview.html.erb
@@ -4,6 +4,6 @@
   <%= render template: @render_args[:template], locals: @render_args[:locals] || {} %>
 <% end %>
 
-<% if ViewComponent::Base.config.show_previews_source %>
+<% if Rails.application.config.view_component.show_previews_source %>
   <%= preview_source %>
 <% end %>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ nav_order: 5
 
 ## 4.0.0
 
+* BREAKING: Make most configuration local to component instances.
+
+    Simon Fish
+
 * BREAKING: Require [non-EOL](https://endoflife.date/rails) Rails (`>= 7.1.0`).
 
     *Joel Hawksley*

--- a/lib/rails/generators/abstract_generator.rb
+++ b/lib/rails/generators/abstract_generator.rb
@@ -29,7 +29,7 @@ module ViewComponent
     end
 
     def component_path
-      ViewComponent::Base.config.view_component_path
+      Rails.application.config.view_component.view_component_path
     end
 
     def stimulus_controller
@@ -42,15 +42,15 @@ module ViewComponent
     end
 
     def sidecar?
-      options["sidecar"] || ViewComponent::Base.config.generate.sidecar
+      options["sidecar"] || Rails.application.config.view_component.generate.sidecar
     end
 
     def stimulus?
-      options["stimulus"] || ViewComponent::Base.config.generate.stimulus_controller
+      options["stimulus"] || Rails.application.config.view_component.generate.stimulus_controller
     end
 
     def typescript?
-      options["typescript"] || ViewComponent::Base.config.generate.typescript
+      options["typescript"] || Rails.application.config.view_component.generate.typescript
     end
   end
 end

--- a/lib/rails/generators/abstract_generator.rb
+++ b/lib/rails/generators/abstract_generator.rb
@@ -29,7 +29,8 @@ module ViewComponent
     end
 
     def component_path
-      Rails.application.config.view_component.view_component_path
+      # FIXME: Doesn't yet handle multiple component paths
+      Rails.application.config.view_component.generate.view_component_paths!.first
     end
 
     def stimulus_controller

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -42,7 +42,7 @@ module Rails
       def parent_class
         return options[:parent] if options[:parent]
 
-        Rails.application.config.view_component.component_parent_class || default_parent_class
+        Rails.application.config.view_component.generate.component_parent_class || default_parent_class
       end
 
       def initialize_signature

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -14,9 +14,10 @@ module Rails
 
       class_option :inline, type: :boolean, default: false
       class_option :locale, type: :boolean, default: Rails.application.config.view_component.generate.locale
-      class_option :parent, type: :string, desc: "The parent class for the generated component"
+      class_option :parent, type: :string, desc: "The parent class for the generated component",
+        default: Rails.application.config.view_component.generate.component_parent_class
       class_option :preview, type: :boolean, default: Rails.application.config.view_component.generate.preview
-      class_option :sidecar, type: :boolean, default: false
+      class_option :sidecar, type: :boolean, default: Rails.application.config.view_component.generate.sidecar
       class_option :stimulus, type: :boolean,
         default: Rails.application.config.view_component.generate.stimulus_controller
       class_option :skip_suffix, type: :boolean, default: false

--- a/lib/rails/generators/component/component_generator.rb
+++ b/lib/rails/generators/component/component_generator.rb
@@ -13,12 +13,12 @@ module Rails
       check_class_collision suffix: "Component"
 
       class_option :inline, type: :boolean, default: false
-      class_option :locale, type: :boolean, default: ViewComponent::Base.config.generate.locale
+      class_option :locale, type: :boolean, default: Rails.application.config.view_component.generate.locale
       class_option :parent, type: :string, desc: "The parent class for the generated component"
-      class_option :preview, type: :boolean, default: ViewComponent::Base.config.generate.preview
+      class_option :preview, type: :boolean, default: Rails.application.config.view_component.generate.preview
       class_option :sidecar, type: :boolean, default: false
       class_option :stimulus, type: :boolean,
-        default: ViewComponent::Base.config.generate.stimulus_controller
+        default: Rails.application.config.view_component.generate.stimulus_controller
       class_option :skip_suffix, type: :boolean, default: false
 
       def create_component_file
@@ -42,7 +42,7 @@ module Rails
       def parent_class
         return options[:parent] if options[:parent]
 
-        ViewComponent::Base.config.component_parent_class || default_parent_class
+        Rails.application.config.view_component.component_parent_class || default_parent_class
       end
 
       def initialize_signature

--- a/lib/rails/generators/locale/component_generator.rb
+++ b/lib/rails/generators/locale/component_generator.rb
@@ -12,7 +12,7 @@ module Locale
       class_option :sidecar, type: :boolean, default: false
 
       def create_locale_file
-        if ViewComponent::Base.config.generate.distinct_locale_files
+        if Rails.application.config.view_component.generate.distinct_locale_files
           I18n.available_locales.each do |locale|
             create_file destination(locale), translations_hash([locale]).to_yaml
           end

--- a/lib/rails/generators/preview/component_generator.rb
+++ b/lib/rails/generators/preview/component_generator.rb
@@ -4,13 +4,13 @@ module Preview
   module Generators
     class ComponentGenerator < ::Rails::Generators::NamedBase
       source_root File.expand_path("templates", __dir__)
-      class_option :preview_path, type: :string, desc: "Path for previews, required when multiple preview paths are configured", default: ViewComponent::Base.config.generate.preview_path
+      class_option :preview_path, type: :string, desc: "Path for previews, required when multiple preview paths are configured", default: Rails.application.config.view_component.generate.preview_path
 
       argument :attributes, type: :array, default: [], banner: "attribute"
       check_class_collision suffix: "ComponentPreview"
 
       def create_preview_file
-        preview_paths = ViewComponent::Base.config.preview_paths
+        preview_paths = Rails.application.config.view_component.preview_paths
         optional_path = options[:preview_path]
         return if preview_paths.count > 1 && optional_path.blank?
 

--- a/lib/rails/generators/preview/component_generator.rb
+++ b/lib/rails/generators/preview/component_generator.rb
@@ -10,7 +10,7 @@ module Preview
       check_class_collision suffix: "ComponentPreview"
 
       def create_preview_file
-        preview_paths = Rails.application.config.view_component.preview_paths
+        preview_paths = Rails.application.config.view_component.previews.paths
         optional_path = options[:preview_path]
         return if preview_paths.count > 1 && optional_path.blank?
 

--- a/lib/rails/generators/rspec/component_generator.rb
+++ b/lib/rails/generators/rspec/component_generator.rb
@@ -16,7 +16,7 @@ module Rspec
       private
 
       def spec_component_path
-        return "spec/components" unless ViewComponent::Base.config.generate.use_component_path_for_rspec_tests
+        return "spec/components" unless Rails.application.config.view_component.generate.use_component_path_for_rspec_tests
 
         configured_component_path = component_path
         if configured_component_path.start_with?("app#{File::SEPARATOR}")

--- a/lib/rails/generators/stimulus/component_generator.rb
+++ b/lib/rails/generators/stimulus/component_generator.rb
@@ -8,8 +8,8 @@ module Stimulus
       include ViewComponent::AbstractGenerator
 
       source_root File.expand_path("templates", __dir__)
-      class_option :sidecar, type: :boolean, default: false
-      class_option :typescript, type: :boolean, default: false
+      class_option :sidecar, type: :boolean, default: Rails.application.config.view_component.generate.sidecar
+      class_option :typescript, type: :boolean, default: Rails.application.config.view_component.generate.typescript
 
       def create_stimulus_controller
         template "component_controller.#{filetype}", destination

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -6,12 +6,12 @@ require "active_support/dependencies/autoload"
 module ViewComponent
   extend ActiveSupport::Autoload
 
+  autoload :ApplicationConfig
   autoload :Base
   autoload :CaptureCompatibility
   autoload :Compiler
   autoload :CompileCache
   autoload :ComponentError
-  autoload :Config
   autoload :Deprecation
   autoload :InlineTemplate
   autoload :Instrumentation

--- a/lib/view_component/application_config.rb
+++ b/lib/view_component/application_config.rb
@@ -3,7 +3,7 @@
 require "view_component/deprecation"
 
 module ViewComponent
-  class Config
+  class ApplicationConfig
     class << self
       # `new` without any arguments initializes the default configuration, but
       # it's important to differentiate in case that's no longer the case in
@@ -29,7 +29,7 @@ module ViewComponent
             controller: "ViewComponentsController",
             route: "/rails/view_components",
             show_source: (Rails.env.development? || Rails.env.test?),
-            paths: ViewComponent::Config.default_preview_paths,
+            paths: default_preview_paths,
             default_layout: nil
           ],
           instrumentation_enabled: false,

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -551,7 +551,7 @@ module ViewComponent
         # TODO: probably a way to rework this, seems like it's load order dependent at the moment?
         if defined?(Rails) && Rails.application
           child.virtual_path = child.identifier.gsub(
-            /(.*#{Regexp.quote(Rails.application.config.view_component.view_component_path)})|(\.rb)/, ""
+            /(.*#{Regexp.quote(Rails.application.config.view_component.generate.view_component_paths!.first)})|(\.rb)/, ""
           )
         end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -571,9 +571,10 @@ module ViewComponent
         # If Rails application is loaded, removes the first part of the path and the extension.
         # TODO: probably a way to rework this, seems like it's load order dependent at the moment?
         if defined?(Rails) && Rails.application
-          child.virtual_path = child.identifier.gsub(
-            /(.*#{Regexp.quote(Rails.application.config.view_component.generate.view_component_paths!.first)})|(\.rb)/, ""
-          )
+          child.virtual_path = Rails.application.config.view_component.generate.view_component_paths!
+            .inject(child.identifier) do |identifier, path|
+            identifier.gsub(/.*#{Regexp.quote(path)}/, "")
+          end
         end
 
         # Set collection parameter to the extended component

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -2,10 +2,10 @@
 
 require "action_view"
 require "active_support/configurable"
+require "view_component/application_config"
 require "view_component/collection"
 require "view_component/compile_cache"
 require "view_component/compiler"
-require "view_component/config"
 require "view_component/errors"
 require "view_component/inline_template"
 require "view_component/preview"

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -19,10 +19,19 @@ require "view_component/use_helpers"
 
 module ViewComponent
   class Base < ActionView::Base
+    class Configuration
+      def initialize
+        @config = ActiveSupport::OrderedOptions[
+          preview: ActiveSupport::OrderedOptions[paths: []]
+        ]
+      end
+
+      delegate :preview, to: :@config
+    end
     # Returns the current config.
     #
     # @return [ActiveSupport::OrderedOptions]
-    class_attribute :configuration, default: ViewComponent::Config.defaults
+    class_attribute :configuration, default: ViewComponent::Base::Configuration.new
 
     class << self
       def configure(&block)

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -21,7 +21,6 @@ module ViewComponent
           show_previews_source: false,
           instrumentation_enabled: false,
           use_deprecated_instrumentation_name: true,
-          view_component_path: "app/components",
           component_parent_class: nil,
           show_previews: Rails.env.development? || Rails.env.test?,
           preview_paths: default_preview_paths,
@@ -199,6 +198,7 @@ module ViewComponent
       def default_generate_options
         options = ActiveSupport::OrderedOptions.new(false)
         options.preview_path = ""
+        options.view_component_paths = ["app/components"]
         options
       end
     end

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -20,7 +20,6 @@ module ViewComponent
           ],
           show_previews_source: false,
           instrumentation_enabled: false,
-          use_deprecated_instrumentation_name: true,
           component_parent_class: nil,
           show_previews: Rails.env.development? || Rails.env.test?,
           preview_paths: default_preview_paths,
@@ -124,13 +123,6 @@ module ViewComponent
       # @return [Boolean]
       # Whether ActiveSupport notifications are enabled.
       # Defaults to `false`.
-
-      # @!attribute use_deprecated_instrumentation_name
-      # @return [Boolean]
-      # Whether ActiveSupport Notifications use the private name `"!render.view_component"`
-      # or are made more publicly available via `"render.view_component"`.
-      # Will default to `false` in next major version.
-      # Defaults to `true`.
 
       # @!attribute view_component_path
       # @return [String]

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -15,9 +15,9 @@ module ViewComponent
           generate: default_generate_options,
           preview_controller: "ViewComponentsController",
           preview_route: "/rails/view_components",
-          preview: ActiveSupport::OrderedOptions.new({
+          preview: ActiveSupport::OrderedOptions[
             paths: default_preview_paths
-          }),
+          ],
           show_previews_source: false,
           instrumentation_enabled: false,
           use_deprecated_instrumentation_name: true,
@@ -100,6 +100,11 @@ module ViewComponent
       # For example, if the `view_component_path` is
       # `app/views/components`, then the generator will create a new spec file
       # in `spec/views/components/` rather than the default `spec/components/`.
+      
+      # @!attribute preview
+      # @return [String]
+      # The subset of configuration options relating to previews.
+      # TODO: Document.
 
       # @!attribute preview_controller
       # @return [String]

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -13,12 +13,19 @@ module ViewComponent
       def defaults
         ActiveSupport::OrderedOptions[
           generate: ActiveSupport::OrderedOptions[
+            sidecar: false,
+            stimulus_controller: false,
+            typescript: false,
+            locale: false,
+            distinct_locale_files: false,
+            preview: false,
             preview_path: "",
+            use_component_path_for_rspec_tests: false,
             view_component_paths: ["app/components"],
-            use_component_path_for_rspec_tests: false
+            component_parent_class: nil
           ],
           previews: ActiveSupport::OrderedOptions[
-            show: true,
+            show: (Rails.env.development? || Rails.env.test?),
             controller: "ViewComponentsController",
             route: "/rails/view_components",
             show_source: (Rails.env.development? || Rails.env.test?),
@@ -26,7 +33,8 @@ module ViewComponent
             default_layout: nil
           ],
           instrumentation_enabled: false,
-          capture_compatibility_patch_enabled: false
+          test_controller: "ApplicationController",
+          capture_compatibility_patch_enabled: false,
         ]
       end
 
@@ -99,65 +107,70 @@ module ViewComponent
       # For example, if the `view_component_path` is
       # `app/views/components`, then the generator will create a new spec file
       # in `spec/views/components/` rather than the default `spec/components/`.
+      #
+      # #### `#view_component_path``
+      #
+      # The path in which components, their templates, and their sidecars should
+      # be stored:
+      #
+      #      config.view_component.generate.view_component_paths = "app/components"
+      #
+      # Defaults to `"app/components"`.
+      # TODO: It looks like this was actually the default path generators would use.
+      #       I think it's used elsewhere inside `base.rb` for some reason, though.
+      #
+      # #### `#component_parent_class`
+      # 
+      # The parent class from which generated components will inherit.
+      # Defaults to `nil`. If this is falsy, generators will use
+      # `"ApplicationComponent"` if defined, `"ViewComponent::Base"` otherwise.
+
       
       # @!attribute previews
       # @return [String]
       # The subset of configuration options relating to previews.
-      # TODO: Document.
-
-      # @!attribute preview_controller
-      # @return [String]
+      #
+      # #### `#show`
+      #
+      # Whether component previews are enabled.
+      # Defaults to `true` in development and test environments.
+      #
+      # #### `#controller`
+      #
       # The controller used for previewing components.
       # Defaults to `ViewComponentsController`.
-
-      # @!attribute preview_route
-      # @return [String]
+      #
+      # #### `route`
+      #
       # The entry route for component previews.
       # Defaults to `"/rails/view_components"`.
-
-      # @!attribute show_previews_source
-      # @return [Boolean]
+      #
+      # #### `show_source`
+      #
       # Whether to display source code previews in component previews.
       # Defaults to `false`.
+      # 
+      # #### `paths`
+      #
+      # The locations in which component previews will be looked up.
+      # Defaults to `['test/components/previews']` relative to your Rails root.
+      #
+      # #### `#default_layout`
+      # 
+      # A custom default layout used for the previews index page and individual
+      # previews.
+      # Defaults to `nil`. If this is falsy, `"component_preview"` is used.
 
       # @!attribute instrumentation_enabled
       # @return [Boolean]
       # Whether ActiveSupport notifications are enabled.
       # Defaults to `false`.
 
-      # @!attribute view_component_path
-      # @return [String]
-      # The path in which components, their templates, and their sidecars should
-      # be stored.
-      # Defaults to `"app/components"`.
-
-      # @!attribute component_parent_class
-      # @return [String]
-      # The parent class from which generated components will inherit.
-      # Defaults to `nil`. If this is falsy, generators will use
-      # `"ApplicationComponent"` if defined, `"ViewComponent::Base"` otherwise.
-
-      # @!attribute show_previews
-      # @return [Boolean]
-      # Whether component previews are enabled.
-      # Defaults to `true` in development and test environments.
-
-      # @!attribute preview_paths
-      # @return [Array<String>]
-      # The locations in which component previews will be looked up.
-      # Defaults to `['test/components/previews']` relative to your Rails root.
-
       # @!attribute test_controller
       # @return [String]
       # The controller used for testing components.
       # Can also be configured on a per-test basis using `#with_controller_class`.
       # Defaults to `ApplicationController`.
-
-      # @!attribute default_preview_layout
-      # @return [String]
-      # A custom default layout used for the previews index page and individual
-      # previews.
-      # Defaults to `nil`. If this is falsy, `"component_preview"` is used.
 
       # @!attribute capture_compatibility_patch_enabled
       # @return [Boolean]

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -14,7 +14,8 @@ module ViewComponent
         ActiveSupport::OrderedOptions[
           generate: ActiveSupport::OrderedOptions[
             preview_path: "",
-            view_component_paths: ["app/components"]
+            view_component_paths: ["app/components"],
+            use_component_path_for_rspec_tests: false
           ],
           previews: ActiveSupport::OrderedOptions[
             show: true,
@@ -24,7 +25,8 @@ module ViewComponent
             paths: ViewComponent::Config.default_preview_paths,
             default_layout: nil
           ],
-          instrumentation_enabled: false
+          instrumentation_enabled: false,
+          capture_compatibility_patch_enabled: false
         ]
       end
 

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -15,6 +15,9 @@ module ViewComponent
           generate: default_generate_options,
           preview_controller: "ViewComponentsController",
           preview_route: "/rails/view_components",
+          preview: ActiveSupport::OrderedOptions.new({
+            paths: default_preview_paths
+          }),
           show_previews_source: false,
           instrumentation_enabled: false,
           use_deprecated_instrumentation_name: true,

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -11,22 +11,21 @@ module ViewComponent
       alias_method :default, :new
 
       def defaults
-        ActiveSupport::OrderedOptions.new.merge!({
-          generate: default_generate_options,
-          preview_controller: "ViewComponentsController",
-          preview_route: "/rails/view_components",
-          preview: ActiveSupport::OrderedOptions[
-            paths: default_preview_paths
+        ActiveSupport::OrderedOptions[
+          generate: ActiveSupport::OrderedOptions[
+            preview_path: "",
+            view_component_paths: ["app/components"]
           ],
-          show_previews_source: false,
-          instrumentation_enabled: false,
-          component_parent_class: nil,
-          show_previews: Rails.env.development? || Rails.env.test?,
-          preview_paths: default_preview_paths,
-          test_controller: "ApplicationController",
-          default_preview_layout: nil,
-          capture_compatibility_patch_enabled: false
-        })
+          previews: ActiveSupport::OrderedOptions[
+            show: true,
+            controller: "ViewComponentsController",
+            route: "/rails/view_components",
+            show_source: (Rails.env.development? || Rails.env.test?),
+            paths: ViewComponent::Config.default_preview_paths,
+            default_layout: nil
+          ],
+          instrumentation_enabled: false
+        ]
       end
 
       # @!attribute generate
@@ -99,7 +98,7 @@ module ViewComponent
       # `app/views/components`, then the generator will create a new spec file
       # in `spec/views/components/` rather than the default `spec/components/`.
       
-      # @!attribute preview
+      # @!attribute previews
       # @return [String]
       # The subset of configuration options relating to previews.
       # TODO: Document.
@@ -194,14 +193,6 @@ module ViewComponent
         options
       end
     end
-
-    # @!attribute current
-    # @return [ViewComponent::Config]
-    # Returns the current ViewComponent::Config. This is persisted against this
-    # class so that config options remain accessible before the rest of
-    # ViewComponent has loaded. Defaults to an instance of ViewComponent::Config
-    # with all other documented defaults set.
-    class_attribute :current, default: defaults, instance_predicate: false
 
     def initialize
       @config = self.class.defaults

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -187,13 +187,6 @@ module ViewComponent
           defined?(descendant.root) && Dir.exist?("#{descendant.root}/test/components/previews")
         end
       end
-
-      def default_generate_options
-        options = ActiveSupport::OrderedOptions.new(false)
-        options.preview_path = ""
-        options.view_component_paths = ["app/components"]
-        options
-      end
     end
 
     def initialize

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -174,8 +174,6 @@ module ViewComponent
       end
 
       def default_rails_preview_paths
-        return [] unless defined?(Rails.root) && Dir.exist?("#{Rails.root}/test/components/previews")
-
         ["#{Rails.root}/test/components/previews"]
       end
 

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -78,12 +78,6 @@ module ViewComponent
         if app.config.view_component.instrumentation_enabled.present?
           # :nocov: Re-executing the below in tests duplicates initializers and causes order-dependent failures.
           ViewComponent::Base.prepend(ViewComponent::Instrumentation)
-          if app.config.view_component.use_deprecated_instrumentation_name
-            ViewComponent::Deprecation.deprecation_warning(
-              "!render.view_component",
-              "Use the new instrumentation key `render.view_component` instead. See https://viewcomponent.org/guide/instrumentation.html"
-            )
-          end
           # :nocov:
         end
       end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require "rails"
-require "view_component/config"
+require "view_component/application_config"
 require "view_component/deprecation"
 
 module ViewComponent
   class Engine < Rails::Engine # :nodoc:
-    config.view_component = ViewComponent::Config.default
+    config.view_component = ViewComponent::ApplicationConfig.default
 
     if Rails.version.to_f < 8.0
       rake_tasks do

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -8,7 +8,10 @@ module ViewComponent
   class Engine < Rails::Engine # :nodoc:
     config.view_component = ActiveSupport::OrderedOptions[
       path: "app/components",
-      generate: ActiveSupport::OrderedOptions.new(false).tap { |generate| generate.preview_path = "" },
+      generate: ActiveSupport::OrderedOptions.new(false).tap do |generate|
+        generate.preview_path = ""
+        generate.view_component_paths = ["app/components"]
+      end,
       previews: ActiveSupport::OrderedOptions[
         show: true,
         controller: "ViewComponentsController",
@@ -48,7 +51,7 @@ module ViewComponent
       options.instrumentation_enabled = false if options.instrumentation_enabled.nil?
       options.show_previews = options.previews.show!
       options.default_preview_layout = options.previews.default_layout
-      options.view_component_path = options.path!
+      options.view_component_paths = options.generate.view_component_paths!
 
       # This is still necessary because when `config.view_component` is declared, `Rails.root` is unspecified.
       # if options.show_previews
@@ -128,17 +131,17 @@ module ViewComponent
 
       if options.show_previews
         app.routes.prepend do
-          preview_controller = options.preview_controller.sub(/Controller$/, "").underscore
+          preview_controller = options.previews.controller!.sub(/Controller$/, "").underscore
 
           get(
-            options.preview_route,
+            options.previews.route!,
             to: "#{preview_controller}#index",
             as: :preview_view_components,
             internal: true
           )
 
           get(
-            "#{options.preview_route}/*path",
+            "#{options.previews.route!}/*path",
             to: "#{preview_controller}#previews",
             as: :preview_view_component,
             internal: true

--- a/lib/view_component/instrumentation.rb
+++ b/lib/view_component/instrumentation.rb
@@ -23,7 +23,7 @@ module ViewComponent # :nodoc:
     private
 
     def notification_name
-      return "!render.view_component" if ViewComponent::Base.config.use_deprecated_instrumentation_name
+      return "!render.view_component" if Rails.application.config.view_component.use_deprecated_instrumentation_name
 
       "render.view_component"
     end

--- a/lib/view_component/instrumentation.rb
+++ b/lib/view_component/instrumentation.rb
@@ -10,7 +10,7 @@ module ViewComponent # :nodoc:
 
     def render_in(view_context, &block)
       ActiveSupport::Notifications.instrument(
-        notification_name,
+        "render.view_component",
         {
           name: self.class.name,
           identifier: self.class.identifier
@@ -18,14 +18,6 @@ module ViewComponent # :nodoc:
       ) do
         super
       end
-    end
-
-    private
-
-    def notification_name
-      return "!render.view_component" if Rails.application.config.view_component.use_deprecated_instrumentation_name
-
-      "render.view_component"
     end
   end
 end

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -107,7 +107,7 @@ module ViewComponent # :nodoc:
       private
 
       def preview_paths
-        Rails.application.config.view_component.preview_paths
+        Rails.application.config.view_component.previews.paths
       end
     end
   end

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -107,7 +107,7 @@ module ViewComponent # :nodoc:
       private
 
       def preview_paths
-        Base.preview_paths
+        Rails.application.config.view_component.preview_paths
       end
     end
   end

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -245,7 +245,7 @@ module ViewComponent
     #
     # @return [ActionController::Base]
     def vc_test_controller
-      @vc_test_controller ||= __vc_test_helpers_build_controller(Base.test_controller.constantize)
+      @vc_test_controller ||= __vc_test_helpers_build_controller(Rails.application.config.view_component.test_controller.constantize)
     end
 
     # Access the request used by `render_inline`:

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -84,7 +84,7 @@ module ViewComponent
     # @param params [Hash] Parameters to be passed to the preview.
     # @return [Nokogiri::HTML]
     def render_preview(name, from: __vc_test_helpers_preview_class, params: {})
-      previews_controller = __vc_test_helpers_build_controller(Rails.application.config.view_component.preview_controller.constantize)
+      previews_controller = __vc_test_helpers_build_controller(Rails.application.config.view_component.previews.controller.constantize)
 
       # From what I can tell, it's not possible to overwrite all request parameters
       # at once, so we set them individually here.

--- a/test/sandbox/app/components/config_base_component.rb
+++ b/test/sandbox/app/components/config_base_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ConfigBaseComponent < ViewComponent::Base
-  configure do
-    preview.paths = ["expected_path"]
+  configure do |config|
+    config.test_controller = "SomeController"
   end
 end

--- a/test/sandbox/app/components/config_base_component.rb
+++ b/test/sandbox/app/components/config_base_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ConfigBaseComponent < ViewComponent::Base
+  configure do
+    preview.paths = ["expected_path"]
+  end
+end

--- a/test/sandbox/app/components/inherited_config_component.rb
+++ b/test/sandbox/app/components/inherited_config_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class InheritedConfigComponent < ConfigBaseComponent
-  configure do
-    preview.paths << "another_expected_path"
+  configure do |config|
+    config.test_controller = "AnotherController"
   end
 end

--- a/test/sandbox/app/components/inherited_config_component.rb
+++ b/test/sandbox/app/components/inherited_config_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class InheritedConfigComponent < ConfigBaseComponent
+  configure do
+    preview.paths << "another_expected_path"
+  end
+end

--- a/test/sandbox/config/application.rb
+++ b/test/sandbox/config/application.rb
@@ -42,7 +42,7 @@ module Sandbox
 
     # Prepare test_set_no_duplicate_autoload_paths
     config.autoload_paths.push("#{config.root}/my/components/previews")
-    config.view_component.preview_paths << "#{config.root}/my/components/previews"
+    config.view_component.previews.paths << "#{config.root}/my/components/previews"
   end
 end
 

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -32,7 +32,7 @@ Sandbox::Application.configure do
 
   config.view_component.show_previews = true
 
-  config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"
+  config.view_component.previews.paths << "#{Rails.root}/lib/component_previews"
   config.view_component.show_previews_source = true
   config.view_component.test_controller = "IntegrationExamplesController"
   config.view_component.capture_compatibility_patch_enabled = ENV["CAPTURE_PATCH_ENABLED"] == "true"

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -30,10 +30,10 @@ Sandbox::Application.configure do
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection = false
 
-  config.view_component.show_previews = true
+  config.view_component.previews.show = true
 
   config.view_component.previews.paths << "#{Rails.root}/lib/component_previews"
-  config.view_component.show_previews_source = true
+  config.view_component.previews.show_source = true
   config.view_component.test_controller = "IntegrationExamplesController"
   config.view_component.capture_compatibility_patch_enabled = ENV["CAPTURE_PATCH_ENABLED"] == "true"
 

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -147,10 +147,10 @@ class ViewComponent::Base::UnitTest < Minitest::Test
   end
 
   def test_configuration_dsl
-    assert_equal ["expected_path"], ConfigBaseComponent.new.configuration.preview.paths
+    # assert_equal ["expected_path"], ConfigBaseComponent.new.configuration.preview.paths
   end
 
   def test_inherited_configuration
-    assert_equal ["expected_path", "another_expected_path"], InheritedConfigComponent.new.configuration.preview.paths
+    # assert_equal ["expected_path", "another_expected_path"], InheritedConfigComponent.new.configuration.preview.paths
   end
 end

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -145,4 +145,18 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     MESSAGE
     assert !exception_message_regex.match?(exception.message)
   end
+
+  def test_configuration_dsl
+    component_class = Class.new(ViewComponent::Base) do
+      configure do
+        preview.paths = ["expected_path"]
+      end
+    end
+
+    assert_equal ConfigBaseComponent.new.config.preview.paths, ["expected_path"]
+  end
+
+  def test_inherited_configuration
+    assert_equal InheritedConfigComponent.new.config.preview.paths, ["expected_path", "another_expected_path"]
+  end
 end

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -147,10 +147,10 @@ class ViewComponent::Base::UnitTest < Minitest::Test
   end
 
   def test_configuration_dsl
-    # assert_equal ["expected_path"], ConfigBaseComponent.new.configuration.preview.paths
+    assert_equal "SomeController", ConfigBaseComponent.new.configuration.test_controller
   end
 
   def test_inherited_configuration
-    # assert_equal ["expected_path", "another_expected_path"], InheritedConfigComponent.new.configuration.preview.paths
+    assert_equal "AnotherController", InheritedConfigComponent.new.configuration.test_controller
   end
 end

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -147,12 +147,6 @@ class ViewComponent::Base::UnitTest < Minitest::Test
   end
 
   def test_configuration_dsl
-    component_class = Class.new(ViewComponent::Base) do
-      configure do
-        preview.paths = ["expected_path"]
-      end
-    end
-
     assert_equal ConfigBaseComponent.new.config.preview.paths, ["expected_path"]
   end
 

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -147,10 +147,10 @@ class ViewComponent::Base::UnitTest < Minitest::Test
   end
 
   def test_configuration_dsl
-    assert_equal ConfigBaseComponent.new.config.preview.paths, ["expected_path"]
+    assert_equal ["expected_path"], ConfigBaseComponent.new.configuration.preview.paths
   end
 
   def test_inherited_configuration
-    assert_equal InheritedConfigComponent.new.config.preview.paths, ["expected_path", "another_expected_path"]
+    assert_equal ["expected_path", "another_expected_path"], InheritedConfigComponent.new.configuration.preview.paths
   end
 end

--- a/test/sandbox/test/config_test.rb
+++ b/test/sandbox/test/config_test.rb
@@ -14,7 +14,6 @@ module ViewComponent
       assert_equal @config.preview_route, "/rails/view_components"
       assert_equal @config.show_previews_source, false
       assert_equal @config.instrumentation_enabled, false
-      assert_equal @config.use_deprecated_instrumentation_name, true
       assert_equal @config.show_previews, true
       assert_equal @config.preview_paths, ["#{Rails.root}/test/components/previews"]
     end

--- a/test/sandbox/test/config_test.rb
+++ b/test/sandbox/test/config_test.rb
@@ -9,7 +9,7 @@ module ViewComponent
     end
 
     def test_defaults_are_correct
-      assert_equal @config.generate, {preview_path: ""}
+      assert_equal @config.generate, {preview_path: "", view_component_paths: ["app/components"]}
       assert_equal @config.preview_controller, "ViewComponentsController"
       assert_equal @config.preview_route, "/rails/view_components"
       assert_equal @config.show_previews_source, false

--- a/test/sandbox/test/config_test.rb
+++ b/test/sandbox/test/config_test.rb
@@ -9,7 +9,18 @@ module ViewComponent
     end
 
     def test_defaults_are_correct
-      assert_equal @config.generate, {preview_path: "", view_component_paths: ["app/components"], use_component_path_for_rspec_tests: false}
+      assert_equal @config.generate, {
+        sidecar: false,
+        stimulus_controller: false,
+        typescript: false,
+        locale: false,
+        distinct_locale_files: false,
+        preview: false,
+        preview_path: "",
+        use_component_path_for_rspec_tests: false,
+        view_component_paths: ["app/components"],
+        component_parent_class: nil,
+      }
       assert_equal @config.previews.controller, "ViewComponentsController"
       assert_equal @config.previews.route, "/rails/view_components"
       assert_equal @config.previews.show_source, true

--- a/test/sandbox/test/config_test.rb
+++ b/test/sandbox/test/config_test.rb
@@ -10,12 +10,12 @@ module ViewComponent
 
     def test_defaults_are_correct
       assert_equal @config.generate, {preview_path: "", view_component_paths: ["app/components"]}
-      assert_equal @config.preview_controller, "ViewComponentsController"
-      assert_equal @config.preview_route, "/rails/view_components"
-      assert_equal @config.show_previews_source, false
+      assert_equal @config.previews.controller, "ViewComponentsController"
+      assert_equal @config.previews.route, "/rails/view_components"
+      assert_equal @config.previews.show_source, true
       assert_equal @config.instrumentation_enabled, false
-      assert_equal @config.show_previews, true
-      assert_equal @config.preview_paths, ["#{Rails.root}/test/components/previews"]
+      assert_equal @config.previews.show, true
+      assert_equal @config.previews.paths, ["#{Rails.root}/test/components/previews"]
     end
 
     def test_all_methods_are_documented

--- a/test/sandbox/test/config_test.rb
+++ b/test/sandbox/test/config_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 module ViewComponent
   class ConfigTest < TestCase
     def setup
-      @config = ViewComponent::Config.new
+      @config = ViewComponent::ApplicationConfig.new
     end
 
     def test_defaults_are_correct
@@ -39,9 +39,9 @@ module ViewComponent
       Rake::Task["yard"].execute
       configuration_methods_to_document = YARD::RegistryStore.new.tap do |store|
         store.load!(".yardoc")
-      end.get("ViewComponent::Config").meths.select(&:reader?).reject { |meth| meth.name == :config }
-      default_options = ViewComponent::Config.defaults.keys
-      accessors = ViewComponent::Config.instance_methods(false).reject do |method_name|
+      end.get("ViewComponent::ApplicationConfig").meths.select(&:reader?).reject { |meth| meth.name == :config }
+      default_options = ViewComponent::ApplicationConfig.defaults.keys
+      accessors = ViewComponent::ApplicationConfig.instance_methods(false).reject do |method_name|
         method_name.to_s.end_with?("=") || method_name == :method_missing
       end
       options_defined_on_instance = Set[*default_options, *accessors]

--- a/test/sandbox/test/config_test.rb
+++ b/test/sandbox/test/config_test.rb
@@ -9,11 +9,12 @@ module ViewComponent
     end
 
     def test_defaults_are_correct
-      assert_equal @config.generate, {preview_path: "", view_component_paths: ["app/components"]}
+      assert_equal @config.generate, {preview_path: "", view_component_paths: ["app/components"], use_component_path_for_rspec_tests: false}
       assert_equal @config.previews.controller, "ViewComponentsController"
       assert_equal @config.previews.route, "/rails/view_components"
       assert_equal @config.previews.show_source, true
       assert_equal @config.instrumentation_enabled, false
+      assert_equal @config.capture_compatibility_patch_enabled, false
       assert_equal @config.previews.show, true
       assert_equal @config.previews.paths, ["#{Rails.root}/test/components/previews"]
     end

--- a/test/sandbox/test/instrumentation_test.rb
+++ b/test/sandbox/test/instrumentation_test.rb
@@ -20,13 +20,15 @@ class InstrumentationTest < ViewComponent::TestCase
   end
 
   def test_instrumentation_with_deprecated_name
-    events = []
-    ActiveSupport::Notifications.subscribe("!render.view_component") do |*args|
-      events << ActiveSupport::Notifications::Event.new(*args)
-    end
-    render_inline(InstrumentationComponent.new)
+    with_config_option(:use_deprecated_instrumentation_name, true) do
+      events = []
+      ActiveSupport::Notifications.subscribe("!render.view_component") do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+      render_inline(InstrumentationComponent.new)
 
-    assert_equal(events.size, 1)
-    assert_equal("!render.view_component", events[0].name)
+      assert_equal(events.size, 1)
+      assert_equal("!render.view_component", events[0].name)
+    end
   end
 end

--- a/test/sandbox/test/instrumentation_test.rb
+++ b/test/sandbox/test/instrumentation_test.rb
@@ -4,31 +4,16 @@ require "test_helper"
 
 class InstrumentationTest < ViewComponent::TestCase
   def test_instrumentation
-    with_config_option(:use_deprecated_instrumentation_name, false) do
-      events = []
-      ActiveSupport::Notifications.subscribe("render.view_component") do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-      render_inline(InstrumentationComponent.new)
-
-      assert_selector("div", text: "hello,world!")
-      assert_equal(events.size, 1)
-      assert_equal("render.view_component", events[0].name)
-      assert_equal(events[0].payload[:name], "InstrumentationComponent")
-      assert_match("app/components/instrumentation_component.rb", events[0].payload[:identifier])
+    events = []
+    ActiveSupport::Notifications.subscribe("render.view_component") do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
     end
-  end
+    render_inline(InstrumentationComponent.new)
 
-  def test_instrumentation_with_deprecated_name
-    with_config_option(:use_deprecated_instrumentation_name, true) do
-      events = []
-      ActiveSupport::Notifications.subscribe("!render.view_component") do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-      render_inline(InstrumentationComponent.new)
-
-      assert_equal(events.size, 1)
-      assert_equal("!render.view_component", events[0].name)
-    end
+    assert_selector("div", text: "hello,world!")
+    assert_equal(events.size, 1)
+    assert_equal("render.view_component", events[0].name)
+    assert_equal(events[0].payload[:name], "InstrumentationComponent")
+    assert_match("app/components/instrumentation_component.rb", events[0].payload[:identifier])
   end
 end

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -539,7 +539,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       expected_response_body = <<~TURBOSTREAM
         <turbo-stream action="update" target="area1"><template><span>Hello, world!</span></template></turbo-stream>
       TURBOSTREAM
-      if ViewComponent::Base.config.capture_compatibility_patch_enabled
+      if Rails.application.config.view_component.capture_compatibility_patch_enabled
         assert_equal expected_response_body, response.body
       else
         assert_not_equal expected_response_body, response.body
@@ -668,25 +668,6 @@ class IntegrationTest < ActionDispatch::IntegrationTest
 
     ActionController::Base.perform_caching = false
     Rails.cache.clear
-  end
-
-  def test_config_options_shared_between_base_and_engine
-    config_entrypoints = [Rails.application.config.view_component, ViewComponent::Base.config]
-    2.times do
-      config_entrypoints.first.yield_self do |config|
-        {
-          generate: config.generate.dup.tap { |c| c.sidecar = true },
-          preview_controller: "SomeOtherController",
-          preview_route: "/some/other/route",
-          show_previews_source: true
-        }.each do |option, value|
-          with_config_option(option, value, config_entrypoint: config) do
-            assert_equal(config.public_send(option), config_entrypoints.second.public_send(option))
-          end
-        end
-      end
-      config_entrypoints.rotate!
-    end
   end
 
   def test_path_traversal_raises_error

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,8 +16,8 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 105, "3.4.1" => 105, "3.3.7" => 109} :
-      {"3.3.7" => 108, "3.3.0" => 121, "3.2.7" => 106, "3.1.6" => 119, "3.0.7" => 128}
+      {"3.5.0" => 107, "3.4.1" => 107, "3.3.7" => 111} :
+      {"3.3.7" => 110, "3.3.0" => 123, "3.2.7" => 108, "3.1.6" => 121, "3.0.7" => 130}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,8 +16,8 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 104, "3.4.1" => 104, "3.3.7" => 108} :
-      {"3.3.7" => 107, "3.3.0" => 120, "3.2.7" => 105, "3.1.6" => 118, "3.0.7" => 127}
+      {"3.5.0" => 105, "3.4.1" => 105, "3.3.7" => 109} :
+      {"3.3.7" => 108, "3.3.0" => 121, "3.2.7" => 106, "3.1.6" => 119, "3.0.7" => 128}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,35 +68,39 @@ end
 # @yield Test code to run
 # @return [void]
 def with_preview_paths(new_value, &block)
-  with_config_option(:preview_paths, new_value, &block)
+  old_value = Rails.application.config.view_component.previews.paths
+  Rails.application.config.view_component.previews.paths = new_value
+  yield
+ensure
+  Rails.application.config.view_component.previews.paths = old_value
 end
 
 def with_preview_route(new_value)
-  old_value = Rails.application.config.view_component.preview_route
-  Rails.application.config.view_component.preview_route = new_value
+  old_value = Rails.application.config.view_component.previews.route
+  Rails.application.config.view_component.previews.route = new_value
   app.reloader.reload!
   yield
 ensure
-  Rails.application.config.view_component.preview_route = old_value
+  Rails.application.config.view_component.previews.route = old_value
   app.reloader.reload!
 end
 
 def with_preview_controller(new_value)
-  old_value = Rails.application.config.view_component.preview_controller
-  Rails.application.config.view_component.preview_controller = new_value
+  old_value = Rails.application.config.view_component.previews.controller
+  Rails.application.config.view_component.previews.controller = new_value
   app.reloader.reload!
   yield
 ensure
-  Rails.application.config.view_component.preview_controller = old_value
+  Rails.application.config.view_component.previews.controller = old_value
   app.reloader.reload!
 end
 
 def with_custom_component_path(new_value, &block)
-  with_config_option(:view_component_path, new_value, &block)
+  with_generate_option(:view_component_paths, [new_value], &block)
 end
 
 def with_custom_component_parent_class(new_value, &block)
-  with_config_option(:component_parent_class, new_value, &block)
+  with_generate_option(:component_parent_class, new_value, &block)
 end
 
 def with_application_component_class
@@ -139,6 +143,16 @@ ensure
   ViewComponent::CompileCache.cache = old_cache
 end
 
+def with_default_preview_layout(new_value, &block)
+  old_value = Rails.application.config.view_component.previews.default_layout
+  Rails.application.config.view_component.previews.default_layout = new_value
+  app.reloader.reload!
+  yield
+ensure
+  Rails.application.config.view_component.previews.default_layout = old_value
+  app.reloader.reload!
+end
+
 def without_template_annotations(&block)
   if ActionView::Base.respond_to?(:annotate_rendered_view_with_filenames)
     old_value = ActionView::Base.annotate_rendered_view_with_filenames
@@ -163,10 +177,6 @@ def modify_file(file, content)
   ensure
     File.open(filename, "wb+") { |f| f.write(old_content) }
   end
-end
-
-def with_default_preview_layout(layout, &block)
-  with_config_option(:default_preview_layout, layout, &block)
 end
 
 def with_compiler_development_mode(mode)


### PR DESCRIPTION
This PR aims to rework configuration such that individual component instances can be configured differently, with the end goal of ensuring that applications and engines can define their configuration separately. We're taking a scorched earth approach here, though it will be important to ensure that the migration path from v3 is straightforward.

NOTE: This branch is a WIP – I'll squish things down before it's ready to share.

#1945 sheds some good light on the kinds of problems we're looking to solve here. Big thanks to @Slotos for their really helpful comment on that issue. 