### PR TITLE
Run RSpec tests in CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -134,4 +134,4 @@ namespace :docs do
   end
 end
 
-task default: [:test, :engine_test]
+task default: [:test, :engine_test, :spec]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ nav_order: 6
 
     *Joel Hawksley*
 
+* Run RSpec tests in CI.
+
+    *Joel Hawksley*
+
 ## 3.22.0
 
 * Rewrite `ViewComponents at GitHub` documentation as more general `Best practices`.


### PR DESCRIPTION
I'm not sure why, but these tests were not being run as part of our CI build. I think it's good to have some sort of compatibility tests with RSpec so I opted to keep them vs. removing them.