### PR TITLE
Remove unnecessary usage of ruby2_keywords.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-ruby_version: 2.5
+ruby_version: 3.2
 require:
   - standard
   - "rubocop-md"

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,3 +1,3 @@
-ruby_version: 2.5
+ruby_version: 3.2
 ignore:
   - 'docs/CHANGELOG.md' # Rubocop doesn't like our indenting of code examples

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,10 @@ nav_order: 5
 
     *Stephen Nelson*
 
+* Remove unnecessary usage of `ruby2_keywords`.
+
+    *Joel Hawksley*
+
 * Remove unnecessary `respond_to` checks.
 
     *Tiago Menegaz*, *Joel Hawksley*

--- a/lib/view_component/inline_template.rb
+++ b/lib/view_component/inline_template.rb
@@ -32,7 +32,6 @@ module ViewComponent # :nodoc:
 
         @__vc_inline_template_defined = true
       end
-      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
       def respond_to_missing?(method, include_all = false)
         method.end_with?("_template") || super

--- a/lib/view_component/slot.rb
+++ b/lib/view_component/slot.rb
@@ -101,8 +101,8 @@ module ViewComponent
     #   end
     # end
     #
-    def method_missing(symbol, **args, &block)
-      @__vc_component_instance.public_send(symbol, **args, &block)
+    def method_missing(symbol, *args, **kwargs, &block)
+      @__vc_component_instance.public_send(symbol, *args, **kwargs, &block)
     end
 
     def html_safe?

--- a/lib/view_component/slot.rb
+++ b/lib/view_component/slot.rb
@@ -101,10 +101,9 @@ module ViewComponent
     #   end
     # end
     #
-    def method_missing(symbol, *args, &block)
-      @__vc_component_instance.public_send(symbol, *args, &block)
+    def method_missing(symbol, **args, &block)
+      @__vc_component_instance.public_send(symbol, **args, &block)
     end
-    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
     def html_safe?
       # :nocov:

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -371,7 +371,7 @@ module ViewComponent
       end
     end
 
-    def set_slot(slot_name, slot_definition = nil, *args, &block)
+    def set_slot(slot_name, slot_definition = nil, *args, **kwargs, &block)
       slot_definition ||= self.class.registered_slots[slot_name]
       slot = Slot.new(self)
 
@@ -388,11 +388,11 @@ module ViewComponent
 
       # If class
       if slot_definition[:renderable]
-        slot.__vc_component_instance = slot_definition[:renderable].new(*args)
+        slot.__vc_component_instance = slot_definition[:renderable].new(*args, **kwargs)
       # If class name as a string
       elsif slot_definition[:renderable_class_name]
         slot.__vc_component_instance =
-          self.class.const_get(slot_definition[:renderable_class_name]).new(*args)
+          self.class.const_get(slot_definition[:renderable_class_name]).new(*args, **kwargs)
       # If passed a lambda
       elsif slot_definition[:renderable_function]
         # Use `bind(self)` to ensure lambda is executed in the context of the
@@ -401,11 +401,11 @@ module ViewComponent
         renderable_function = slot_definition[:renderable_function].bind(self)
         renderable_value =
           if block
-            renderable_function.call(*args) do |*rargs|
+            renderable_function.call(*args, **kwargs) do |*rargs|
               view_context.capture(*rargs, &block)
             end
           else
-            renderable_function.call(*args)
+            renderable_function.call(*args, **kwargs)
           end
 
         # Function calls can return components, so if it's a component handle it specially
@@ -427,9 +427,8 @@ module ViewComponent
 
       slot
     end
-    ruby2_keywords(:set_slot) if respond_to?(:ruby2_keywords, true)
 
-    def set_polymorphic_slot(slot_name, poly_type = nil, ...)
+    def set_polymorphic_slot(slot_name, poly_type = nil, *args, **kwargs, &block)
       slot_definition = self.class.registered_slots[slot_name]
 
       if !slot_definition[:collection] && (defined?(@__vc_set_slots) && @__vc_set_slots[slot_name])
@@ -438,7 +437,7 @@ module ViewComponent
 
       poly_def = slot_definition[:renderable_hash][poly_type]
 
-      set_slot(slot_name, poly_def, ...)
+      set_slot(slot_name, poly_def, *args, **kwargs, &block)
     end
   end
 end

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -84,10 +84,9 @@ module ViewComponent
 
           setter_method_name = :"with_#{slot_name}"
 
-          define_method setter_method_name do |*args, &block|
-            set_slot(slot_name, nil, *args, &block)
+          define_method setter_method_name do |*args, **kwargs, &block|
+            set_slot(slot_name, nil, *args, **kwargs, &block)
           end
-          ruby2_keywords(setter_method_name) if respond_to?(:ruby2_keywords, true)
 
           self::GeneratedSlotMethods.define_method slot_name do
             get_slot(slot_name)
