### PR TITLE
Re-add rake tasks to bundled gem

### DIFF
--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
     "docs/CHANGELOG.md",
     "lib/rails/**/*.rb",
     "lib/view_component.rb",
-    "lib/view_component/**/*.rb"
+    "lib/view_component/**/*"
   ]
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
### What are you trying to accomplish?

Because of a change to the gemspec in commit 10a93e96c65c30cd12df912996fd17ceec87a9f8, the Rake tasks were no longer matched by the glob pattern.

Fixes #2318.

### What approach did you choose and why?

We now match *all* files within `lib/view_component`. The `.rake` file in question is the only non-rb files, so there are no unexpected side effects here, that would require a more specific pattern.
