### PR TITLE
Remove unnecessary call to `view_renderer`

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -88,9 +88,6 @@ module ViewComponent
 
       @lookup_context ||= view_context.lookup_context
 
-      # required for path helpers in older Rails versions
-      @view_renderer ||= view_context.view_renderer
-
       # For content_for
       @view_flow ||= view_context.view_flow
 


### PR DESCRIPTION
### What are you trying to accomplish?

As noted in the code comment, this is no longer needed.