### PR TITLE
ViewComponentsSystemTestController only exists in test env

### DIFF
--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -1,30 +1,27 @@
 # frozen_string_literal: true
 
-class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
-  before_action :validate_test_env
-  before_action :validate_file_path
+if Rails.env.test?
+  class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
+    before_action :validate_file_path
 
-  def self.temp_dir
-    @_tmpdir ||= FileUtils.mkdir_p("./tmp/view_components/").first
-  end
+    def self.temp_dir
+      @_tmpdir ||= FileUtils.mkdir_p("./tmp/view_components/").first
+    end
 
-  def system_test_entrypoint
-    render file: @path
-  end
+    def system_test_entrypoint
+      render file: @path
+    end
 
-  private
+    private
 
-  def validate_test_env
-    raise ViewComponent::SystemTestControllerOnlyAllowedInTestError unless Rails.env.test?
-  end
-
-  # Ensure that the file path is valid and doesn't target files outside
-  # the expected directory (e.g. via a path traversal or symlink attack)
-  def validate_file_path
-    base_path = ::File.realpath(self.class.temp_dir)
-    @path = ::File.realpath(params.permit(:file)[:file], base_path)
-    unless @path.start_with?(base_path)
-      raise ViewComponent::SystemTestControllerNefariousPathError
+    # Ensure that the file path is valid and doesn't target files outside
+    # the expected directory (e.g. via a path traversal or symlink attack)
+    def validate_file_path
+      base_path = ::File.realpath(self.class.temp_dir)
+      @path = ::File.realpath(params.permit(:file)[:file], base_path)
+      unless @path.start_with?(base_path)
+        raise ViewComponent::SystemTestControllerNefariousPathError
+      end
     end
   end
 end

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,10 @@ nav_order: 5
 
     *Stephen Nelson*
 
+* `ViewComponentsSystemTestController` should not exist outside of test environment
+
+    *Joel Hawksley*
+
 * Remove unnecessary ENABLE_RELOADING test suite flag.
 
     *Joel Hawksley*

--- a/docs/api.md
+++ b/docs/api.md
@@ -503,10 +503,6 @@ To fix this issue, choose a different name.
 
 ViewComponent SystemTest controller attempted to load a file outside of the expected directory.
 
-### `SystemTestControllerOnlyAllowedInTestError`
-
-ViewComponent SystemTest controller must only be called in a test environment for security reasons.
-
 ### `TranslateCalledBeforeRenderError`
 
 `#translate` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -218,10 +218,6 @@ module ViewComponent
       "`#controller` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void)."
   end
 
-  class SystemTestControllerOnlyAllowedInTestError < BaseError
-    MESSAGE = "ViewComponent SystemTest controller must only be called in a test environment for security reasons."
-  end
-
   class SystemTestControllerNefariousPathError < BaseError
     MESSAGE = "ViewComponent SystemTest controller attempted to load a file outside of the expected directory."
   end

--- a/lib/view_component/system_test_helpers.rb
+++ b/lib/view_component/system_test_helpers.rb
@@ -4,7 +4,6 @@ module ViewComponent
   module SystemTestHelpers
     include TestHelpers
 
-    #
     # Returns a block that can be used to visit the path of the inline rendered component.
     # @param fragment [Nokogiri::Fragment] The fragment returned from `render_inline`.
     # @param layout [String] The (optional) layout to use.
@@ -18,7 +17,7 @@ module ViewComponent
         file.write(vc_test_controller.render_to_string(html: fragment.to_html.html_safe, layout: layout))
         file.rewind
 
-        block.call("/_system_test_entrypoint?file=#{file.path.split("/").last}")
+        yield("/_system_test_entrypoint?file=#{file.path.split("/").last}")
       ensure
         file.unlink
       end


### PR DESCRIPTION
Out of an abundance of caution, this PR changes `ViewComponentsSystemTestController` to only be loaded in the test environment.