### PR TITLE
Update deprecation horizon and version #

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    view_component (3.22.0)
+    view_component (4.0.0.alpha1)
       activesupport (>= 7.1.0, < 8.1)
       concurrent-ruby (~> 1)
 

--- a/lib/view_component/deprecation.rb
+++ b/lib/view_component/deprecation.rb
@@ -3,6 +3,6 @@
 require "active_support/deprecation"
 
 module ViewComponent
-  DEPRECATION_HORIZON = "4.0.0"
+  DEPRECATION_HORIZON = "5.0.0"
   Deprecation = ActiveSupport::Deprecation.new(DEPRECATION_HORIZON, "ViewComponent")
 end

--- a/lib/view_component/version.rb
+++ b/lib/view_component/version.rb
@@ -2,10 +2,10 @@
 
 module ViewComponent
   module VERSION
-    MAJOR = 3
-    MINOR = 22
+    MAJOR = 4
+    MINOR = 0
     PATCH = 0
-    PRE = nil
+    PRE = "alpha1"
 
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join(".")
   end


### PR DESCRIPTION
This PR starts to prepare us for the first alpha release of `v4` by establishing a new deprecation horizon and setting the version as `4.0.0.alpha1`.