### PR TITLE
ViewComponentsSystemTestController should always create a class

### DIFF
--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -24,4 +24,8 @@ if Rails.env.test?
       end
     end
   end
+else
+  class ViewComponentsSystemTestController # :nodoc:
+    # stub for Zeitwerk to load
+  end
 end

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,9 +76,9 @@ This release makes the following breaking changes:
 
     *Joel Hawksley*, *Stephen Nelson*
 
-* `ViewComponentsSystemTestController` should not exist outside of test environment
+* `ViewComponentsSystemTestController` should not be useable outside of test environment
 
-    *Joel Hawksley*
+    *Joel Hawksley*, *Stephen Nelson*
 
 * Remove unnecessary ENABLE_RELOADING test suite flag.
 


### PR DESCRIPTION
### What are you trying to accomplish?

Resolves #2269

### What approach did you choose and why?

Return an empty class outside test environments so Zeitwerk doesn't raise an error.

### Anything you want to highlight for special attention from reviewers?

<!-- Performance/security implications, reasoning for lack of test coverage, etc -->
