### PR TITLE
[v4] Remove unnecessary #format definitions, which returned nil

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,10 @@ nav_order: 5
 
     *Stephen Nelson*
 
+* Remove unnecessary `#format` methods that returned `nil`.
+
+    *Joel Hawksley*
+
 * Clean up project dependencies, relaxing versions of development gems.
 
     *Joel Hawksley*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -273,12 +273,6 @@ module ViewComponent
       []
     end
 
-    # Rails expects us to define `format` on all renderables,
-    # but we do not know the `format` of a ViewComponent until runtime.
-    def format
-      nil
-    end
-
     # The current request. Use sparingly as doing so introduces coupling that
     # inhibits encapsulation & reuse, often making testing difficult.
     #

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -40,12 +40,6 @@ module ViewComponent
       components.each(&block)
     end
 
-    # Rails expects us to define `format` on all renderables,
-    # but we do not know the `format` of a ViewComponent until runtime.
-    def format
-      nil
-    end
-
     private
 
     def initialize(component, object, spacer_component, **options)


### PR DESCRIPTION
### What are you trying to accomplish?

This PR looks to close https://github.com/ViewComponent/view_component/issues/1973 by removing our definition of `#format` methods, as:

1) @seanpdoyle [noted](https://github.com/ViewComponent/view_component/issues/1973#issuecomment-1889928719) they are optional
2) We were returning `nil` anyways. 

We can always revisit adding them back if needed, which I don't think would be a breaking change.