### PR TITLE
Rename private and internal methods to indicate they are not part of public API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,7 +60,7 @@ nav_order: 5
 
     *Stephen Nelson*
 
-* BREAKING: Rename internal methods to have `__vc_` prefix if they shouldn't be used by consumers. Make internal contants private. Make `Collection#components`, `Slotable#register_polymorphic_slot` private.
+* BREAKING: Rename internal methods to have `__vc_` prefix if they shouldn't be used by consumers. Make internal contants private. Make `Collection#components`, `Slotable#register_polymorphic_slot` private. Remove unused `ComponentError` class.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,7 +60,7 @@ nav_order: 5
 
     *Stephen Nelson*
 
-* BREAKING: Rename internal methods to have `__vc_` prefix if they shouldn't be used by consumers. Make internal contants private. Make `Collection#components`, `Slotable#register_polymorphic_slot` private. Remove unused `ComponentError` class.
+* BREAKING: Rename internal methods to have `__vc_` prefix if they shouldn't be used by consumers. Make internal constants private. Make `Collection#components`, `Slotable#register_polymorphic_slot` private. Remove unused `ComponentError` class.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,6 +60,10 @@ nav_order: 5
 
     *Stephen Nelson*
 
+* BREAKING: Rename internal methods to have `__vc_` prefix if they should not be used by consumers. Make internal contants private. Make `Collection#components`, `Slotable#register_polymorphic_slot` private.
+
+    *Joel Hawksley*
+
 * `ViewComponentsSystemTestController` should not exist outside of test environment
 
     *Joel Hawksley*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,7 +60,7 @@ nav_order: 5
 
     *Stephen Nelson*
 
-* BREAKING: Rename internal methods to have `__vc_` prefix if they should not be used by consumers. Make internal contants private. Make `Collection#components`, `Slotable#register_polymorphic_slot` private.
+* BREAKING: Rename internal methods to have `__vc_` prefix if they shouldn't be used by consumers. Make internal contants private. Make `Collection#components`, `Slotable#register_polymorphic_slot` private.
 
     *Joel Hawksley*
 

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -10,7 +10,6 @@ module ViewComponent
   autoload :CaptureCompatibility
   autoload :Compiler
   autoload :CompileCache
-  autoload :ComponentError
   autoload :Config
   autoload :Deprecation
   autoload :InlineTemplate

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -610,8 +610,8 @@ module ViewComponent
       # is accepted, as support for collection
       # rendering is optional.
       # @private
-      def validate_collection_parameter!(validate_default: false)
-        parameter = validate_default ? collection_parameter : provided_collection_parameter
+      def __vc_validate_collection_parameter!(validate_default: false)
+        parameter = validate_default ? __vc_collection_parameter : provided_collection_parameter
 
         return unless parameter
         return if initialize_parameter_names.include?(parameter) || splatted_keyword_argument_present?
@@ -630,35 +630,35 @@ module ViewComponent
       # invalid parameters that could override the framework's
       # methods.
       # @private
-      def validate_initialization_parameters!
+      def __vc_validate_initialization_parameters!
         return unless initialize_parameter_names.include?(:content)
 
         raise ReservedParameterError.new(name, :content)
       end
 
       # @private
-      def collection_parameter
+      def __vc_collection_parameter
         provided_collection_parameter || name && name.demodulize.underscore.chomp("_component").to_sym
       end
 
       # @private
-      def collection_counter_parameter
-        :"#{collection_parameter}_counter"
+      def __vc_collection_counter_parameter
+        :"#{__vc_collection_parameter}_counter"
       end
 
       # @private
-      def counter_argument_present?
-        initialize_parameter_names.include?(collection_counter_parameter)
+      def __vc_counter_argument_present?
+        initialize_parameter_names.include?(__vc_collection_counter_parameter)
       end
 
       # @private
-      def collection_iteration_parameter
-        :"#{collection_parameter}_iteration"
+      def __vc_collection_iteration_parameter
+        :"#{__vc_collection_parameter}_iteration"
       end
 
       # @private
-      def iteration_argument_present?
-        initialize_parameter_names.include?(collection_iteration_parameter)
+      def __vc_iteration_argument_present?
+        initialize_parameter_names.include?(__vc_collection_iteration_parameter)
       end
 
       private

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -75,7 +75,7 @@ module ViewComponent
     #
     # @return [String]
     def render_in(view_context, &block)
-      self.class.compile(raise_errors: true)
+      self.class.__vc_compile(raise_errors: true)
 
       @view_context = view_context
       self.__vc_original_view_context ||= view_context
@@ -501,7 +501,7 @@ module ViewComponent
       def inherited(child)
         # Compile so child will inherit compiled `call_*` template methods that
         # `compile` defines
-        compile
+        __vc_compile
 
         # Give the child its own personal #render_template_for to protect against the case when
         # eager loading is disabled and the parent component is rendered before the child. In
@@ -512,8 +512,8 @@ module ViewComponent
             def render_template_for(requested_details)
               # Force compilation here so the compiler always redefines render_template_for.
               # This is mostly a safeguard to prevent infinite recursion.
