### PR TITLE
[v4] BREAKING: Move previews-related configuration to separate namespace

### DIFF
--- a/app/controllers/concerns/view_component/preview_actions.rb
+++ b/app/controllers/concerns/view_component/preview_actions.rb
@@ -47,7 +47,7 @@ module ViewComponent
 
     # :doc:
     def default_preview_layout
-      ViewComponent::Base.config.default_preview_layout
+      ViewComponent::Base.config.previews.default_layout
     end
 
     # :doc:
@@ -99,7 +99,7 @@ module ViewComponent
     end
 
     def prepend_preview_examples_view_path
-      prepend_view_path(ViewComponent::Base.preview_paths)
+      prepend_view_path(ViewComponent::Base.previews.paths)
     end
   end
 end

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ nav_order: 6
 
     *Joel Hawksley*
 
+* BREAKING: Move previews-related configuration (`enabled`, `route`, `paths`, `default_layout`, `controller`) to under `previews` namespace.
+
+    *Joel Hawksley*
+
 * Add template annotations for components with `def call`.
 
     *Joel Hawksley*

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,6 +14,15 @@ nav_order: 3
 
 Returns the current config.
 
+### `.identifier` → [String]
+
+The file path of the component Ruby file.
+
+### `.new(...)`
+
+Redefine `new` so we can pre-allocate instance variables to optimize
+for Ruby object shapes.
+
 ### `.sidecar_files(extensions)`
 
 Find sidecar files for the given extensions.
@@ -37,7 +46,7 @@ end
 
 Whether trailing whitespace will be stripped before compilation.
 
-### `.with_collection(collection, **args)`
+### `.with_collection(collection, spacer_component: nil, **args)`
 
 Render a component for each element in a collection ([documentation](/guide/collections)):
 
@@ -73,18 +82,22 @@ Whether `content` has been passed to the component.
 The current controller. Use sparingly as doing so introduces coupling
 that inhibits encapsulation & reuse, often making testing difficult.
 
+### `#current_template`
+
+Returns the value of attribute current_template.
+
 ### `#helpers` → [ActionView::Base]
 
 A proxy through which to access helpers. Use sparingly as doing so introduces
 coupling that inhibits encapsulation & reuse, often making testing difficult.
 
-### `#output_preamble` → [String]
-
-Optional content to be returned before the rendered template.
-
 ### `#output_postamble` → [String]
 
 Optional content to be returned after the rendered template.
+
+### `#output_preamble` → [String]
+
+Optional content to be returned before the rendered template.
 
 ### `#render?` → [Boolean]
 
@@ -142,12 +155,6 @@ so helpers, etc work as expected.
 
 ## Configuration
 
-### `.component_parent_class`
-
-The parent class from which generated components will inherit.
-Defaults to `nil`. If this is falsy, generators will use
-`"ApplicationComponent"` if defined, `"ViewComponent::Base"` otherwise.
-
 ### `#config`
 
 Returns the value of attribute config.
@@ -159,18 +166,18 @@ class so that config options remain accessible before the rest of
 ViewComponent has loaded. Defaults to an instance of ViewComponent::Config
 with all other documented defaults set.
 
-### `.default_preview_layout`
-
-A custom default layout used for the previews index page and individual
-previews.
-Defaults to `nil`. If this is falsy, `"component_preview"` is used.
-
 ### `.generate`
 
 The subset of configuration options relating to generators.
 
 All options under this namespace default to `false` unless otherwise
 stated.
+
+#### `#path`
+
+Where to put generated components. Defaults to `app/components`:
+
+    config.view_component.generate.path = "lib/components"
 
 #### `#sidecar`
 
@@ -183,6 +190,12 @@ Always generate a component with a sidecar directory:
 Always generate a Stimulus controller alongside the component:
 
     config.view_component.generate.stimulus_controller = true
