### PR TITLE
Do not cache classes in test env

### DIFF
--- a/test/sandbox/app/components/unreferenced_component.html.erb
+++ b/test/sandbox/app/components/unreferenced_component.html.erb
@@ -1,1 +1,0 @@
-<div>Hello, World!</div>

--- a/test/sandbox/app/components/unreferenced_component.rb
+++ b/test/sandbox/app/components/unreferenced_component.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class UnreferencedComponent < ViewComponent::Base
-end

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -16,7 +16,7 @@ Sandbox::Application.configure do
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs.  Don't rely on the data there!
 
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Show full error reports and disable caching
   config.consider_all_requests_local = true

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -127,8 +127,6 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def test_helper_changes_are_reflected_on_new_request
-    skip if Rails.application.config.cache_classes
-
     get "/helpers_proxy_component"
     assert_select("div", "Hello helper method")
     assert_response :success
@@ -152,8 +150,6 @@ class IntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def test_helper_changes_are_reflected_on_new_request_with_previews
-    skip if Rails.application.config.cache_classes
-
     with_preview_route("/previews") do
       get "/previews/helpers_proxy_component/default"
       assert_select("div", "Hello helper method")

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -449,22 +449,6 @@ class RenderingTest < ViewComponent::TestCase
     assert_includes exception.message, "Validation failed: Content"
   end
 
-  def test_compiles_unrendered_component
-    # The UnreferencedComponent will get compiled at boot,
-    # but that might have been thrown away if code-reloading is enabled
-    skip unless Rails.application.config.cache_classes
-
-    assert UnreferencedComponent.__vc_compiled?
-  end
-
-  def test_compiles_components_without_initializers
-    # MissingInitializerComponent will get compiled at boot,
-    # but that might have been thrown away if code-reloading is enabled
-    skip unless Rails.application.config.cache_classes
-
-    assert MissingInitializerComponent.__vc_compiled?
-  end
-
   def test_renders_when_initializer_is_not_defined
     render_inline(MissingInitializerComponent.new)
 


### PR DESCRIPTION
I've decided to prioritize testing code reloading, which has broken before, over testing compilation of an unreferenced component, which hasn't caught any regressions to my knowledge.

This resolves the last of the skips in the test suite.