### PR TITLE
Fix generation of docs that was broken due to HTML safety issues

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -142,4 +142,4 @@ namespace :docs do
   end
 end
 
-task default: [:test, :engine_test, :spec, :docs_test]
+task default: [:docs_test, :test, :engine_test, :spec]

--- a/Rakefile
+++ b/Rakefile
@@ -142,4 +142,4 @@ namespace :docs do
   end
 end
 
-task default: [:test, :docs_test, :engine_test, :spec]
+task default: [:test, :engine_test, :spec, :docs_test]

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,12 @@ Rake::TestTask.new(:engine_test) do |t|
   t.test_files = FileList["test/test_engine/**/*_test.rb"]
 end
 
+Rake::TestTask.new(:docs_test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/docs/*_test.rb"]
+end
+
 begin
   require "rspec/core/rake_task"
   RSpec::Core::RakeTask.new(:spec)
@@ -100,7 +106,7 @@ namespace :docs do
 
     error_keys = registry.keys.select { |key| key.to_s.include?("Error::MESSAGE") }.map(&:to_s)
 
-    docs = ActionController::Base.new.render_to_string(
+    docs = ActionController::Base.renderer.render(
       ViewComponent::DocsBuilderComponent.new(
         sections: [
           ViewComponent::DocsBuilderComponent::Section.new(
@@ -128,10 +134,12 @@ namespace :docs do
       )
     ).chomp
 
-    File.open("docs/api.md", "w") do |f|
-      f.puts(docs)
+    if ENV["RAILS_ENV"] != "test"
+      File.open("docs/api.md", "w") do |f|
+        f.puts(docs)
+      end
     end
   end
 end
 
-task default: [:test, :engine_test, :spec]
+task default: [:test, :docs_test, :engine_test, :spec]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Fix generation of ViewComponent documentation that was broken due to HTML safety issues.
+
+  *Simon Fish*
+
 * Add documentation on how ViewComponent works.
 
     *Joel Hawksley*

--- a/lib/view_component/docs_builder_component.html.erb
+++ b/lib/view_component/docs_builder_component.html.erb
@@ -12,11 +12,11 @@ nav_order: 3
 ## <%= section.heading %>
 
 <% section.methods.each do |method| %>
-### <%== render ViewComponent::DocsBuilderComponent::MethodDoc.new(method, section.show_types) %>
+### <%= render ViewComponent::DocsBuilderComponent::MethodDoc.new(method, section.show_types) %>
 
 <% end %>
 <% section.error_klasses.each do |error_klass| %>
-### <%== render ViewComponent::DocsBuilderComponent::ErrorKlassDoc.new(error_klass, section.show_types) %>
+### <%= render ViewComponent::DocsBuilderComponent::ErrorKlassDoc.new(error_klass, section.show_types) %>
 
 <% end %>
 <% end %>

--- a/lib/view_component/docs_builder_component.rb
+++ b/lib/view_component/docs_builder_component.rb
@@ -24,7 +24,7 @@ module ViewComponent
       end
 
       def call
-        <<~DOCS.chomp
+        <<~DOCS.chomp.html_safe
           `#{klass_name}`
 
           #{error_message}
@@ -67,7 +67,7 @@ module ViewComponent
       end
 
       def docstring_and_deprecation_text
-        <<~DOCS.strip
+        <<~DOCS.strip.html_safe
           #{docstring}
 
           #{"_#{deprecation_text}_" if deprecated?}
@@ -75,7 +75,7 @@ module ViewComponent
       end
 
       def call
-        <<~DOCS.chomp
+        <<~DOCS.chomp.html_safe
           `#{separator}#{signature_or_name}`#{types}#{suffix}
 
           #{docstring_and_deprecation_text}

--- a/test/docs/docs_rake_task_test.rb
+++ b/test/docs/docs_rake_task_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DocsRakeTaskTest < ActiveSupport::TestCase
+  def test_rake_task
+    load "Rakefile"
+
+    assert_nothing_raised do
+      Rake::Task["docs:build"].invoke
+    end
+
+    Rake::Task.clear
+  end
+end


### PR DESCRIPTION
Running `rake docs:build` after changes in #2230 resulted in some issues with HTML-escaped tags being generated, overriding existing working documentation. These changes mark output as HTML-safe so that docs are generated properly.