+
+#### `#typescript`
+
+Generate TypeScript files instead of JavaScript files:
+
+    config.view_component.generate.typescript = true
 
 #### `#locale`
 
@@ -213,33 +226,54 @@ Path to generate preview:
 
 Required when there is more than one path defined in preview_paths.
 Defaults to `""`. If this is blank, the generator will use
-`ViewComponent.config.preview_paths` if defined,
+`ViewComponent.config.previews.paths` if defined,
 `"test/components/previews"` otherwise
+
+#### `#use_component_path_for_rspec_tests`
+
+Whether to use `config.generate.path` when generating new
+RSpec component tests:
+
+    config.view_component.generate.use_component_path_for_rspec_tests = true
+
+When set to `true`, the generator will use the `path` to
+decide where to generate the new RSpec component test.
+For example, if the `path` is
+`app/views/components`, then the generator will create a new spec file
+in `spec/views/components/` rather than the default `spec/components/`.
 
 ### `.instrumentation_enabled`
 
 Whether ActiveSupport notifications are enabled.
 Defaults to `false`.
 
-### `.preview_controller`
+### `.previews`
 
-The controller used for previewing components.
-Defaults to `ViewComponentsController`.
+The subset of configuration options relating to previews.
 
-### `.preview_paths`
+#### `#controller`
 
-The locations in which component previews will be looked up.
-Defaults to `['test/components/previews']` relative to your Rails root.
+The controller used for previewing components. Defaults to `ViewComponentsController`:
 
-### `.preview_route`
+    config.view_component.previews.controller = "MyPreviewController"
 
-The entry route for component previews.
-Defaults to `"/rails/view_components"`.
+#### `#route`
 
-### `.show_previews`
+The entry route for component previews. Defaults to `/rails/view_components`:
 
-Whether component previews are enabled.
-Defaults to `true` in development and test environments.
+    config.view_component.previews.route = "/my_previews"
+
+#### `#enabled`
+
+Whether component previews are enabled. Defaults to `true` in development and test environments:
+
+    config.view_component.previews.enabled = false
+
+#### `#default_layout`
+
+A custom default layout used for the previews index page and individual previews. Defaults to `false`:
+
+    config.view_component.previews.default_layout = false
 
 ### `.test_controller`
 
@@ -249,7 +283,7 @@ Defaults to `ApplicationController`.
 
 ## ViewComponent::TestHelpers
 
-### `#render_in_view_context(*args, &block)`
+### `#render_in_view_context(...)`
 
 Execute the given block in the view context (using `instance_exec`).
 Internally sets `page` to be a `Capybara::Node::Simple`, allowing for
@@ -263,7 +297,7 @@ end
 assert_text("Hello, World!")
 ```
 
-### `#render_inline(component, **args, &block)` → [Nokogiri::HTML]
+### `#render_inline(component, **args, &block)` → [Nokogiri::HTML5]
 
 Render a component inline. Internally sets `page` to be a `Capybara::Node::Simple`,
 allowing for Capybara assertions to be used:
@@ -273,7 +307,7 @@ render_inline(MyComponent.new)
 assert_text("Hello, World!")
 ```
 
-### `#render_preview(name, from: __vc_test_helpers_preview_class, params: {})` → [Nokogiri::HTML]
+### `#render_preview(name, from: __vc_test_helpers_preview_class, params: {})` → [Nokogiri::HTML5]
 
 Render a preview inline. Internally sets `page` to be a `Capybara::Node::Simple`,
 allowing for Capybara assertions to be used:
@@ -294,6 +328,15 @@ In RSpec, `Preview` is appended to `described_class`.
 
 Returns the result of a render_inline call.
 
+### `#rendered_json`
+
+`JSON.parse`-d component output.
+
+```ruby
+render_inline(MyJsonComponent.new)
+assert_equal(rendered_json["hello"], "world")
+```
+
 ### `#vc_test_controller` → [ActionController::Base]
 
 Access the controller used by `render_inline`:
