### PR TITLE
remove TODO for slot name collisions

### DIFF
--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -333,7 +333,6 @@ module ViewComponent
 
       def raise_if_slot_registered(slot_name)
         if registered_slots.key?(slot_name)
-          # TODO remove? This breaks overriding slots when slots are inherited
           raise RedefinedSlotError.new(name, slot_name)
         end
       end


### PR DESCRIPTION
After giving this a deep read, I'm not convinced we should change this behavior. I'm removing the TODO.