### PR TITLE
Add #current_template accessor and Template#path

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -136,6 +136,10 @@ This release makes the following breaking changes:
 
     *Joel Hawksley*
 
+* Add `#current_template` accessor and `Template#path` for diagnostic usage.
+
+    *Joel Hawksley*
+
 ## 3.22.0
 
 * Rewrite `ViewComponents at GitHub` documentation as more general `Best practices`.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -50,6 +50,7 @@ module ViewComponent
     class_attribute :__vc_strip_trailing_whitespace, instance_accessor: false, instance_predicate: false, default: false
 
     attr_accessor :__vc_original_view_context
+    attr_reader :current_template
 
     # Components render in their own view context. Helpers and other functionality
     # require a reference to the original Rails view context, an instance of

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -7,7 +7,7 @@ module ViewComponent
 
     DataWithSource = Struct.new(:format, :identifier, :short_identifier, :type, keyword_init: true)
 
-    attr_reader :details
+    attr_reader :details, :path
 
     delegate :virtual_path, to: :@component
     delegate :format, :variant, to: :@details

--- a/test/sandbox/app/components/current_template_component.html.erb
+++ b/test/sandbox/app/components/current_template_component.html.erb
@@ -1,0 +1,1 @@
+<%= current_template.path %>

--- a/test/sandbox/app/components/current_template_component.rb
+++ b/test/sandbox/app/components/current_template_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class CurrentTemplateComponent < ViewComponent::Base
+end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1270,4 +1270,12 @@ class RenderingTest < ViewComponent::TestCase
       render_inline(mock_component.new)
     end
   end
+
+  def test_current_template
+    component = CurrentTemplateComponent.new
+
+    render_inline(component)
+
+    assert(rendered_content.include?("current_template_component.html.erb"))
+  end
 end


### PR DESCRIPTION
Prior to the compiler changes in v4, we set @current_template to be the current instance of the component. Now, we set it to the current ViewComponent::Template. In the GitHub monolith, we reference @current_template when doing certain diagnostic operations. 

I added an accessor to make this less messy to use (and test) and exposed #path on template, which now allows for such diagnostic operations to reference the specific component template being rendered.