### PR TITLE
Add layout attribute  POC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,11 @@ jobs:
           - ruby_version: "head"
             rails_version: "main"
             mode: "capture_patch_enabled"
+          - ruby_version: "head"
+            rails_version: "main"
+            mode: "capture_patch_enabled"
+            layout_patch: "true"
+
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails_version }}.gemfile
     steps:
@@ -92,6 +97,7 @@ jobs:
         RAILS_VERSION: ${{ matrix.rails_version }}
         RUBY_VERSION: ${{ matrix.ruby_version }}
         CAPTURE_PATCH_ENABLED: ${{ matrix.mode == 'capture_patch_enabled' && 'true' || 'false' }}
+        RENDER_LAYOUT_PATCH_ENABLED: ${{ matrix.layout_patch == 'true' || 'false' }}
     - name: Upload coverage results
       uses: actions/upload-artifact@v4.4.0
       if: always()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
----
+lear ---
 layout: default
 title: Changelog
 nav_order: 5

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -19,6 +19,7 @@ module ViewComponent
           instrumentation_enabled: false,
           use_deprecated_instrumentation_name: true,
           render_monkey_patch_enabled: true,
+          render_layout_monkey_patch_enabled: false,
           view_component_path: "app/components",
           component_parent_class: nil,
           show_previews: Rails.env.development? || Rails.env.test?,
@@ -127,6 +128,12 @@ module ViewComponent
       # Defaults to `true`.
 
       # @!attribute render_monkey_patch_enabled
+      # @return [Boolean] Whether the #render method should be monkey patched.
+      # If this is disabled, use `#render_component` or
+      # `#render_component_to_string` instead.
+      # Defaults to `true`.
+
+      # @!attribute render_layout_monkey_patch_enabled
       # @return [Boolean] Whether the #render method should be monkey patched.
       # If this is disabled, use `#render_component` or
       # `#render_component_to_string` instead.

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -111,6 +111,16 @@ module ViewComponent
       # :nocov:
     end
 
+    initializer "view_component.monkey_patch_render_collection" do |app|
+      next if Rails.version.to_f <= 6.1
+
+      ActiveSupport.on_load(:action_view) do
+        require "view_component/render_layout_monkey_patch.rb"
+        ActionView::Base.prepend ViewComponent::RenderLayoutMonkeyPatch
+      end
+      # :nocov:
+    end
+
     initializer "view_component.include_render_component" do |_app|
       next if Rails.version.to_f >= 6.1
 

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -34,6 +34,7 @@ module ViewComponent
       end
       options.instrumentation_enabled = false if options.instrumentation_enabled.nil?
       options.render_monkey_patch_enabled = true if options.render_monkey_patch_enabled.nil?
+      options.render_layout_monkey_patch_enabled = false if options.render_layout_monkey_patch_enabled.nil?
       options.show_previews = (Rails.env.development? || Rails.env.test?) if options.show_previews.nil?
 
       if options.show_previews
@@ -112,7 +113,7 @@ module ViewComponent
     end
 
     initializer "view_component.monkey_patch_render_layout" do |app|
-      next if Rails.version.to_f <= 6.1
+      next if Rails.version.to_f <= 6.1 || !app.config.view_component.render_layout_monkey_patch_enabled
 
       ActiveSupport.on_load(:action_view) do
         require "view_component/render_layout_monkey_patch.rb"

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -111,7 +111,7 @@ module ViewComponent
       # :nocov:
     end
 
-    initializer "view_component.monkey_patch_render_collection" do |app|
+    initializer "view_component.monkey_patch_render_layout" do |app|
       next if Rails.version.to_f <= 6.1
 
       ActiveSupport.on_load(:action_view) do

--- a/lib/view_component/render_layout_monkey_patch.rb
+++ b/lib/view_component/render_layout_monkey_patch.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module RenderLayoutMonkeyPatch # :nodoc:
+    def render(options = {}, locals = {}, &block)
+      if locals[:layout].blank? || locals[:layout].is_a?(Symbol) || locals[:layout].is_a?(String)
+        super(options, locals, &block)
+      else
+        render(locals[:layout]) do
+          options.render_in(self, &block)
+        end
+      end
+    end
+  end
+end
+
+
+
+
+

--- a/test/sandbox/app/components/layout_component.html.erb
+++ b/test/sandbox/app/components/layout_component.html.erb
@@ -1,0 +1,3 @@
+<div class="layout__container">
+  <%= content %>
+</div>

--- a/test/sandbox/app/components/layout_component.rb
+++ b/test/sandbox/app/components/layout_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class LayoutComponent < ViewComponent::Base
+
+end

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -34,6 +34,7 @@ Sandbox::Application.configure do
 
   config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"
   config.view_component.render_monkey_patch_enabled = true
+  config.view_component.render_layout_monkey_patch_enabled = ENV["RENDER_LAYOUT_PATCH_ENABLED"] == "true"
   config.view_component.show_previews_source = true
   config.view_component.test_controller = "IntegrationExamplesController"
   config.view_component.capture_compatibility_patch_enabled = ENV["CAPTURE_PATCH_ENABLED"] == "true"

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1257,9 +1257,11 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_layout_attribute
-    render_inline(MyComponent.new, layout: LayoutComponent.new)
+    if Rails.version.to_f >= 6.1 && ViewComponent::Base.config.render_layout_monkey_patch_enabled
+      render_inline(MyComponent.new, layout: LayoutComponent.new)
 
-    assert_selector("div", text: "hello,world!")
-    assert_selector(".layout__container")
+      assert_selector("div", text: "hello,world!")
+      assert_selector(".layout__container")
+    end
   end
 end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1255,4 +1255,11 @@ class RenderingTest < ViewComponent::TestCase
       render_inline(mock_component.new)
     end
   end
+
+  def test_layout_attribute
+    render_inline(MyComponent.new, layout: LayoutComponent.new)
+
+    assert_selector("div", text: "hello,world!")
+    assert_selector(".layout__container")
+  end
 end


### PR DESCRIPTION
closses #2173 
### What are you trying to accomplish?
As per #2173 this adds a layout attribute, the main difference is that this monkey patches rails's `render_in`  instead of making use of an upstream addition, this is supposed to act as a POC to strat the discusion about how the api looks like and top start next steps to get this done 


### Anything you want to highlight for special attention from reviewers?
This is not to  be merged in its current state but to start the discusion for the api's implementation in view component and rails and how to achieve this