-              self.class.compile(raise_errors: true, force: true)
-              # .compile replaces this method; call the new one
+              self.class.__vc_compile(raise_errors: true, force: true)
+              # .__vc_compile replaces this method; call the new one
               render_template_for(requested_details)
             end
           RUBY
@@ -558,12 +558,12 @@ module ViewComponent
       end
 
       # @private
-      def ensure_compiled
-        compile unless __vc_compiled?
+      def __vc_ensure_compiled
+        __vc_compile unless __vc_compiled?
       end
 
       # @private
-      def compile(raise_errors: false, force: false)
+      def __vc_compile(raise_errors: false, force: false)
         compiler.compile(raise_errors: raise_errors, force: force)
       end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -554,7 +554,7 @@ module ViewComponent
 
       # @private
       def __vc_compiled?
-        compiler.compiled?
+        __vc_compiler.compiled?
       end
 
       # @private
@@ -564,11 +564,11 @@ module ViewComponent
 
       # @private
       def __vc_compile(raise_errors: false, force: false)
-        compiler.compile(raise_errors: raise_errors, force: force)
+        __vc_compiler.compile(raise_errors: raise_errors, force: force)
       end
 
       # @private
-      def compiler
+      def __vc_compiler
         @__vc_compiler ||= Compiler.new(self)
       end
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -507,7 +507,7 @@ module ViewComponent
         # eager loading is disabled and the parent component is rendered before the child. In
         # such a scenario, the parent will override ViewComponent::Base#render_template_for,
         # meaning it will not be called for any children and thus not compile their templates.
-        if !child.instance_methods(false).include?(:render_template_for) && !child.compiled?
+        if !child.instance_methods(false).include?(:render_template_for) && !child.__vc_compiled?
           child.class_eval <<~RUBY, __FILE__, __LINE__ + 1
             def render_template_for(requested_details)
               # Force compilation here so the compiler always redefines render_template_for.
@@ -553,13 +553,13 @@ module ViewComponent
       end
 
       # @private
-      def compiled?
+      def __vc_compiled?
         compiler.compiled?
       end
 
       # @private
       def ensure_compiled
-        compile unless compiled?
+        compile unless __vc_compiled?
       end
 
       # @private

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -40,9 +40,6 @@ module ViewComponent
     include ViewComponent::Translatable
     include ViewComponent::WithContentHelper
 
-    RESERVED_PARAMETER = :content
-    VC_INTERNAL_DEFAULT_FORMAT = :html
-
     # For CSRF authenticity tokens in forms
     delegate :form_authenticity_token, :protect_against_forgery?, :config, to: :helpers
 
@@ -634,9 +631,9 @@ module ViewComponent
       # methods.
       # @private
       def validate_initialization_parameters!
-        return unless initialize_parameter_names.include?(RESERVED_PARAMETER)
+        return unless initialize_parameter_names.include?(:content)
 
-        raise ReservedParameterError.new(name, RESERVED_PARAMETER)
+        raise ReservedParameterError.new(name, :content)
       end
 
       # @private

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -27,7 +27,7 @@ module ViewComponent
 
       iterator = ActionView::PartialIteration.new(@collection.size)
 
-      component.validate_collection_parameter!(validate_default: true)
+      component.__vc_validate_collection_parameter!(validate_default: true)
 
       @components = @collection.map do |item|
         component.new(**component_options(item, iterator)).tap do |component|
@@ -58,9 +58,9 @@ module ViewComponent
     end
 
     def component_options(item, iterator)
-      item_options = {component.collection_parameter => item}
-      item_options[component.collection_counter_parameter] = iterator.index if component.counter_argument_present?
-      item_options[component.collection_iteration_parameter] = iterator.dup if component.iteration_argument_present?
+      item_options = {component.__vc_collection_parameter => item}
+      item_options[component.__vc_collection_counter_parameter] = iterator.index if component.__vc_counter_argument_present?
+      item_options[component.__vc_collection_iteration_parameter] = iterator.dup if component.__vc_iteration_argument_present?
 
       @options.merge(item_options)
     end

--- a/lib/view_component/collection.rb
+++ b/lib/view_component/collection.rb
@@ -22,6 +22,12 @@ module ViewComponent
       end.join(rendered_spacer(view_context)).html_safe
     end
 
+    def each(&block)
+      components.each(&block)
+    end
+
+    private
+
     def components
       return @components if defined? @components
 
@@ -35,12 +41,6 @@ module ViewComponent
         end
       end
     end
-
-    def each(&block)
-      components.each(&block)
-    end
-
-    private
 
     def initialize(component, object, spacer_component, **options)
       @component = component

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -42,8 +42,8 @@ module ViewComponent
         end
 
         if raise_errors
-          @component.validate_initialization_parameters!
-          @component.validate_collection_parameter!
+          @component.__vc_validate_initialization_parameters!
+          @component.__vc_validate_collection_parameter!
         end
 
         define_render_template_for

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -31,7 +31,7 @@ module ViewComponent
         gather_templates
 
         if self.class.development_mode && @templates.any?(&:requires_compiled_superclass?)
