### PR TITLE
BREAKING: Use Nokogiri::HTML5 instead of Nokogiri::HTML4

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ nav_order: 5
 
 ## 4.0.0
 
+* BREAKING: Use `Nokogiri::HTML5` instead of `Nokogiri::HTML4` for test helpers.
+
+    *Noah Silvera*, *Joel Hawksley*
+
 * BREAKING: Move generators to a ViewComponent namespace.
 
   Before, ViewComponent generators pollute the generator namespace with a bunch of top level items, and claim the generic "component" name.

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -46,12 +46,12 @@ module ViewComponent
     # ```
     #
     # @param component [ViewComponent::Base, ViewComponent::Collection] The instance of the component to be rendered.
-    # @return [Nokogiri::HTML]
+    # @return [Nokogiri::HTML5]
     def render_inline(component, **args, &block)
       @page = nil
       @rendered_content = vc_test_controller.view_context.render(component, args, &block)
 
-      Nokogiri::HTML.fragment(@rendered_content)
+      Nokogiri::HTML5.fragment(@rendered_content)
     end
 
     # `JSON.parse`-d component output.
@@ -82,7 +82,7 @@ module ViewComponent
     # @param name [String] The name of the preview to be rendered.
     # @param from [ViewComponent::Preview] The class of the preview to be rendered.
     # @param params [Hash] Parameters to be passed to the preview.
-    # @return [Nokogiri::HTML]
+    # @return [Nokogiri::HTML5]
     def render_preview(name, from: __vc_test_helpers_preview_class, params: {})
       previews_controller = __vc_test_helpers_build_controller(Rails.application.config.view_component.preview_controller.constantize)
 
@@ -98,7 +98,7 @@ module ViewComponent
 
       @rendered_content = result
 
-      Nokogiri::HTML.fragment(@rendered_content)
+      Nokogiri::HTML5.fragment(@rendered_content)
     end
 
     # Execute the given block in the view context (using `instance_exec`).
@@ -115,7 +115,7 @@ module ViewComponent
     def render_in_view_context(*args, &block)
       @page = nil
       @rendered_content = vc_test_controller.view_context.instance_exec(*args, &block)
-      Nokogiri::HTML.fragment(@rendered_content)
+      Nokogiri::HTML5.fragment(@rendered_content)
     end
     ruby2_keywords(:render_in_view_context) if respond_to?(:ruby2_keywords, true)
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,7 +16,7 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 104, "3.4.2" => 75, "3.3.7" => 76} :
+      {"3.5.0" => 73, "3.4.2" => 75, "3.3.7" => 76} :
       {"3.3.7" => 75, "3.2.7" => 74}
 
     assert_allocations(**allocations) do

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,8 +16,8 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 104, "3.4.1" => 104, "3.3.7" => 108} :
-      {"3.3.7" => 107, "3.3.0" => 120, "3.2.7" => 105, "3.1.6" => 118, "3.0.7" => 127}
+      {"3.5.0" => 104, "3.4.2" => 75, "3.3.7" => 76} :
+      {"3.3.7" => 75, "3.2.7" => 74}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)


### PR DESCRIPTION
### What are you trying to accomplish?

Update our test helpers to use newer Nokogiri HTML parser. Related: https://github.com/ViewComponent/view_component/pull/2209
 
### What approach did you choose and why?

I opted to update the class here directly for v4 instead of adding a configuration option, as I don't think we need to allow both cases. I also want to avoid adding unnecessary configuration.