### PR TITLE
[v4] Remove final nocov

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ nav_order: 5
 
 ## 4.0.0
 
+* BREAKING: Remove `use_deprecated_instrumentation_name` configuration option. Events will always use `render.view_component` name.
+
+    *Joel Hawksley*
+
 * BREAKING: Remove `preview_source` functionality. Consider using [Lookbook](https://lookbook.build/) instead.
 
     *Joel Hawksley*

--- a/docs/api.md
+++ b/docs/api.md
@@ -254,13 +254,6 @@ The controller used for testing components.
 Can also be configured on a per-test basis using `#with_controller_class`.
 Defaults to `ApplicationController`.
 
-### `.use_deprecated_instrumentation_name`
-
-Whether ActiveSupport Notifications use the private name `"!render.view_component"`
-or are made more publicly available via `"render.view_component"`.
-Will default to `false` in next major version.
-Defaults to `true`.
-
 ### `.view_component_path`
 
 The path in which components, their templates, and their sidecars should

--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -15,10 +15,7 @@ To enable ActiveSupport notifications, use the `instrumentation_enabled` option:
 # config/application.rb
 # Enable ActiveSupport notifications for all ViewComponents
 config.view_component.instrumentation_enabled = true
-config.view_component.use_deprecated_instrumentation_name = false
 ```
-
-Setting `use_deprecated_instrumentation_name` configures the event name. If `false` the name is `"render.view_component"`. If `true` (default) the deprecated `"!render.view_component"` will be used.
 
 Subscribe to the event:
 

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -16,7 +16,6 @@ module ViewComponent
           preview_controller: "ViewComponentsController",
           preview_route: "/rails/view_components",
           instrumentation_enabled: false,
-          use_deprecated_instrumentation_name: true,
           view_component_path: "app/components",
           component_parent_class: nil,
           show_previews: Rails.env.development? || Rails.env.test?,
@@ -111,13 +110,6 @@ module ViewComponent
       # @return [Boolean]
       # Whether ActiveSupport notifications are enabled.
       # Defaults to `false`.
-
-      # @!attribute use_deprecated_instrumentation_name
-      # @return [Boolean]
-      # Whether ActiveSupport Notifications use the private name `"!render.view_component"`
-      # or are made more publicly available via `"render.view_component"`.
-      # Will default to `false` in next major version.
-      # Defaults to `true`.
 
       # @!attribute view_component_path
       # @return [String]

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -46,7 +46,6 @@ module ViewComponent
     initializer "view_component.enable_instrumentation" do |app|
       ActiveSupport.on_load(:view_component) do
         if app.config.view_component.instrumentation_enabled.present?
-          # :nocov: Re-executing the below in tests duplicates initializers and causes order-dependent failures.
           ViewComponent::Base.prepend(ViewComponent::Instrumentation)
           if app.config.view_component.use_deprecated_instrumentation_name
             ViewComponent::Deprecation.deprecation_warning(
@@ -54,7 +53,6 @@ module ViewComponent
               "Use the new instrumentation key `render.view_component` instead. See https://viewcomponent.org/guide/instrumentation.html"
             )
           end
-          # :nocov:
         end
       end
     end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -46,7 +46,7 @@ module ViewComponent
     initializer "view_component.enable_instrumentation" do |app|
       ActiveSupport.on_load(:view_component) do
         if app.config.view_component.instrumentation_enabled.present?
-          ViewComponent::Base.include(ViewComponent::Instrumentation)
+          ViewComponent::Base.prepend(ViewComponent::Instrumentation)
         end
       end
     end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -47,12 +47,6 @@ module ViewComponent
       ActiveSupport.on_load(:view_component) do
         if app.config.view_component.instrumentation_enabled.present?
           ViewComponent::Base.prepend(ViewComponent::Instrumentation)
-          if app.config.view_component.use_deprecated_instrumentation_name
-            ViewComponent::Deprecation.deprecation_warning(
-              "!render.view_component",
-              "Use the new instrumentation key `render.view_component` instead. See https://viewcomponent.org/guide/instrumentation.html"
-            )
-          end
         end
       end
     end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -46,7 +46,7 @@ module ViewComponent
     initializer "view_component.enable_instrumentation" do |app|
       ActiveSupport.on_load(:view_component) do
         if app.config.view_component.instrumentation_enabled.present?
-          ViewComponent::Base.prepend(ViewComponent::Instrumentation)
+          ViewComponent::Base.include(ViewComponent::Instrumentation)
         end
       end
     end

--- a/lib/view_component/instrumentation.rb
+++ b/lib/view_component/instrumentation.rb
@@ -5,12 +5,12 @@ require "active_support/notifications"
 module ViewComponent # :nodoc:
   module Instrumentation
     def self.included(mod)
-      mod.prepend(self) unless ancestors.include?(ViewComponent::Instrumentation)
+      mod.prepend(self) unless self <= ViewComponent::Instrumentation
     end
 
     def render_in(view_context, &block)
       ActiveSupport::Notifications.instrument(
-        notification_name,
+        "render.view_component",
         {
           name: self.class.name,
           identifier: self.class.identifier
@@ -18,14 +18,6 @@ module ViewComponent # :nodoc:
       ) do
         super
       end
-    end
-
-    private
-
-    def notification_name
-      return "!render.view_component" if ViewComponent::Base.config.use_deprecated_instrumentation_name
-
-      "render.view_component"
     end
   end
 end

--- a/lib/view_component/instrumentation.rb
+++ b/lib/view_component/instrumentation.rb
@@ -9,6 +9,8 @@ module ViewComponent # :nodoc:
     end
 
     def render_in(view_context, &block)
+      return super if !Rails.application.config.view_component.instrumentation_enabled.present?
+
       ActiveSupport::Notifications.instrument(
         "render.view_component",
         {

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -16,7 +16,7 @@ Sandbox::Application.configure do
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs.  Don't rely on the data there!
 
-  config.cache_classes = false
+  config.cache_classes = true
 
   # Show full error reports and disable caching
   config.consider_all_requests_local = true

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -29,7 +29,7 @@ Sandbox::Application.configure do
   config.action_controller.allow_forgery_protection = false
 
   config.view_component.show_previews = true
-  config.view_component.instrumentation_enabled = false
+  config.view_component.instrumentation_enabled = true
   config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"
   config.view_component.test_controller = "IntegrationExamplesController"
   config.view_component.capture_compatibility_patch_enabled = ENV["CAPTURE_PATCH_ENABLED"] == "true"

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -29,7 +29,7 @@ Sandbox::Application.configure do
   config.action_controller.allow_forgery_protection = false
 
   config.view_component.show_previews = true
-  config.view_component.instrumentation_enabled = true
+  config.view_component.instrumentation_enabled = false
   config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"
   config.view_component.test_controller = "IntegrationExamplesController"
   config.view_component.capture_compatibility_patch_enabled = ENV["CAPTURE_PATCH_ENABLED"] == "true"

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -29,7 +29,7 @@ Sandbox::Application.configure do
   config.action_controller.allow_forgery_protection = false
 
   config.view_component.show_previews = true
-
+  config.view_component.instrumentation_enabled = true
   config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"
   config.view_component.test_controller = "IntegrationExamplesController"
   config.view_component.capture_compatibility_patch_enabled = ENV["CAPTURE_PATCH_ENABLED"] == "true"

--- a/test/sandbox/test/config_test.rb
+++ b/test/sandbox/test/config_test.rb
@@ -13,8 +13,6 @@ module ViewComponent
       assert_equal @config.preview_controller, "ViewComponentsController"
       assert_equal @config.preview_route, "/rails/view_components"
       assert_equal @config.instrumentation_enabled, false
-      assert_equal @config.use_deprecated_instrumentation_name, true
-      assert_equal @config.show_previews, true
       assert_equal @config.preview_paths, ["#{Rails.root}/test/components/previews"]
     end
 

--- a/test/sandbox/test/instrumentation_test.rb
+++ b/test/sandbox/test/instrumentation_test.rb
@@ -4,29 +4,16 @@ require "test_helper"
 
 class InstrumentationTest < ViewComponent::TestCase
   def test_instrumentation
-    with_config_option(:use_deprecated_instrumentation_name, false) do
-      events = []
-      ActiveSupport::Notifications.subscribe("render.view_component") do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-      render_inline(InstrumentationComponent.new)
-
-      assert_selector("div", text: "hello,world!")
-      assert_equal(events.size, 1)
-      assert_equal("render.view_component", events[0].name)
-      assert_equal(events[0].payload[:name], "InstrumentationComponent")
-      assert_match("app/components/instrumentation_component.rb", events[0].payload[:identifier])
-    end
-  end
-
-  def test_instrumentation_with_deprecated_name
     events = []
-    ActiveSupport::Notifications.subscribe("!render.view_component") do |*args|
+    ActiveSupport::Notifications.subscribe("render.view_component") do |*args|
       events << ActiveSupport::Notifications::Event.new(*args)
     end
     render_inline(InstrumentationComponent.new)
 
+    assert_selector("div", text: "hello,world!")
     assert_equal(events.size, 1)
-    assert_equal("!render.view_component", events[0].name)
+    assert_equal("render.view_component", events[0].name)
+    assert_equal(events[0].payload[:name], "InstrumentationComponent")
+    assert_match("app/components/instrumentation_component.rb", events[0].payload[:identifier])
   end
 end

--- a/test/sandbox/test/instrumentation_test.rb
+++ b/test/sandbox/test/instrumentation_test.rb
@@ -3,11 +3,12 @@
 require "test_helper"
 
 class InstrumentationTest < ViewComponent::TestCase
-  def test_instrumentation
+  def test_instrumentation_for_include
     events = []
     ActiveSupport::Notifications.subscribe("render.view_component") do |*args|
       events << ActiveSupport::Notifications::Event.new(*args)
     end
+
     render_inline(InstrumentationComponent.new)
 
     assert_selector("div", text: "hello,world!")
@@ -15,5 +16,19 @@ class InstrumentationTest < ViewComponent::TestCase
     assert_equal("render.view_component", events[0].name)
     assert_equal(events[0].payload[:name], "InstrumentationComponent")
     assert_match("app/components/instrumentation_component.rb", events[0].payload[:identifier])
+  end
+
+  def test_instrumentation_disabled
+    with_instrumentation_enabled_option(false) do
+      events = []
+      ActiveSupport::Notifications.subscribe("render.view_component") do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      render_inline(InstrumentationComponent.new)
+
+      assert_selector("div", text: "hello,world!")
+      assert_equal(events.size, 0)
+    end
   end
 end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,10 +16,18 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 77, "3.4.2" => 83, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 92}
+      {"3.5.0" => 77, "3.4.2" => 107, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 92}
 
     assert_allocations(**allocations) do
+      events = []
+
+      ActiveSupport::Notifications.subscribe("render.view_component") do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
       render_inline(MyComponent.new)
+
+      assert_equal(events.size, 1)
     end
 
     assert_selector("div", text: "hello,world!")

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,18 +16,10 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 77, "3.4.2" => 107, "3.3.7" => 84} : {"3.3.7" => 107, "3.2.8" => 109}
+      {"3.5.0" => 77, "3.4.2" => 83, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 92}
 
     assert_allocations(**allocations) do
-      events = []
-
-      ActiveSupport::Notifications.subscribe("render.view_component") do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-
       render_inline(MyComponent.new)
-
-      assert_equal(events.size, 1)
     end
 
     assert_selector("div", text: "hello,world!")

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,7 +16,7 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 77, "3.4.2" => 107, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 92}
+      {"3.5.0" => 77, "3.4.2" => 107, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 106}
 
     assert_allocations(**allocations) do
       events = []

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,7 +16,7 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 77, "3.4.2" => 83, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 82}
+      {"3.5.0" => 77, "3.4.2" => 83, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 92}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,7 +16,7 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 77, "3.4.2" => 83, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 92}
+      {"3.5.0" => 77, "3.4.2" => 83, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 82}
 
     assert_allocations(**allocations) do
       render_inline(MyComponent.new)

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,7 +16,7 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 77, "3.4.2" => 85, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 82}
+      {"3.5.0" => 79, "3.4.2" => 85, "3.3.7" => 86} : {"3.3.7" => 85, "3.2.8" => 84}
 
     with_instrumentation_enabled_option(false) do
       assert_allocations(**allocations) do

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,10 +16,12 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 77, "3.4.2" => 83, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 82}
+      {"3.5.0" => 77, "3.4.2" => 85, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 82}
 
-    assert_allocations(**allocations) do
-      render_inline(MyComponent.new)
+    with_instrumentation_enabled_option(false) do
+      assert_allocations(**allocations) do
+        render_inline(MyComponent.new)
+      end
     end
 
     assert_selector("div", text: "hello,world!")

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,7 +16,7 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 77, "3.4.2" => 107, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 109}
+      {"3.5.0" => 77, "3.4.2" => 107, "3.3.7" => 84} : {"3.3.7" => 107, "3.2.8" => 109}
 
     assert_allocations(**allocations) do
       events = []

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,7 +16,7 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 77, "3.4.2" => 107, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 106}
+      {"3.5.0" => 77, "3.4.2" => 107, "3.3.7" => 84} : {"3.3.7" => 83, "3.2.8" => 109}
 
     assert_allocations(**allocations) do
       events = []

--- a/test/test_engine/test/config_test.rb
+++ b/test/test_engine/test/config_test.rb
@@ -13,7 +13,6 @@ module ViewComponent
       assert_equal @config.preview_controller, "ViewComponentsController"
       assert_equal @config.preview_route, "/rails/view_components"
       assert_equal @config.instrumentation_enabled, false
-      assert_equal @config.use_deprecated_instrumentation_name, true
       assert_equal @config.show_previews, true
       assert_equal @config.preview_paths, ["#{TestEngine::Engine.root}/test/components/previews"]
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -114,6 +114,14 @@ ensure
   Rails.application.config.view_component.generate[config_option] = old_value
 end
 
+def with_instrumentation_enabled_option(value)
+  old_value = Rails.application.config.view_component.instrumentation_enabled
+  Rails.application.config.view_component.instrumentation_enabled = value
+  yield
+ensure
+  Rails.application.config.view_component.instrumentation_enabled = old_value
+end
+
 def with_generate_sidecar(enabled, &block)
   with_generate_option(:sidecar, enabled, &block)
 end


### PR DESCRIPTION
This PR removes the final `# :nocov:` from the codebase by enabling instrumentation in the test suite.

### Flaky allocations

The memory allocations test became flaky with instrumentation enabled, randomly adding three allocations:

```ruby
80 finish activesupport-8.0.2/lib/active_support/notifications/fanout.rb 133
160 dup activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb 112
160 new view_component/test/sandbox/test/instrumentation_test.rb 9
```

This appeared to be a race condition with ActiveSupport Notifications, so I opted to disable them for the memory allocations test.

### Removing use_deprecated_instrumentation_name

There was conflicting verbiage around the deprecation of this option. I've clarified it in https://github.com/ViewComponent/view_component/pull/2254 for release on the v3 series.