-          @component.superclass.compile(raise_errors: raise_errors)
+          @component.superclass.__vc_compile(raise_errors: raise_errors)
         end
 
         if template_errors.present?

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -49,7 +49,7 @@ module ViewComponent
         define_render_template_for
 
         @component.register_default_slots
-        @component.build_i18n_backend
+        @component.__vc_build_i18n_backend
 
         CompileCache.register(@component)
       end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -8,7 +8,7 @@ module ViewComponent
     # * true (a blocking mode which ensures thread safety when redefining the `call` method for components,
     #                default in Rails development and test mode)
     # * false(a non-blocking mode, default in Rails production mode)
-    class_attribute :development_mode, default: false
+    class_attribute :__vc_development_mode, default: false
 
     def initialize(component)
       @component = component
@@ -30,7 +30,7 @@ module ViewComponent
 
         gather_templates
 
-        if self.class.development_mode && @templates.any?(&:requires_compiled_superclass?)
+        if self.class.__vc_development_mode && @templates.any?(&:requires_compiled_superclass?)
           @component.superclass.__vc_compile(raise_errors: raise_errors)
         end
 

--- a/lib/view_component/component_error.rb
+++ b/lib/view_component/component_error.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module ViewComponent
-  class ComponentError < StandardError
-  end
-end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -68,7 +68,7 @@ module ViewComponent
 
     initializer "view_component.eager_load_actions" do
       ActiveSupport.on_load(:after_initialize) do
-        ViewComponent::Base.descendants.each(&:compile) if Rails.application.config.eager_load
+        ViewComponent::Base.descendants.each(&:__vc_compile) if Rails.application.config.eager_load
       end
     end
 

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -73,7 +73,7 @@ module ViewComponent
     end
 
     initializer "compiler mode" do |_app|
-      ViewComponent::Compiler.development_mode = (Rails.env.development? || Rails.env.test?)
+      ViewComponent::Compiler.__vc_development_mode = (Rails.env.development? || Rails.env.test?)
     end
 
     config.after_initialize do |app|

--- a/lib/view_component/inline_template.rb
+++ b/lib/view_component/inline_template.rb
@@ -41,13 +41,13 @@ module ViewComponent # :nodoc:
         @__vc_inline_template if defined?(@__vc_inline_template)
       end
 
-      def inline_template_language
+      def __vc_inline_template_language
         @__vc_inline_template_language if defined?(@__vc_inline_template_language)
       end
 
       def inherited(subclass)
         super
-        subclass.instance_variable_set(:@__vc_inline_template_language, inline_template_language)
+        subclass.instance_variable_set(:@__vc_inline_template_language, __vc_inline_template_language)
       end
     end
   end

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -33,7 +33,7 @@ module ViewComponent # :nodoc:
     class << self
       # Returns all component preview classes.
       def all
-        load_previews
+        __vc_load_previews
 
         descendants
       end
@@ -92,7 +92,8 @@ module ViewComponent # :nodoc:
           .sub(/\..*$/, "")
       end
 
-      def load_previews
+      # @private
+      def __vc_load_previews
         Array(preview_paths).each do |preview_path|
           Dir["#{preview_path}/**/*preview.rb"].sort.each { |file| require_dependency file }
         end

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -14,11 +14,8 @@ module ViewComponent
     }.freeze
     private_constant :RESERVED_NAMES
 
-    # Setup component slot state
     included do
-      # Hash of registered Slots
-      class_attribute :registered_slots
-      self.registered_slots = {}
+      class_attribute :registered_slots, default: {}
     end
 
     class_methods do

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -15,7 +15,7 @@ module ViewComponent
     private_constant :RESERVED_NAMES
 
     included do
-      class_attribute :__vc_registered_slots, default: {}
+      class_attribute :registered_slots, default: {}
     end
 
     class_methods do
@@ -185,12 +185,12 @@ module ViewComponent
       end
 
       def slot_type(slot_name)
-        registered_slot = __vc_registered_slots[slot_name]
+        registered_slot = registered_slots[slot_name]
         if registered_slot
           registered_slot[:collection] ? :collection : :single
         else
           plural_slot_name = ActiveSupport::Inflector.pluralize(slot_name).to_sym
-          plural_registered_slot = __vc_registered_slots[plural_slot_name]
+          plural_registered_slot = registered_slots[plural_slot_name]
           plural_registered_slot&.fetch(:collection) ? :collection_item : nil
         end
       end
@@ -198,7 +198,7 @@ module ViewComponent
       def inherited(child)
         # Clone slot configuration into child class
         # see #test_slots_pollution
-        child.__vc_registered_slots = __vc_registered_slots.clone
+        child.registered_slots = registered_slots.clone
 
         # Add a module for slot methods, allowing them to be overriden by the component class
         # see #test_slot_name_can_be_overriden
