### PR TITLE
Cleanup references to old Rails versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -74,7 +74,7 @@ jobs:
     - uses: actions/cache@v4
       with:
         path: vendor/bundle
-        key: gems-build-rails-7.1-ruby-3.2-${{ hashFiles('**/Gemfile.lock') }}
+        key: gems-build-rails-8-ruby-3.2-${{ hashFiles('**/Gemfile.lock') }}
     - name: Lint with Rubocop and ERB Lint
       run: |
         bundle config path vendor/bundle
@@ -82,4 +82,4 @@ jobs:
         bundle exec standardrb -r "rubocop-md"
         bundle exec erblint **/*.html.erb
       env:
-        RAILS_VERSION: '~> 7.1.0'
+        RAILS_VERSION: '~> 8'

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,7 +64,7 @@ bundle exec m test/view_component/YOUR_COMPONENT_test.rb:line_number
 Specify one of the supported versions listed in [Appraisals](https://github.com/viewcomponent/view_component/blob/main/Appraisals):
 
 ```command
-bundle exec appraisal rails-5.2 rake
+bundle exec appraisal rails-8.0 rake
 ```
 
 ## Documentation

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -92,7 +92,7 @@ def show
 end
 ```
 
-_Note: Content can't be passed to a component via a block in controllers. Instead, use `with_content`. In versions of Rails < 6.1, rendering a ViewComponent from a controller doesn't include the layout._
+_Note: Content can't be passed to a component via a block in controllers. Instead, use `with_content`._
 
 When using turbo frames with [turbo-rails](https://github.com/hotwired/turbo-rails), set `content_type` as `text/html`:
 

--- a/lib/generators/view_component/component/USAGE
+++ b/lib/generators/view_component/component/USAGE
@@ -5,7 +5,7 @@ Description:
 
 Example:
 ========
-    bin/rails generate component Profile name age
+    bin/rails generate view_component Profile name age
 
     creates a Profile component and test:
         Component:    app/components/profile_component.rb

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -50,8 +50,7 @@ module ViewComponent
     delegate :content_security_policy_nonce, to: :helpers
 
     # Config option that strips trailing whitespace in templates before compiling them.
-    class_attribute :__vc_strip_trailing_whitespace, instance_accessor: false, instance_predicate: false
-    self.__vc_strip_trailing_whitespace = false # class_attribute:default doesn't work until Rails 5.2
+    class_attribute :__vc_strip_trailing_whitespace, instance_accessor: false, instance_predicate: false, default: false
 
     attr_accessor :__vc_original_view_context
 

--- a/test/sandbox/config/application.rb
+++ b/test/sandbox/config/application.rb
@@ -9,7 +9,6 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie" if Rails.version.to_f < 8.0
 require "propshaft" if Rails.version.to_f >= 8.0
-
 require "turbo-rails"
 
 # Track when different Rails frameworks get loaded.

--- a/test/sandbox/config/environment.rb
+++ b/test/sandbox/config/environment.rb
@@ -1,7 +1,4 @@
 # frozen_string_literal: true
 
-# Load the rails application
 require File.expand_path("../application", __FILE__)
-
-# Initialize the rails application
 Sandbox::Application.initialize!


### PR DESCRIPTION
This PR removes references to old Rails versions we no longer support.