### PR TITLE
add template annotations for inline_call components

### DIFF
--- a/app/controllers/view_components_system_test_controller.rb
+++ b/app/controllers/view_components_system_test_controller.rb
@@ -19,9 +19,7 @@ class ViewComponentsSystemTestController < ActionController::Base # :nodoc:
     def validate_file_path
       base_path = ::File.realpath(self.class.temp_dir)
       @path = ::File.realpath(params.permit(:file)[:file], base_path)
-      unless @path.start_with?(base_path)
-        raise ViewComponent::SystemTestControllerNefariousPathError
-      end
+      raise ViewComponent::SystemTestControllerNefariousPathError unless @path.start_with?(base_path)
     end
   end
 end

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Add template annotations for components with `def call`.
+
+    *Joel Hawksley*
+
 ## 4.0.0.alpha5
 
 * BREAKING: `config.view_component_path` is now `config.generate.path`, as components have long since been able to exist in any directory.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -170,6 +170,10 @@ module ViewComponent
           end
         end
 
+        if ActionView::Base.annotate_rendered_view_with_filenames && current_template.inline_call? && request.format == :html
+          value = "<!-- BEGIN #{self.class.identifier} -->".html_safe + value + "<!-- END #{self.class.identifier} -->".html_safe
+        end
+
         value
       else
         ""

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -171,7 +171,8 @@ module ViewComponent
         end
 
         if ActionView::Base.annotate_rendered_view_with_filenames && current_template.inline_call? && request.format == :html
-          value = "<!-- BEGIN #{self.class.identifier} -->".html_safe + value + "<!-- END #{self.class.identifier} -->".html_safe
+          identifier = defined?(Rails.root) ? self.class.identifier.sub("#{Rails.root}/", "") : self.class.identifier
+          value = "<!-- BEGIN #{identifier} -->".html_safe + value + "<!-- END #{identifier} -->".html_safe
         end
 
         value

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -131,6 +131,12 @@ class RenderingTest < ViewComponent::TestCase
     end
   end
 
+  def test_render_empty_component_with_annotations
+    render_inline(EmptyComponent.new)
+
+    assert_includes rendered_content, "empty_component.rb"
+  end
+
   def test_renders_slim_template
     render_inline(SlimComponent.new(message: "bar")) { "foo" }
 


### PR DESCRIPTION
Per @dmarcoux, inline_call components do not render template annotations due to their lack of template.

This change adds functionality to mimic Rails' built-in behavior for inline_call components.

Closes #1301