### PR TITLE
Delegate config to parent modules (no-op)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 5
 
 ## main
 
+* Add unused mechanism for inheriting config from parent modules to enable future engine-local configuration.
+
+    *Simon Fish*
+
 * Improve handling of malformed component edge case when mocking components in tests.
 
     *Martin Meyerhoff*, *Joel Hawksley*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -25,6 +25,10 @@ module ViewComponent
       #
       # @return [ActiveSupport::OrderedOptions]
       def config
+        module_parents.each do |m|
+          config = m.try(:config).try(:view_component)
+          return config if config
+        end
         ViewComponent::Config.current
       end
     end

--- a/lib/view_component/configurable.rb
+++ b/lib/view_component/configurable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Configurable
+    extend ActiveSupport::Concern
+
+    included do
+      next if respond_to?(:config) && config.respond_to?(:view_component) && config.respond_to_missing?(:test_controller)
+
+      include ActiveSupport::Configurable
+
+      configure do |config|
+        config.view_component ||= ActiveSupport::InheritableOptions.new
+      end
+    end
+  end
+end

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -146,4 +146,30 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     MESSAGE
     assert !exception_message_regex.match?(exception.message)
   end
+
+  module TestModuleWithoutConfig
+    class SomeComponent < ViewComponent::Base
+
+    end
+  end
+
+  # Config defined on top-level module as opposed to engine.
+  module TestModuleWithConfig
+    include ActiveSupport::Configurable
+
+    configure do |config|
+      # To get this green.
+      config.view_component = ActiveSupport::InheritableOptions.new
+      config.view_component.test_controller = "AnotherController"
+    end
+
+    class SomeComponent < ViewComponent::Base
+    end
+  end
+
+  def test_uses_module_configuration
+    # We override this ourselves in test/sandbox/config/environments/test.rb.
+    assert_equal "IntegrationExamplesController", TestModuleWithoutConfig::SomeComponent.test_controller
+    assert_equal "AnotherController", TestModuleWithConfig::SomeComponent.test_controller
+  end
 end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,8 +16,8 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 115, "3.4.2" => 117, "3.3.7" => 129} :
-      {"3.3.7" => 120, "3.3.0" => 132, "3.2.7" => 118, "3.1.6" => 118, "3.0.7" => 127}
+      {"3.5.0" => 123, "3.4.2" => 125, "3.3.7" => 137} :
+      {"3.3.7" => 128, "3.3.0" => 140, "3.2.7" => 126, "3.1.6" => 126, "3.0.7" => 135}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)


### PR DESCRIPTION
Adds a mechanism for inheriting config from a parent module. Since `Base` is generally used when referring to "global" config options, this doesn't do anything right now beyond exposing the ability to configure parent modules.

Modules can be configured by requiring and including `ViewComponent::Configurable`, which will expose a `config` accessor with a `view_component` configuration on the module. These will not interfere with existing configuration that might be granted to, e.g., a `Rails::Engine` by default.

This would give us a starting point to begin migrating options into engine-local config.

---

The separation between:
- module and/or Rails app-local config (this PR)
- exclusively Rails app-local config (`lib/view_component/engine.rb`)
- component-local config (#2230)

isn't perfect right now, but this PR and #2230 put us on the road to this.

It should only be possible to set options in each area as appropriate. Particularly with this PR, we should be concerned with making sure that module-local and exclusively Rails app-local config don't merge.

Because `ViewComponent::Base.config` is named as it is right now, the difference between component-local config (#2230) and module-local config isn't super clear, but we can rename parts of this interface in v4.