@@ -155,10 +154,9 @@ module ViewComponent
 
           setter_method_name = :"with_#{singular_name}"
 
-          define_method setter_method_name do |*args, &block|
-            set_slot(slot_name, nil, *args, &block)
+          define_method setter_method_name do |*args, **kwargs, &block|
+            set_slot(slot_name, nil, *args, **kwargs, &block)
           end
-          ruby2_keywords(setter_method_name) if respond_to?(:ruby2_keywords, true)
 
           define_method :"with_#{singular_name}_content" do |content|
             send(setter_method_name) { content.to_s }

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -250,10 +250,9 @@ module ViewComponent
             raise AlreadyDefinedPolymorphicSlotSetterError.new(setter_method_name, poly_slot_name)
           end
 
-          define_method(setter_method_name) do |*args, &block|
-            set_polymorphic_slot(slot_name, poly_type, *args, &block)
+          define_method(setter_method_name) do |*args, **kwargs, &block|
+            set_polymorphic_slot(slot_name, poly_type, *args, **kwargs, &block)
           end
-          ruby2_keywords(setter_method_name) if respond_to?(:ruby2_keywords, true)
 
           define_method :"with_#{poly_slot_name}_content" do |content|
             send(setter_method_name) { content.to_s }

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -429,7 +429,7 @@ module ViewComponent
     end
     ruby2_keywords(:set_slot) if respond_to?(:ruby2_keywords, true)
 
-    def set_polymorphic_slot(slot_name, poly_type = nil, *args, &block)
+    def set_polymorphic_slot(slot_name, poly_type = nil, ...)
       slot_definition = self.class.registered_slots[slot_name]
 
       if !slot_definition[:collection] && (defined?(@__vc_set_slots) && @__vc_set_slots[slot_name])
@@ -438,8 +438,7 @@ module ViewComponent
 
       poly_def = slot_definition[:renderable_hash][poly_type]
 
-      set_slot(slot_name, poly_def, *args, &block)
+      set_slot(slot_name, poly_def, ...)
     end
-    ruby2_keywords(:set_polymorphic_slot) if respond_to?(:ruby2_keywords, true)
   end
 end

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -112,12 +112,11 @@ module ViewComponent
     #
     # assert_text("Hello, World!")
     # ```
-    def render_in_view_context(*args, &block)
+    def render_in_view_context(...)
       @page = nil
-      @rendered_content = vc_test_controller.view_context.instance_exec(*args, &block)
+      @rendered_content = vc_test_controller.view_context.instance_exec(...)
       Nokogiri::HTML5.fragment(@rendered_content)
     end
-    ruby2_keywords(:render_in_view_context) if respond_to?(:ruby2_keywords, true)
 
     # Set the Action Pack request variant for the given block:
     #

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "erb"
-require "set"
 require "i18n"
 require "active_support/concern"
 

--- a/lib/view_component/use_helpers.rb
+++ b/lib/view_component/use_helpers.rb
@@ -12,13 +12,12 @@ module ViewComponent::UseHelpers
       helper_method_name = full_helper_method_name(helper_method, prefix: prefix, source: from)
 
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-        def #{helper_method_name}(*args, &block)
+        def #{helper_method_name}(...)
           raise HelpersCalledBeforeRenderError if view_context.nil?
 
           #{define_helper(helper_method: helper_method, source: from)}
         end
       RUBY
-      ruby2_keywords(helper_method_name) if respond_to?(:ruby2_keywords, true)
     end
 
     private
@@ -34,9 +33,9 @@ module ViewComponent::UseHelpers
     end
 
     def define_helper(helper_method:, source:)
-      return "__vc_original_view_context.#{helper_method}(*args, &block)" unless source.present?
+      return "__vc_original_view_context.#{helper_method}(...)" unless source.present?
 
-      "#{source}.instance_method(:#{helper_method}).bind(self).call(*args, &block)"
+      "#{source}.instance_method(:#{helper_method}).bind(self).call(...)"
     end
   end
 end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -17,7 +17,7 @@ class RenderingTest < ViewComponent::TestCase
 
     allocations = (Rails.version.to_f >= 8.0) ?
       {"3.5.0" => 73, "3.4.2" => 75, "3.3.7" => 76} :
-      {"3.3.7" => 75, "3.2.7" => 76}
+      {"3.3.7" => 75, "3.2.7" => 74}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -17,7 +17,7 @@ class RenderingTest < ViewComponent::TestCase
 
     allocations = (Rails.version.to_f >= 8.0) ?
       {"3.5.0" => 73, "3.4.2" => 75, "3.3.7" => 76} :
-      {"3.3.7" => 75, "3.2.7" => 74}
+      {"3.3.7" => 75, "3.2.7" => 76}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)


### PR DESCRIPTION
### What are you trying to accomplish?

Remove unnecessary usage of `ruby2_keywords`.

### What approach did you choose and why?

I removed the usage wholesale as we do not support Ruby v2 in ViewComponent v4.