### PR TITLE
Add test coverage for custom preview paths

### DIFF
--- a/test/sandbox/config/application.rb
+++ b/test/sandbox/config/application.rb
@@ -43,6 +43,7 @@ module Sandbox
     # Prepare test_set_no_duplicate_autoload_paths
     config.autoload_paths.push("#{config.root}/my/components/previews")
     config.view_component.preview_paths << "#{config.root}/my/components/previews"
+    config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"
   end
 end
 

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -32,7 +32,6 @@ Sandbox::Application.configure do
 
   config.view_component.show_previews = true
 
-  config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"
   config.view_component.render_monkey_patch_enabled = true
   config.view_component.show_previews_source = true
   config.view_component.test_controller = "IntegrationExamplesController"

--- a/test/sandbox/test/components/render_preview_test.rb
+++ b/test/sandbox/test/components/render_preview_test.rb
@@ -24,4 +24,10 @@ class RenderPreviewTest < ViewComponent::TestCase
 
     assert_selector("div", text: "subclass")
   end
+
+  def test_render_preview_custom_path
+    render_preview(:default, from: MyComponentLibPreview)
+
+    assert_selector("div", text: "hello,world!")
+  end
 end

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -787,4 +787,10 @@ class IntegrationTest < ActionDispatch::IntegrationTest
 
     assert_includes response.body, "Hello, CSS!"
   end
+
+  def test_renders_preview_from_custom_preview_path
+    get "/rails/view_components/my_component_lib/default"
+
+    assert_select "div", "hello,world!"
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR adds additional test coverage for rendering previews from a custom preview path.

### What approach did you choose and why?

I was attempting to reproduce the issue in #2182. I could not, but figured it would be good to keep the test coverage around.