### PR TITLE
Fix bug where request-aware helpers did not work outside of the request context

### DIFF
--- a/app/views/test_mailer/test_asset_email.html.erb
+++ b/app/views/test_mailer/test_asset_email.html.erb
@@ -1,0 +1,1 @@
+<%= render AssetComponent.new %>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,6 +72,10 @@ This release makes the following breaking changes:
 
     *Joel Hawksley*
 
+* Fix bug where request-aware helpers did not work outside of the request context.
+
+    *Joel Hawksley*, *Stephen Nelson*
+
 * `ViewComponentsSystemTestController` should not exist outside of test environment
 
     *Joel Hawksley*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -276,11 +276,10 @@ module ViewComponent
       __vc_request
     end
 
-    # Enables consumers to override request/@request
-    #
     # @private
     def __vc_request
-      @__vc_request ||= controller.request
+      # The current request (if present, as mailers/jobs/etc do not have a request)
+      @__vc_request ||= controller.request if controller.respond_to?(:request)
     end
 
     # The content passed to the component instance as a block.

--- a/test/sandbox/app/components/asset_component.html.erb
+++ b/test/sandbox/app/components/asset_component.html.erb
@@ -1,1 +1,2 @@
 <div><%= asset_url("application.css") %></div>
+<div><%= request %></div>

--- a/test/sandbox/app/mailers/test_mailer.rb
+++ b/test/sandbox/app/mailers/test_mailer.rb
@@ -8,4 +8,12 @@ class TestMailer < ActionMailer::Base
       subject: "Testing ViewComponent in ActionMailer"
     )
   end
+
+  def test_asset_email
+    mail(
+      from: "no-reply@example.com",
+      to: "test@example.com",
+      subject: "Testing ViewComponent with Assets in ActionMailer"
+    )
+  end
 end

--- a/test/sandbox/test/mailer_test.rb
+++ b/test/sandbox/test/mailer_test.rb
@@ -2,8 +2,15 @@
 
 require "test_helper"
 
-class MailerTest < ViewComponent::TestCase
+class MailerTest < ActionMailer::TestCase
   def test_rendering_component_in_an_action_mailer
-    assert_includes TestMailer.test_email.deliver_now.body.raw_source, "<div>Hello world!</div>"
+    result = TestMailer.test_email.deliver_now.body.to_s
+    assert_includes result, "<div>Hello world!</div>"
+    assert_includes result, "test_email.html.erb"
+  end
+
+  def test_rendering_component_in_an_action_mailer_with_asset_component
+    result = TestMailer.test_asset_email.deliver_now.body.to_s
+    assert_includes result, "<div>/assets"
   end
 end


### PR DESCRIPTION
Closes #2267 