### PR TITLE
v4 regression when using Turbo::StreamsHelper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ nav_order: 6
 
     *Joel Hawksley*
 
+* Add support for including Turbo::StreamsHelper
+
+    *Stephen Nelson*
+
 ## 4.0.0.alpha5
 
 * BREAKING: `config.view_component_path` is now `config.generate.path`, as components have long since been able to exist in any directory.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -97,6 +97,9 @@ module ViewComponent
     # HTML construction methods
     delegate :output_buffer, :lookup_context, :view_renderer, :view_flow, to: :helpers
 
+    # For Turbo::StreamsHelper
+    delegate :formats, :formats=, to: :helpers
+
     # For Content Security Policy nonces
     delegate :content_security_policy_nonce, to: :helpers
 

--- a/test/sandbox/app/components/turbo_stream_component.html.erb
+++ b/test/sandbox/app/components/turbo_stream_component.html.erb
@@ -1,1 +1,1 @@
-<%= helpers.turbo_stream.update 'area1' do %><span>Hello, world!</span><% end %>
+<%= turbo_stream.update 'area1' do %><span>Hello, world!</span><% end %>

--- a/test/sandbox/app/components/turbo_stream_component.rb
+++ b/test/sandbox/app/components/turbo_stream_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class TurboStreamComponent < ViewComponent::Base
+  include Turbo::StreamsHelper
 end


### PR DESCRIPTION
### What are you trying to accomplish?

We have code that includes `Turbo::StreamsHelper` in our components and calls `<%= turbo_stream.<verb> %>` in the frontend. This may not be a supported use-case in v4 but I think it's worth a call-out as a breaking change.

Alternatively, consider delegating `format` to helpers.

This PR demonstrates the breaking change by changing the existing turbo stream component.