@@ -312,7 +355,7 @@ Access the request used by `render_inline`:
 
 ```ruby
 test "component does not render in Firefox" do
-  vc_test_request.env["HTTP_USER_AGENT"] = "Mozilla/5.0"
+  request.env["HTTP_USER_AGENT"] = "Mozilla/5.0"
   render_inline(NoFirefoxComponent.new)
   refute_component_rendered
 end
@@ -325,6 +368,16 @@ allowing access to controller-specific methods:
 
 ```ruby
 with_controller_class(UsersController) do
+  render_inline(MyComponent.new)
+end
+```
+
+### `#with_format(*formats)`
+
+Set format of the current request
+
+```ruby
+with_format(:json) do
   render_inline(MyComponent.new)
 end
 ```
@@ -355,7 +408,7 @@ with_request_url("/users/42", method: "POST") do
 end
 ```
 
-### `#with_variant(variant)`
+### `#with_variant(*variants)`
 
 Set the Action Pack request variant for the given block:
 
@@ -387,7 +440,7 @@ To fix this issue, either use the `content` accessor directly or choose a differ
 
 ### `ControllerCalledBeforeRenderError`
 
-`#controller` can't be used during initialization, as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
+`#controller` can't be used before rendering, as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
 
 It's sometimes possible to fix this issue by moving code dependent on `#controller` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void).
 