@@ -213,17 +213,17 @@ module ViewComponent
 
       # Called by the compiler, as instance methods are not defined when slots are first registered
       def register_default_slots
-        __vc_registered_slots.each do |slot_name, config|
+        registered_slots.each do |slot_name, config|
           config[:default_method] = instance_methods.find { |method_name| method_name == :"default_#{slot_name}" }
 
-          __vc_registered_slots[slot_name] = config
+          registered_slots[slot_name] = config
         end
       end
 
       private
 
       def register_slot(slot_name, **kwargs)
-        __vc_registered_slots[slot_name] = define_slot(slot_name, **kwargs)
+        registered_slots[slot_name] = define_slot(slot_name, **kwargs)
       end
 
       def register_polymorphic_slot(slot_name, types, collection:)
@@ -272,7 +272,7 @@ module ViewComponent
           end
         end
 
-        __vc_registered_slots[slot_name] = {
+        registered_slots[slot_name] = {
           collection: collection,
           renderable_hash: renderable_hash
         }
@@ -327,7 +327,7 @@ module ViewComponent
       end
 
       def raise_if_slot_registered(slot_name)
-        if __vc_registered_slots.key?(slot_name)
+        if registered_slots.key?(slot_name)
           raise RedefinedSlotError.new(name, slot_name)
         end
       end
@@ -353,7 +353,7 @@ module ViewComponent
     def get_slot(slot_name)
       content unless content_evaluated? # ensure content is loaded so slots will be defined
 
-      slot = self.class.__vc_registered_slots[slot_name]
+      slot = self.class.registered_slots[slot_name]
       @__vc_set_slots ||= {}
 
       if @__vc_set_slots[slot_name]
@@ -366,7 +366,7 @@ module ViewComponent
     end
 
     def set_slot(slot_name, slot_definition = nil, *args, **kwargs, &block)
-      slot_definition ||= self.class.__vc_registered_slots[slot_name]
+      slot_definition ||= self.class.registered_slots[slot_name]
       slot = Slot.new(self)
 
       # Passing the block to the sub-component wrapper like this has two
@@ -423,7 +423,7 @@ module ViewComponent
     end
 
     def set_polymorphic_slot(slot_name, poly_type = nil, *args, **kwargs, &block)
-      slot_definition = self.class.__vc_registered_slots[slot_name]
+      slot_definition = self.class.registered_slots[slot_name]
 
       if !slot_definition[:collection] && (defined?(@__vc_set_slots) && @__vc_set_slots[slot_name])
         raise ContentAlreadySetForPolymorphicSlotError.new(slot_name)

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -211,6 +211,21 @@ module ViewComponent
         super
       end
 
+      # Called by the compiler, as instance methods are not defined when slots are first registered
+      def register_default_slots
+        __vc_registered_slots.each do |slot_name, config|
+          config[:default_method] = instance_methods.find { |method_name| method_name == :"default_#{slot_name}" }
+
+          __vc_registered_slots[slot_name] = config
+        end
+      end
+
+      private
+
+      def register_slot(slot_name, **kwargs)
+        __vc_registered_slots[slot_name] = define_slot(slot_name, **kwargs)
+      end
+
       def register_polymorphic_slot(slot_name, types, collection:)
         self::GeneratedSlotMethods.define_method(slot_name) do
           get_slot(slot_name)
@@ -261,21 +276,6 @@ module ViewComponent
           collection: collection,
           renderable_hash: renderable_hash
         }
-      end
-
-      # Called by the compiler, as instance methods are not defined when slots are first registered
-      def register_default_slots
-        __vc_registered_slots.each do |slot_name, config|
-          config[:default_method] = instance_methods.find { |method_name| method_name == :"default_#{slot_name}" }
-
-          __vc_registered_slots[slot_name] = config
-        end
-      end
-
-      private
-
-      def register_slot(slot_name, **kwargs)
-        __vc_registered_slots[slot_name] = define_slot(slot_name, **kwargs)
       end
 
       def define_slot(slot_name, collection:, callable:)

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -12,6 +12,7 @@ module ViewComponent
       singular: %i[content render].freeze,
       plural: %i[contents renders].freeze
     }.freeze
+    private_constant :RESERVED_NAMES
 
     # Setup component slot state
     included do

--- a/lib/view_component/slotable_default.rb
+++ b/lib/view_component/slotable_default.rb
@@ -3,7 +3,7 @@ module ViewComponent
     def get_slot(slot_name)
       @__vc_set_slots ||= {}
 
-      return super unless !@__vc_set_slots[slot_name] && (default_method = __vc_registered_slots[slot_name][:default_method])
+      return super unless !@__vc_set_slots[slot_name] && (default_method = registered_slots[slot_name][:default_method])
 
       renderable_value = send(default_method)
       slot = Slot.new(self)

--- a/lib/view_component/slotable_default.rb
+++ b/lib/view_component/slotable_default.rb
@@ -3,7 +3,7 @@ module ViewComponent
     def get_slot(slot_name)
       @__vc_set_slots ||= {}
 
