### PR TITLE
clarify deprecation plan for use_deprecated_instrumentation_name

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ nav_order: 6
 
     *Joel Hawksley*
 
+* Clarify that `config.use_deprecated_instrumentation_name` will be removed in v4.
+
+    *Joel Hawksley*
+
 ## 3.22.0
 
 * Rewrite `ViewComponents at GitHub` documentation as more general `Best practices`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -269,7 +269,7 @@ Defaults to `ApplicationController`.
 
 Whether ActiveSupport Notifications use the private name `"!render.view_component"`
 or are made more publicly available via `"render.view_component"`.
-Will default to `false` in next major version.
+Will be removed in next major version.
 Defaults to `true`.
 
 ### `.view_component_path`

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -123,7 +123,7 @@ module ViewComponent
       # @return [Boolean]
       # Whether ActiveSupport Notifications use the private name `"!render.view_component"`
       # or are made more publicly available via `"render.view_component"`.
-      # Will default to `false` in next major version.
+      # Will be removed in next major version.
       # Defaults to `true`.
 
       # @!attribute render_monkey_patch_enabled

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -16,7 +16,7 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
-      {"3.5.0" => 121, "3.4.2" => 125, "3.3.7" => 137} :
+      {"3.5.0" => 119, "3.4.2" => 125, "3.3.7" => 137} :
       {"3.3.7" => 128, "3.3.0" => 140, "3.2.8" => 126, "3.1.7" => 126, "3.0.7" => 135}
 
     assert_allocations(**allocations) do


### PR DESCRIPTION
This option should have been documented as headed for removal as the deprecation warning already indicates.
