### PR TITLE
Reduce allocations in Slotable#register_default_slots

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Reduce string allocations during compilation.
+
+    *Jonathan del Strother*
+
 ## 3.23.2
 
 * Include .tt files in published gem. Fixes templates not being available when using generators.

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -271,7 +271,8 @@ module ViewComponent
       # Called by the compiler, as instance methods are not defined when slots are first registered
       def register_default_slots
         registered_slots.each do |slot_name, config|
-          config[:default_method] = instance_methods.find { |method_name| method_name == :"default_#{slot_name}" }
+          default_method_name = :"default_#{slot_name}"
+          config[:default_method] = instance_methods.find { |method_name| method_name == default_method_name }
 
           registered_slots[slot_name] = config
         end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -19,9 +19,9 @@ class RenderingTest < ViewComponent::TestCase
       if Rails.version.to_f < 8.0
         {"3.3.8" => 124, "3.3.0" => 140, "3.2.8" => 122, "3.1.7" => 122, "3.0.7" => 131}
       elsif Rails.version.split(".").first(2).map(&:to_i) == [8, 0]
-        {"3.5.0" => 117, "3.4.4" => 121, "3.3.8" => 133}
+        {"3.5.0" => 117, "3.4.4" => 121, "3.4.3" => 121, "3.3.8" => 133}
       else
-        {"3.4.4" => 119}
+        {"3.4.4" => 119, "3.4.3" => 119}
       end
 
     assert_allocations(**allocations) do


### PR DESCRIPTION
While profiling something unrelated I noticed a lot of unnecessary string allocations in Slotable#register_default_slots. How about this change to move it out of the `instance_methods` loop?