-      return super unless !@__vc_set_slots[slot_name] && (default_method = registered_slots[slot_name][:default_method])
+      return super unless !@__vc_set_slots[slot_name] && (default_method = __vc_registered_slots[slot_name][:default_method])
 
       renderable_value = send(default_method)
       slot = Slot.new(self)

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -2,6 +2,9 @@
 
 module ViewComponent
   class Template
+    DEFAULT_FORMAT = :html
+    private_constant :DEFAULT_FORMAT
+
     DataWithSource = Struct.new(:format, :identifier, :short_identifier, :type, keyword_init: true)
 
     attr_reader :details
@@ -119,7 +122,7 @@ module ViewComponent
     end
 
     def default_format?
-      format.nil? || format == ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT
+      format.nil? || format == DEFAULT_FORMAT
     end
     alias_method :html?, :default_format?
 
@@ -145,7 +148,7 @@ module ViewComponent
       this_source.rstrip! if @component.strip_trailing_whitespace?
 
       short_identifier = defined?(Rails.root) ? @path.sub("#{Rails.root}/", "") : @path
-      format = self.format || ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT
+      format = self.format || DEFAULT_FORMAT
       type = ActionView::Template::Types[format]
 
       handler.call(DataWithSource.new(format:, identifier: @path, short_identifier:, type:), this_source)

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -15,7 +15,7 @@ module ViewComponent
     private_constant :TRANSLATION_EXTENSIONS
 
     included do
-      class_attribute :i18n_backend, instance_writer: false, instance_predicate: false
+      class_attribute :__vc_i18n_backend, instance_writer: false, instance_predicate: false
     end
 
     class_methods do
@@ -35,7 +35,7 @@ module ViewComponent
         end
 
         # In development it will become nil if the translations file is removed
