### PR TITLE
Move component_parent_class to generator configuration namespace

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 6
 
 ## main
 
-* BREAKING: `config.component_parent_class` is now `config.generate.component_parent_class`, moving the generator-specific option to generator configruation namespace.
+* BREAKING: `config.component_parent_class` is now `config.generate.component_parent_class`, moving the generator-specific option to the generator configuration namespace.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* BREAKING: `config.component_parent_class` is now `config.generate.component_parent_class`, moving the generator-specific option to generator configruation namespace.
+
+    *Joel Hawksley*
+
 * Add template annotations for components with `def call`.
 
     *Joel Hawksley*

--- a/lib/generators/view_component/component/component_generator.rb
+++ b/lib/generators/view_component/component/component_generator.rb
@@ -43,7 +43,7 @@ module ViewComponent
       def parent_class
         return options[:parent] if options[:parent]
 
-        ViewComponent::Base.config.component_parent_class || default_parent_class
+        ViewComponent::Base.config.generate.component_parent_class || default_parent_class
       end
 
       def initialize_signature?

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -405,16 +405,6 @@ module ViewComponent
     # configured on a per-test basis using `with_controller_class`.
     #
 
-    # Parent class for generated components
-    #
-    # ```ruby
-    # config.view_component.component_parent_class = "MyBaseComponent"
-    # ```
-    #
-    # Defaults to nil. If this is falsy, generators will use
-    # "ApplicationComponent" if defined, "ViewComponent::Base" otherwise.
-    #
-
     # Configuration for generators.
     #
     # All options under this namespace default to `false` unless otherwise
@@ -472,6 +462,18 @@ module ViewComponent
     # ```
     #
     #  Defaults to `false`.
+    #
+    # #### component_parent_class
+    #
+    # Parent class for generated components
+    #
+    # ```ruby
+    # config.view_component.generate.component_parent_class = "MyBaseComponent"
+    # ```
+    #
+    # Defaults to nil. If this is falsy, generators will use
+    # "ApplicationComponent" if defined, "ViewComponent::Base" otherwise.
+    #
 
     class << self
       # The file path of the component Ruby file.

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -16,7 +16,6 @@ module ViewComponent
           preview_controller: "ViewComponentsController",
           preview_route: "/rails/view_components",
           instrumentation_enabled: false,
-          component_parent_class: nil,
           show_previews: Rails.env.development? || Rails.env.test?,
           preview_paths: default_preview_paths,
           test_controller: "ApplicationController",
@@ -114,12 +113,6 @@ module ViewComponent
       # @return [Boolean]
       # Whether ActiveSupport notifications are enabled.
       # Defaults to `false`.
-
-      # @!attribute component_parent_class
-      # @return [String]
-      # The parent class from which generated components will inherit.
-      # Defaults to `nil`. If this is falsy, generators will use
-      # `"ApplicationComponent"` if defined, `"ViewComponent::Base"` otherwise.
 
       # @!attribute show_previews
       # @return [Boolean]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -98,7 +98,7 @@ def with_custom_component_path(new_value, &block)
 end
 
 def with_custom_component_parent_class(new_value, &block)
-  with_config_option(:component_parent_class, new_value, &block)
+  with_generate_option(:component_parent_class, new_value, &block)
 end
 
 def with_application_component_class


### PR DESCRIPTION
### What are you trying to accomplish?

`config.component_parent_class` is only used for generators. It should be in the `generate` namespace!