### PR TITLE
Remove .test_controller in favor of vc_test_controller_class

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* BREAKING: Remove `config.test_controller` in favor of `vc_test_controller_class` test helper method.
+
+    *Joel Hawksley*
+
 * BREAKING: `config.component_parent_class` is now `config.generate.component_parent_class`, moving the generator-specific option to the generator configuration namespace.
 
     *Joel Hawksley*

--- a/docs/api.md
+++ b/docs/api.md
@@ -349,6 +349,16 @@ test "logged out user sees login link" do
 end
 ```
 
+### `#vc_test_controller_class`
+
+Set the controller used by `render_inline`:
+
+```ruby
+def vc_test_controller_class
+  MyTestController
+end
+```
+
 ### `#vc_test_request` → [ActionDispatch::TestRequest]
 
 Access the request used by `render_inline`:

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -169,10 +169,20 @@ end
 Since 2.27.0
 {: .label }
 
-Component tests assume the existence of an `ApplicationController` class, which can be configured globally using the `test_controller` option:
+Component tests assume the existence of an `ApplicationController` class. To set the controller for a test file, define `vc_test_controller_class`:
 
 ```ruby
-config.view_component.test_controller = "BaseController"
+class ExampleComponentTest < ViewComponent::TestCase
+  def vc_test_controller_class
+    PublicController
+  end
+
+  def test_component_in_public_controller
+    render_inline ExampleComponent.new
+
+    assert_text "foo"
+  end
+end
 ```
 
 To configure the controller used for a test case, use `with_controller_class` from `ViewComponent::TestHelpers`.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -400,16 +400,6 @@ module ViewComponent
       end
     end
 
-    # Set the controller used for testing components:
-    #
-    # ```ruby
-    # config.view_component.test_controller = "MyTestController"
-    # ```
-    #
-    # Defaults to `nil`. If this is falsy, `"ApplicationController"` is used. Can also be
-    # configured on a per-test basis using `with_controller_class`.
-    #
-
     # Configuration for generators.
     #
     # All options under this namespace default to `false` unless otherwise

--- a/lib/view_component/config.rb
+++ b/lib/view_component/config.rb
@@ -14,8 +14,7 @@ module ViewComponent
         ActiveSupport::OrderedOptions.new.merge!({
           generate: default_generate_options,
           previews: default_previews_options,
-          instrumentation_enabled: false,
-          test_controller: "ApplicationController"
+          instrumentation_enabled: false
         })
       end
 

--- a/lib/view_component/test_helpers.rb
+++ b/lib/view_component/test_helpers.rb
@@ -233,7 +233,20 @@ module ViewComponent
     #
     # @return [ActionController::Base]
     def vc_test_controller
-      @vc_test_controller ||= __vc_test_helpers_build_controller(Base.test_controller.constantize)
+      @vc_test_controller ||= __vc_test_helpers_build_controller(vc_test_controller_class)
+    end
+
+    # Set the controller used by `render_inline`:
+    #
+    # ```ruby
+    # def vc_test_controller_class
+    #   MyTestController
+    # end
+    # ```
+    def vc_test_controller_class
+      return @__vc_test_controller_class if defined?(@__vc_test_controller_class)
+
+      defined?(ApplicationController) ? ApplicationController : ActionController::Base
     end
 
     # Access the request used by `render_inline`:

--- a/test/sandbox/config/environments/test.rb
+++ b/test/sandbox/config/environments/test.rb
@@ -30,7 +30,6 @@ Sandbox::Application.configure do
 
   config.view_component.show_previews = true
   config.view_component.instrumentation_enabled = true
-  config.view_component.test_controller = "IntegrationExamplesController"
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/test/sandbox/test/base_test.rb
+++ b/test/sandbox/test/base_test.rb
@@ -157,7 +157,7 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     include ViewComponent::Configurable
 
     configure do |config|
-      config.view_component.test_controller = "AnotherController"
+      config.view_component.instrumentation_enabled = false
     end
 
     class SomeComponent < ViewComponent::Base
@@ -169,7 +169,7 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     include ViewComponent::Configurable
 
     configure do |config|
-      config.view_component.test_controller = "AnotherController"
+      config.view_component.instrumentation_enabled = false
     end
 
     class SomeComponent < ViewComponent::Base
@@ -180,7 +180,7 @@ class ViewComponent::Base::UnitTest < Minitest::Test
     include ActiveSupport::Configurable
 
     configure do |config|
-      config.view_component = ActiveSupport::InheritableOptions[test_controller: "AnotherController"]
+      config.view_component = ActiveSupport::InheritableOptions[instrumentation_enabled: false]
     end
 
     include ViewComponent::Configurable
@@ -190,10 +190,9 @@ class ViewComponent::Base::UnitTest < Minitest::Test
   end
 
   def test_uses_module_configuration
-    # We override this ourselves in test/sandbox/config/environments/test.rb.
-    assert_equal "IntegrationExamplesController", TestModuleWithoutConfig::SomeComponent.test_controller
-    assert_equal "AnotherController", TestModuleWithConfig::SomeComponent.test_controller
-    assert_equal "AnotherController", TestAlreadyConfigurableModule::SomeComponent.test_controller
-    assert_equal "AnotherController", TestAlreadyConfiguredModule::SomeComponent.test_controller
+    assert_equal true, TestModuleWithoutConfig::SomeComponent.instrumentation_enabled
+    assert_equal false, TestModuleWithConfig::SomeComponent.instrumentation_enabled
+    assert_equal false, TestAlreadyConfigurableModule::SomeComponent.instrumentation_enabled
+    assert_equal false, TestAlreadyConfiguredModule::SomeComponent.instrumentation_enabled
   end
 end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -17,6 +17,10 @@ class RenderingTest < ViewComponent::TestCase
     @vc_test_request = nil
   end
 
+  def vc_test_controller_class
+    IntegrationExamplesController
+  end
+
   def test_render_inline
     render_inline(MyComponent.new)
 
@@ -30,7 +34,7 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.__vc_ensure_compiled
 
     with_instrumentation_enabled_option(false) do
-      assert_allocations({"3.5" => 75, "3.4" => 80, "3.3" => 82, "3.2" => 81}) do
+      assert_allocations({"3.5" => 75, "3.4" => 73, "3.3" => 82, "3.2" => 81}) do
         render_inline(MyComponent.new)
       end
     end


### PR DESCRIPTION
ViewComponent tests should not be beholden to application configuration, but instead should be configured in the test setup. I've removed `config.test_controller` and added `vc_test_controller_class` as such.