-        self.i18n_backend = if translation_files.any?
+        self.__vc_i18n_backend = if translation_files.any?
           I18nBackend.new(
             i18n_scope: i18n_scope,
             load_paths: translation_files
@@ -59,7 +59,7 @@ module ViewComponent
         locale = options.delete(:locale) || ::I18n.locale
         key = i18n_key(key, options.delete(:scope))
 
-        i18n_backend.translate(locale, key, options)
+        __vc_i18n_backend.translate(locale, key, options)
       end
 
       alias_method :t, :translate
@@ -93,7 +93,7 @@ module ViewComponent
     def translate(key = nil, **options)
       raise ViewComponent::TranslateCalledBeforeRenderError if view_context.nil?
 
-      return super unless i18n_backend
+      return super unless __vc_i18n_backend
       return key.map { |k| translate(k, **options) } if key.is_a?(Array)
 
       locale = options.delete(:locale) || ::I18n.locale
@@ -105,7 +105,7 @@ module ViewComponent
       if key.start_with?(i18n_scope + ".")
         translated =
           catch(:exception) do
-            i18n_backend.translate(locale, key, options)
+            __vc_i18n_backend.translate(locale, key, options)
           end
 
         # Fallback to the global translations

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -23,7 +23,7 @@ module ViewComponent
         @i18n_scope ||= virtual_path.sub(%r{^/}, "").gsub(%r{/_?}, ".")
       end
 
-      def build_i18n_backend
+      def __vc_build_i18n_backend
         return if __vc_compiled?
 
         # We need to load the translations files from the ancestors so a component

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -54,7 +54,7 @@ module ViewComponent
       def translate(key = nil, **options)
         return key.map { |k| translate(k, **options) } if key.is_a?(Array)
 
-        ensure_compiled
+        __vc_ensure_compiled
 
         locale = options.delete(:locale) || ::I18n.locale
         key = i18n_key(key, options.delete(:scope))

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -24,7 +24,7 @@ module ViewComponent
       end
 
       def build_i18n_backend
-        return if compiled?
+        return if __vc_compiled?
 
         # We need to load the translations files from the ancestors so a component
         # can inherit translations from its parent and is able to overwrite them.

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -37,7 +37,7 @@ module ViewComponent
         # In development it will become nil if the translations file is removed
         self.__vc_i18n_backend = if translation_files.any?
           I18nBackend.new(
-            __vc_i18n_scope: __vc_i18n_scope,
+            scope: __vc_i18n_scope,
             load_paths: translation_files
           )
         end

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -43,7 +43,7 @@ module ViewComponent
         end
       end
 
-      def i18n_key(key, scope = nil)
+      def __vc_i18n_key(key, scope = nil)
         scope = scope.join(".") if scope.is_a? Array
         key = key&.to_s unless key.is_a?(String)
         key = "#{scope}.#{key}" if scope
@@ -57,7 +57,7 @@ module ViewComponent
         __vc_ensure_compiled
 
         locale = options.delete(:locale) || ::I18n.locale
-        key = i18n_key(key, options.delete(:scope))
+        key = __vc_i18n_key(key, options.delete(:scope))
 
         __vc_i18n_backend.translate(locale, key, options)
       end
@@ -97,7 +97,7 @@ module ViewComponent
       return key.map { |k| translate(k, **options) } if key.is_a?(Array)
 
       locale = options.delete(:locale) || ::I18n.locale
-      key = self.class.i18n_key(key, options.delete(:scope))
+      key = self.class.__vc_i18n_key(key, options.delete(:scope))
       as_html = HTML_SAFE_TRANSLATION_KEY.match?(key)
 
       html_escape_translation_options!(options) if as_html
@@ -121,7 +121,6 @@ module ViewComponent
     end
     alias_method :t, :translate
 
-    # Exposes .__vc_i18n_scope as an instance method
     def __vc_i18n_scope
       self.class.__vc_i18n_scope
     end

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -9,7 +9,10 @@ module ViewComponent
     extend ActiveSupport::Concern
 
     HTML_SAFE_TRANSLATION_KEY = /(?:_|\b)html\z/
+    private_constant :HTML_SAFE_TRANSLATION_KEY
+
     TRANSLATION_EXTENSIONS = %w[yml yaml].freeze
+    private_constant :TRANSLATION_EXTENSIONS
 
     included do
       class_attribute :i18n_backend, instance_writer: false, instance_predicate: false

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -68,8 +68,8 @@ module ViewComponent
     class I18nBackend < ::I18n::Backend::Simple
       EMPTY_HASH = {}.freeze
 
-      def initialize(__vc_i18n_scope:, load_paths:)
-        @__vc_i18n_scope = __vc_i18n_scope.split(".").map(&:to_sym)
+      def initialize(scope:, load_paths:)
+        @__vc_i18n_scope = scope.split(".").map(&:to_sym)
         @load_paths = load_paths
       end
 

--- a/lib/view_component/translatable.rb
+++ b/lib/view_component/translatable.rb
@@ -19,8 +19,8 @@ module ViewComponent
     end
 
     class_methods do
-      def i18n_scope
-        @i18n_scope ||= virtual_path.sub(%r{^/}, "").gsub(%r{/_?}, ".")
+      def __vc_i18n_scope
+        @__vc_i18n_scope ||= virtual_path.sub(%r{^/}, "").gsub(%r{/_?}, ".")
       end
 
       def __vc_build_i18n_backend
@@ -37,7 +37,7 @@ module ViewComponent
         # In development it will become nil if the translations file is removed
         self.__vc_i18n_backend = if translation_files.any?
           I18nBackend.new(
-            i18n_scope: i18n_scope,
+            __vc_i18n_scope: __vc_i18n_scope,
             load_paths: translation_files
           )
         end
@@ -47,7 +47,7 @@ module ViewComponent
         scope = scope.join(".") if scope.is_a? Array
         key = key&.to_s unless key.is_a?(String)
         key = "#{scope}.#{key}" if scope
-        key = "#{i18n_scope}#{key}" if key.start_with?(".")
+        key = "#{__vc_i18n_scope}#{key}" if key.start_with?(".")
         key
       end
 
@@ -68,8 +68,8 @@ module ViewComponent
     class I18nBackend < ::I18n::Backend::Simple
       EMPTY_HASH = {}.freeze
 
-      def initialize(i18n_scope:, load_paths:)
-        @i18n_scope = i18n_scope.split(".").map(&:to_sym)
+      def initialize(__vc_i18n_scope:, load_paths:)
+        @__vc_i18n_scope = __vc_i18n_scope.split(".").map(&:to_sym)
         @load_paths = load_paths
       end
 
@@ -79,7 +79,7 @@ module ViewComponent
       end
 
       def scope_data(data)
-        @i18n_scope.reverse_each do |part|
+        @__vc_i18n_scope.reverse_each do |part|
           data = {part => data}
         end
         data
@@ -102,7 +102,7 @@ module ViewComponent
 
       html_escape_translation_options!(options) if as_html
 
-      if key.start_with?(i18n_scope + ".")
+      if key.start_with?(__vc_i18n_scope + ".")
         translated =
           catch(:exception) do
             __vc_i18n_backend.translate(locale, key, options)
@@ -121,9 +121,9 @@ module ViewComponent
     end
     alias_method :t, :translate
 
-    # Exposes .i18n_scope as an instance method
-    def i18n_scope
-      self.class.i18n_scope
+    # Exposes .__vc_i18n_scope as an instance method
+    def __vc_i18n_scope
+      self.class.__vc_i18n_scope
     end
 
     private

--- a/test/sandbox/spec/components/previews/preview_component_spec.rb
+++ b/test/sandbox/spec/components/previews/preview_component_spec.rb
@@ -1,6 +1,6 @@
 describe PreviewComponent do
   before do
-    ViewComponent::Preview.load_previews
+    ViewComponent::Preview.__vc_load_previews
   end
 
   it "renders the preview" do
@@ -12,7 +12,7 @@ end
 
 describe "PreviewComponent" do
   before do
-    ViewComponent::Preview.load_previews
+    ViewComponent::Preview.__vc_load_previews
   end
 
   it "raises an error" do

--- a/test/sandbox/test/components/described_class_test.rb
+++ b/test/sandbox/test/components/described_class_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class DescribedClassTest < ViewComponent::TestCase
   def setup
-    ViewComponent::Preview.load_previews
+    ViewComponent::Preview.__vc_load_previews
   end
 
   def described_class

--- a/test/sandbox/test/components/my_component_test.rb
+++ b/test/sandbox/test/components/my_component_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class MyComponentTest < ViewComponent::TestCase
   def setup
-    ViewComponent::Preview.load_previews
+    ViewComponent::Preview.__vc_load_previews
   end
 
   def test_render_preview

--- a/test/sandbox/test/components/nil_described_class_test.rb
+++ b/test/sandbox/test/components/nil_described_class_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class NilDescribedClassTest < ViewComponent::TestCase
   def setup
-    ViewComponent::Preview.load_previews
+    ViewComponent::Preview.__vc_load_previews
   end
 
   def described_class

--- a/test/sandbox/test/components/render_preview_test.rb
+++ b/test/sandbox/test/components/render_preview_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class RenderPreviewTest < ViewComponent::TestCase
   def setup
-    ViewComponent::Preview.load_previews
+    ViewComponent::Preview.__vc_load_previews
   end
 
   def test_render_preview_from_class

--- a/test/sandbox/test/inline_template_test.rb
+++ b/test/sandbox/test/inline_template_test.rb
@@ -114,7 +114,7 @@ class InlineErbTest < ViewComponent::TestCase
   end
 
   test "inherits template_language" do
-    assert_equal "slim", InheritedInlineSlimComponent.inline_template_language
+    assert_equal "slim", InheritedInlineSlimComponent.__vc_inline_template_language
   end
 
   test "subclassed erb works" do

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -605,7 +605,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       Rails.env = "production".inquiry
 
       ViewComponent::Engine.initializers.find { |i| i.name == "compiler mode" }.run
-      assert_equal false, ViewComponent::Compiler.development_mode
+      assert_equal false, ViewComponent::Compiler.__vc_development_mode
     ensure
       Rails.env = old_env
       ViewComponent::Engine.initializers.find { |i| i.name == "compiler mode" }.run
@@ -615,12 +615,12 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   def test_sets_the_compiler_mode_in_development_mode
     Rails.env.stub :development?, true do
       ViewComponent::Engine.initializers.find { |i| i.name == "compiler mode" }.run
-      assert_equal true, ViewComponent::Compiler.development_mode
+      assert_equal true, ViewComponent::Compiler.__vc_development_mode
     end
 
     Rails.env.stub :test?, true do
       ViewComponent::Engine.initializers.find { |i| i.name == "compiler mode" }.run
-      assert_equal true, ViewComponent::Compiler.development_mode
+      assert_equal true, ViewComponent::Compiler.__vc_development_mode
     end
   end
 

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -110,7 +110,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       assert_select "div", "hello world"
       assert_response :success
 
-      compile_method_lines = UncompilableComponent.method(:compile).source.split("\n")
+      compile_method_lines = UncompilableComponent.method(:__vc_compile).source.split("\n")
       compile_method_lines.insert(1, 'raise "this should not happen" if self.name == "UncompilableComponent"')
       UncompilableComponent.instance_eval compile_method_lines.join("\n")
 

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 
 class IntegrationTest < ActionDispatch::IntegrationTest
   def setup
-    ViewComponent::Preview.load_previews
+    ViewComponent::Preview.__vc_load_previews
   end
 
   def test_rendering_component_in_a_view

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -97,14 +97,14 @@ class RenderingTest < ViewComponent::TestCase
   def test_render_without_template
     render_inline(InlineComponent.new)
 
-    assert_predicate InlineComponent, :compiled?
+    assert_predicate InlineComponent, :__vc_compiled?
     assert_selector("input[type='text'][name='name']")
   end
 
   def test_render_child_without_template
     render_inline(InlineChildComponent.new)
 
-    assert_predicate InlineChildComponent, :compiled?
+    assert_predicate InlineChildComponent, :__vc_compiled?
     assert_selector("input[type='text'][name='name']")
   end
 
@@ -223,7 +223,7 @@ class RenderingTest < ViewComponent::TestCase
     with_variant :inline_variant do
       render_inline(InlineVariantComponent.new)
 
-      assert_predicate InlineVariantComponent, :compiled?
+      assert_predicate InlineVariantComponent, :__vc_compiled?
       assert_selector("input[type='text'][name='inline_variant']")
     end
   end
@@ -232,7 +232,7 @@ class RenderingTest < ViewComponent::TestCase
     with_variant :inline_variant do
       render_inline(InlineVariantChildComponent.new)
 
-      assert_predicate InlineVariantChildComponent, :compiled?
+      assert_predicate InlineVariantChildComponent, :__vc_compiled?
       assert_selector("input[type='text'][name='inline_variant']")
     end
   end
@@ -437,7 +437,7 @@ class RenderingTest < ViewComponent::TestCase
     # but that might have been thrown away if code-reloading is enabled
     skip unless Rails.application.config.cache_classes
 
-    assert UnreferencedComponent.compiled?
+    assert UnreferencedComponent.__vc_compiled?
   end
 
   def test_compiles_components_without_initializers
@@ -445,7 +445,7 @@ class RenderingTest < ViewComponent::TestCase
     # but that might have been thrown away if code-reloading is enabled
     skip unless Rails.application.config.cache_classes
 
-    assert MissingInitializerComponent.compiled?
+    assert MissingInitializerComponent.__vc_compiled?
   end
 
   def test_renders_when_initializer_is_not_defined
@@ -786,7 +786,7 @@ class RenderingTest < ViewComponent::TestCase
   def test_inherited_inline_component_inherits_inline_method
     render_inline(InlineInheritedComponent.new)
 
-    assert_predicate InlineInheritedComponent, :compiled?
+    assert_predicate InlineInheritedComponent, :__vc_compiled?
     assert_selector("input[type='text'][name='name']")
   end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -13,7 +13,7 @@ class RenderingTest < ViewComponent::TestCase
     # Stabilize compilation status ahead of testing allocations to simulate rendering
     # performance with compiled component
     ViewComponent::CompileCache.cache.delete(MyComponent)
-    MyComponent.ensure_compiled
+    MyComponent.__vc_ensure_compiled
 
     allocations = (Rails.version.to_f >= 8.0) ?
       {"3.5.0" => 79, "3.4.2" => 85, "3.3.7" => 86} : {"3.3.7" => 85, "3.2.8" => 84}
@@ -733,7 +733,7 @@ class RenderingTest < ViewComponent::TestCase
     with_new_cache do
       exception =
         assert_raises ViewComponent::ReservedParameterError do
-          InvalidParametersComponent.compile(raise_errors: true)
+          InvalidParametersComponent.__vc_compile(raise_errors: true)
         end
 
       assert_match(/InvalidParametersComponent initializer can't accept the parameter/, exception.message)
@@ -744,7 +744,7 @@ class RenderingTest < ViewComponent::TestCase
     with_new_cache do
       exception =
         assert_raises ViewComponent::ReservedParameterError do
-          InvalidNamedParametersComponent.compile(raise_errors: true)
+          InvalidNamedParametersComponent.__vc_compile(raise_errors: true)
         end
 
       assert_match(
@@ -975,7 +975,7 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_inherited_component_renders_when_lazy_loading
     # Simulate lazy loading by manually removing the classes in question. This will completely
-    # undo the changes made by self.class.compile and friends, forcing a compile the next time
+    # undo the changes made by self.class.__vc_compile and friends, forcing a compile the next time
     # #render_template_for is called. This shouldn't be necessary except in the test environment,
     # since eager loading is turned on here.
     Object.send(:remove_const, :MyComponent) if defined?(MyComponent)

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -250,7 +250,7 @@ class SlotableTest < ViewComponent::TestCase
     new_component_class = Class.new(ViewComponent::Base)
     # this returned:
     # [SlotsComponent::Subtitle, SlotsComponent::Tab...]
-    assert_empty new_component_class.__vc_registered_slots
+    assert_empty new_component_class.registered_slots
   end
 
   def test_renders_slots_with_before_render_hook

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -250,7 +250,7 @@ class SlotableTest < ViewComponent::TestCase
     new_component_class = Class.new(ViewComponent::Base)
     # this returned:
     # [SlotsComponent::Subtitle, SlotsComponent::Tab...]
-    assert_empty new_component_class.registered_slots
+    assert_empty new_component_class.__vc_registered_slots
   end
 
   def test_renders_slots_with_before_render_hook

--- a/test/sandbox/test/translatable_test.rb
+++ b/test/sandbox/test/translatable_test.rb
@@ -95,7 +95,7 @@ class TranslatableTest < ViewComponent::TestCase
     ) do
       assert_equal "MISSING", translate(".hello", default: "MISSING")
       assert_equal "Hello from Rails translations!", translate("hello")
-      assert_nil TranslatableComponent.i18n_backend
+      assert_nil TranslatableComponent.__vc_i18n_backend
     end
   ensure
     ViewComponent::CompileCache.invalidate_class!(TranslatableComponent)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -174,11 +174,11 @@ def with_default_preview_layout(layout, &block)
 end
 
 def with_compiler_development_mode(mode)
-  previous_mode = ViewComponent::Compiler.development_mode
-  ViewComponent::Compiler.development_mode = mode
+  previous_mode = ViewComponent::Compiler.__vc_development_mode
+  ViewComponent::Compiler.__vc_development_mode = mode
   yield
 ensure
-  ViewComponent::Compiler.development_mode = previous_mode
+  ViewComponent::Compiler.__vc_development_mode = previous_mode
 end
 
 def capture_warnings(&block)


### PR DESCRIPTION
### What are you trying to accomplish?

Rename internal methods to have `__vc_` prefix if they shouldn't be used by consumers. Make internal constants private. Make `Collection#components`, `Slotable#register_polymorphic_slot` private. Remove unused `ComponentError` class.