### PR TITLE
Include .tt files in gem.

### DIFF
--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
     "app/**/*",
     "docs/CHANGELOG.md",
     "lib/rails/**/*.rb",
+    "lib/rails/**/*.tt",
     "lib/view_component.rb",
     "lib/view_component/**/*"
   ]


### PR DESCRIPTION
### What are you trying to accomplish?

Make generators work again.

### What approach did you choose and why?

Since the generators work differently now (using .tt files now) they weren't packed in the gem anymore. I added a glob in the .gemspec to include files matching `lib/rails/**/*.tt`.
I could've just loosened the glob that includes all ruby files in `lib/rails` but I voted against the "include all" option since I assume that there must be a reason for being restrictive here.

### Anything you want to highlight for special attention from reviewers?

This ain't covered by tests and it seems either nobody is using generators on the latest version (3.23.1) except me. Otherwise I would've spotted a Github issue I guess.