@@ -413,7 +466,7 @@ See [the collections docs](https://viewcomponent.org/guide/collections.html) for
 
 ### `HelpersCalledBeforeRenderError`
 
-`#helpers` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
+`#helpers` can't be used before rendering as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
 
 It's sometimes possible to fix this issue by moving code dependent on `#helpers` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void).
 
@@ -438,6 +491,12 @@ See [the collections docs](https://viewcomponent.org/guide/collections.html) for
 A preview template for example EXAMPLE doesn't exist.
 
 To fix this issue, create a template for the example.
+
+### `MissingTemplateError`
+
+No templates for COMPONENT match the request DETAIL.
+
+To fix this issue, provide a suitable template.
 
 ### `MultipleInlineTemplatesError`
 
@@ -485,7 +544,7 @@ ViewComponent SystemTest controller attempted to load a file outside of the expe
 
 ### `TranslateCalledBeforeRenderError`
 
-`#translate` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
+`#translate` can't be used before rendering as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
 
 It's sometimes possible to fix this issue by moving code dependent on `#translate` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void).
 

--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -119,16 +119,16 @@ Preview classes live in `test/components/previews`, which can be configured usin
 
 ```ruby
 # config/application.rb
-config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"
+config.view_component.previews.paths << "#{Rails.root}/lib/component_previews"
 ```
 
 ## Previews route
 
-Previews are served from `/rails/view_components` by default. To use a different endpoint, set the `preview_route` option:
+Previews are served from `/rails/view_components` by default. To use a different endpoint, set the `previews.route` option:
 
 ```ruby
 # config/application.rb
-config.view_component.preview_route = "/previews"
+config.view_component.previews.route = "/previews"
 ```
 
 ## Preview templates
@@ -155,7 +155,7 @@ end
 ```
 
 To use a different location for preview templates, pass the `template` argument:
-(the path should be relative to `config.view_component.preview_paths`):
+(the path should be relative to `config.view_component.previews.paths`):
 
 ```ruby
 # test/components/previews/cell_component_preview.rb
@@ -184,11 +184,11 @@ Which enables passing in a value: `/rails/view_components/cell_component/default
 
 ## Configuring preview controller
 
-Extend previews to add authentication, authorization, before actions, etc. using the `preview_controller` option:
+Extend previews to add authentication, authorization, before actions, etc. using the `previews.controller` option:
 
 ```ruby
 # config/application.rb
-config.view_component.preview_controller = "MyPreviewController"
+config.view_component.previews.controller = "MyPreviewController"
 ```
 
 Then include `PreviewActions` in the controller:

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -304,7 +304,7 @@ To use component previews:
 
 ```ruby
 # config/application.rb
-config.view_component.preview_paths << "#{Rails.root}/spec/components/previews"
+config.view_component.previews.paths << "#{Rails.root}/spec/components/previews"
 ```
 
 ## Component system tests

--- a/lib/generators/view_component/preview/preview_generator.rb
+++ b/lib/generators/view_component/preview/preview_generator.rb
@@ -10,7 +10,7 @@ module ViewComponent
       check_class_collision suffix: "ComponentPreview"
 
       def create_preview_file
-        preview_paths = ViewComponent::Base.config.preview_paths
+        preview_paths = ViewComponent::Base.config.previews.paths
         optional_path = options[:preview_path]
         return if preview_paths.count > 1 && optional_path.blank?
 

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -13,13 +13,9 @@ module ViewComponent
       def defaults
         ActiveSupport::OrderedOptions.new.merge!({
           generate: default_generate_options,
-          preview_controller: "ViewComponentsController",
-          preview_route: "/rails/view_components",
+          previews: default_previews_options,
           instrumentation_enabled: false,
-          show_previews: Rails.env.development? || Rails.env.test?,
-          preview_paths: default_preview_paths,
-          test_controller: "ApplicationController",
-          default_preview_layout: nil
+          test_controller: "ApplicationController"
         })
       end
 
@@ -83,7 +79,7 @@ module ViewComponent
       #
       # Required when there is more than one path defined in preview_paths.
       # Defaults to `""`. If this is blank, the generator will use
-      # `ViewComponent.config.preview_paths` if defined,
+      # `ViewComponent.config.previews.paths` if defined,
       # `"test/components/previews"` otherwise
       #
       # #### `#use_component_path_for_rspec_tests`
@@ -99,42 +95,45 @@ module ViewComponent
       # `app/views/components`, then the generator will create a new spec file
       # in `spec/views/components/` rather than the default `spec/components/`.
 
-      # @!attribute preview_controller
-      # @return [String]
-      # The controller used for previewing components.
-      # Defaults to `ViewComponentsController`.
-
-      # @!attribute preview_route
-      # @return [String]
-      # The entry route for component previews.
-      # Defaults to `"/rails/view_components"`.
+      # @!attribute previews
+      # @return [ActiveSupport::OrderedOptions]
+      # The subset of configuration options relating to previews.
+      #
+      # #### `#controller`
+      #
+      # The controller used for previewing components. Defaults to `ViewComponentsController`:
+      #
+      #     config.view_component.previews.controller = "MyPreviewController"
+      #
+      # #### `#route`
+      #
+      # The entry route for component previews. Defaults to `/rails/view_components`:
+      #
+      #     config.view_component.previews.route = "/my_previews"
+      #
+      # #### `#enabled`
+      #
+      # Whether component previews are enabled. Defaults to `true` in development and test environments:
+      #
+      #     config.view_component.previews.enabled = false
+      #
+      # #### `#default_layout`
+      #
+      # A custom default layout used for the previews index page and individual previews. Defaults to `false`:
+      #
+      #     config.view_component.previews.default_layout = false
+      #
 
       # @!attribute instrumentation_enabled
       # @return [Boolean]
       # Whether ActiveSupport notifications are enabled.
       # Defaults to `false`.
 
-      # @!attribute show_previews
-      # @return [Boolean]
-      # Whether component previews are enabled.
-      # Defaults to `true` in development and test environments.
-
-      # @!attribute preview_paths
-      # @return [Array<String>]
-      # The locations in which component previews will be looked up.
-      # Defaults to `['test/components/previews']` relative to your Rails root.
-
       # @!attribute test_controller
       # @return [String]
       # The controller used for testing components.
       # Can also be configured on a per-test basis using `#with_controller_class`.
       # Defaults to `ApplicationController`.
-
-      # @!attribute default_preview_layout
-      # @return [String]
-      # A custom default layout used for the previews index page and individual
-      # previews.
-      # Defaults to `nil`. If this is falsy, `"component_preview"` is used.
 
       def default_preview_paths
         (default_rails_preview_paths + default_rails_engines_preview_paths).uniq
@@ -164,6 +163,16 @@ module ViewComponent
         options = ActiveSupport::OrderedOptions.new(false)
         options.preview_path = ""
         options.path = "app/components"
+        options
+      end
+
+      def default_previews_options
+        options = ActiveSupport::OrderedOptions.new(false)
+        options.controller = "ViewComponentsController"
+        options.route = "/rails/view_components"
+        options.enabled = Rails.env.development? || Rails.env.test?
+        options.default_layout = false
+        options.paths = default_preview_paths
         options
       end
     end

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -167,7 +167,7 @@ module ViewComponent
       end
 
       def default_previews_options
-        options = ActiveSupport::OrderedOptions.new(false)
+        options = ActiveSupport::OrderedOptions.new
         options.controller = "ViewComponentsController"
         options.route = "/rails/view_components"
         options.enabled = Rails.env.development? || Rails.env.test?

--- a/lib/view_component/preview.rb
+++ b/lib/view_component/preview.rb
@@ -102,7 +102,7 @@ module ViewComponent # :nodoc:
       private
 
       def preview_paths
-        Base.preview_paths
+        Base.previews.paths
       end
     end
   end

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -73,7 +73,7 @@ module ViewComponent
     # @param params [Hash] Parameters to be passed to the preview.
     # @return [Nokogiri::HTML5]
     def render_preview(name, from: __vc_test_helpers_preview_class, params: {})
-      previews_controller = __vc_test_helpers_build_controller(Rails.application.config.view_component.preview_controller.constantize)
+      previews_controller = __vc_test_helpers_build_controller(Rails.application.config.view_component.previews.controller.constantize)
 
       # From what I can tell, it's not possible to overwrite all request parameters
       # at once, so we set them individually here.

--- a/test/sandbox/config/application.rb
+++ b/test/sandbox/config/application.rb
@@ -41,8 +41,8 @@ module Sandbox
 
     # Prepare test_set_no_duplicate_autoload_paths
     config.autoload_paths.push("#{config.root}/my/components/previews")
-    config.view_component.preview_paths << "#{config.root}/my/components/previews"
-    config.view_component.preview_paths << "#{Rails.root}/lib/component_previews"
+    config.view_component.previews.paths << "#{config.root}/my/components/previews"
+    config.view_component.previews.paths << "#{Rails.root}/lib/component_previews"
   end
 end
 

--- a/test/sandbox/test/config_test.rb
+++ b/test/sandbox/test/config_test.rb
@@ -10,10 +10,10 @@ module ViewComponent
 
     def test_defaults_are_correct
       assert_equal @config.generate, {preview_path: "", path: "app/components"}
-      assert_equal @config.preview_controller, "ViewComponentsController"
-      assert_equal @config.preview_route, "/rails/view_components"
+      assert_equal @config.previews.controller, "ViewComponentsController"
+      assert_equal @config.previews.route, "/rails/view_components"
       assert_equal @config.instrumentation_enabled, false
-      assert_equal @config.preview_paths, ["#{Rails.root}/test/components/previews"]
+      assert_equal @config.previews.paths, ["#{Rails.root}/test/components/previews"]
     end
 
     def test_all_methods_are_documented

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -649,8 +649,10 @@ class IntegrationTest < ActionDispatch::IntegrationTest
       config_entrypoints.first.yield_self do |config|
         {
           generate: config.generate.dup.tap { |c| c.sidecar = true },
-          preview_controller: "SomeOtherController",
-          preview_route: "/some/other/route"
+          previews: config.previews.dup.tap { |c|
+            c.controller = "SomeOtherController"
+            c.route = "/some/other/route"
+          }
         }.each do |option, value|
           with_config_option(option, value, config_entrypoint: config) do
             assert_equal(config.public_send(option), config_entrypoints.second.public_send(option))

--- a/test/test_engine/test/config_test.rb
+++ b/test/test_engine/test/config_test.rb
@@ -10,11 +10,11 @@ module ViewComponent
 
     def test_defaults_are_correct
       assert_equal @config.generate, {preview_path: "", path: "app/components"}
-      assert_equal @config.preview_controller, "ViewComponentsController"
-      assert_equal @config.preview_route, "/rails/view_components"
+      assert_equal @config.previews.controller, "ViewComponentsController"
+      assert_equal @config.previews.route, "/rails/view_components"
       assert_equal @config.instrumentation_enabled, false
-      assert_equal @config.show_previews, true
-      assert_equal @config.preview_paths, ["#{TestEngine::Engine.root}/test/components/previews"]
+      assert_equal @config.previews.enabled, true
+      assert_equal @config.previews.paths, ["#{TestEngine::Engine.root}/test/components/previews"]
     end
   end
 end

--- a/test/test_engine/test_helper.rb
+++ b/test/test_engine/test_helper.rb
@@ -30,6 +30,10 @@ ensure
   config_entrypoint.public_send(:"#{option_name}=", old_value)
 end
 
-def with_preview_paths(new_value, &block)
-  with_config_option(:preview_paths, new_value, &block)
+def with_preview_paths(new_value, config_entrypoint: TestEngine::Engine.config.view_component, &block)
+  old_value = config_entrypoint.previews.paths
+  config_entrypoint.previews.paths = new_value
+  yield
+ensure
+  config_entrypoint.previews.paths = old_value
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,26 +70,26 @@ end
 # @yield Test code to run
 # @return [void]
 def with_preview_paths(new_value, &block)
-  with_config_option(:preview_paths, new_value, &block)
+  with_previews_option(:paths, new_value, &block)
 end
 
-def with_preview_route(new_value)
-  old_value = Rails.application.config.view_component.preview_route
-  Rails.application.config.view_component.preview_route = new_value
+def with_preview_route(new_value, &block)
+  old_value = Rails.application.config.view_component.previews.route
+  Rails.application.config.view_component.previews.route = new_value
   app.reloader.reload!
   yield
 ensure
-  Rails.application.config.view_component.preview_route = old_value
+  Rails.application.config.view_component.previews.route = old_value
   app.reloader.reload!
 end
 
-def with_preview_controller(new_value)
-  old_value = Rails.application.config.view_component.preview_controller
-  Rails.application.config.view_component.preview_controller = new_value
+def with_preview_controller(new_value, &block)
+  old_value = Rails.application.config.view_component.previews.controller
+  Rails.application.config.view_component.previews.controller = new_value
   app.reloader.reload!
   yield
 ensure
-  Rails.application.config.view_component.preview_controller = old_value
+  Rails.application.config.view_component.previews.controller = old_value
   app.reloader.reload!
 end
 
@@ -114,6 +114,14 @@ def with_generate_option(config_option, value)
   yield
 ensure
   Rails.application.config.view_component.generate[config_option] = old_value
+end
+
+def with_previews_option(config_option, value)
+  old_value = Rails.application.config.view_component.previews[config_option]
+  Rails.application.config.view_component.previews[config_option] = value
+  yield
+ensure
+  Rails.application.config.view_component.previews[config_option] = old_value
 end
 
 def with_instrumentation_enabled_option(value)
@@ -172,7 +180,7 @@ def modify_file(file, content)
 end
 
 def with_default_preview_layout(layout, &block)
-  with_config_option(:default_preview_layout, layout, &block)
+  with_previews_option(:default_layout, layout, &block)
 end
 
 def with_compiler_development_mode(mode)


### PR DESCRIPTION
This PR isolates the previews-related configuration into its own namespace for better organization and comprehension by consumers.