### PR TITLE
Reduce allocations in #with_collection

### DIFF
--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -665,7 +665,7 @@ module ViewComponent
 
       # @private
       def collection_counter_parameter
-        :"#{collection_parameter}_counter"
+        @collection_counter_parameter ||= :"#{collection_parameter}_counter"
       end
 
       # @private

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -675,7 +675,7 @@ module ViewComponent
 
       # @private
       def collection_iteration_parameter
-        :"#{collection_parameter}_iteration"
+        @collection_iteration_parameter ||= :"#{collection_parameter}_iteration"
       end
 
       # @private

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -694,8 +694,6 @@ module ViewComponent
         @initialize_parameter_names ||=
           if respond_to?(:attribute_names)
             attribute_names.map(&:to_sym)
-          elsif Rails::VERSION::MAJOR <= 5 && respond_to?(:attribute_types)
-            attribute_types.keys.map(&:to_sym)
           else
             initialize_parameters.map(&:last)
           end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -660,7 +660,7 @@ module ViewComponent
 
       # @private
       def collection_parameter
-        provided_collection_parameter || name && name.demodulize.underscore.chomp("_component").to_sym
+        @provided_collection_parameter ||= name && name.demodulize.underscore.chomp("_component").to_sym
       end
 
       # @private

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -691,11 +691,14 @@ module ViewComponent
       end
 
       def initialize_parameter_names
-        return attribute_names.map(&:to_sym) if respond_to?(:attribute_names)
-
-        return attribute_types.keys.map(&:to_sym) if Rails::VERSION::MAJOR <= 5 && respond_to?(:attribute_types)
-
-        initialize_parameters.map(&:last)
+        @initialize_parameter_names ||=
+          if respond_to?(:attribute_names)
+            attribute_names.map(&:to_sym)
+          elsif Rails::VERSION::MAJOR <= 5 && respond_to?(:attribute_types)
+            attribute_types.keys.map(&:to_sym)
+          else
+            initialize_parameters.map(&:last)
+          end
       end
 
       def initialize_parameters

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -612,6 +612,23 @@ class RenderingTest < ViewComponent::TestCase
     assert_selector("p", text: "Mints counter: 1")
   end
 
+  def test_render_collection_inline_allocations
+    # Stabilize compilation status ahead of testing allocations to simulate rendering
+    # performance with compiled component
+    ViewComponent::CompileCache.cache.delete(ProductComponent)
+    ProductComponent.ensure_compiled
+
+    allocations =
+      { "3.4.4" => 264 }
+
+    products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
+    notice = "On sale"
+    assert_allocations(**allocations) do
+      render_inline(ProductComponent.with_collection(products, notice: notice))
+    end
+    assert_selector("h1", text: "Product", count: 2)
+  end
+
   def test_render_collection_custom_collection_parameter_name
     coupons = [Coupon.new(percent_off: 20), Coupon.new(percent_off: 50)]
     render_inline(ProductCouponComponent.with_collection(coupons))

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -619,7 +619,13 @@ class RenderingTest < ViewComponent::TestCase
     ProductComponent.ensure_compiled
 
     allocations =
-      { "3.4.4" => 121 }
+      if Rails.version.to_f < 8.0
+        {"3.3.8" => 128, "3.2.8" => 125, "3.1.7" => 125, "3.0.7" => 122}
+      elsif Rails.version.split(".").first(2).map(&:to_i) == [8, 0]
+        {"3.5.0" => 121, "3.4.4" => 121, "3.3.8" => 128}
+      else
+        {"3.4.4" => 119}
+      end
 
     products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
     notice = "On sale"

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -619,10 +619,13 @@ class RenderingTest < ViewComponent::TestCase
     ProductComponent.ensure_compiled
 
     allocations =
-      { "3.4.4" => 264 }
+      { "3.4.4" => 211 }
 
     products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
     notice = "On sale"
+    # Ensure any one-time allocations are done
+    render_inline(ProductComponent.with_collection(products, notice: notice))
+
     assert_allocations(**allocations) do
       render_inline(ProductComponent.with_collection(products, notice: notice))
     end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -619,7 +619,7 @@ class RenderingTest < ViewComponent::TestCase
     ProductComponent.ensure_compiled
 
     allocations =
-      { "3.4.4" => 134 }
+      { "3.4.4" => 130 }
 
     products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
     notice = "On sale"

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -619,7 +619,7 @@ class RenderingTest < ViewComponent::TestCase
     ProductComponent.ensure_compiled
 
     allocations =
-      { "3.4.4" => 126 }
+      { "3.4.4" => 121 }
 
     products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
     notice = "On sale"

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -619,7 +619,7 @@ class RenderingTest < ViewComponent::TestCase
     ProductComponent.ensure_compiled
 
     allocations =
-      { "3.4.4" => 211 }
+      { "3.4.4" => 134 }
 
     products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
     notice = "On sale"

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -619,7 +619,7 @@ class RenderingTest < ViewComponent::TestCase
     ProductComponent.ensure_compiled
 
     allocations =
-      { "3.4.4" => 130 }
+      { "3.4.4" => 126 }
 
     products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
     notice = "On sale"


### PR DESCRIPTION
### What are you trying to accomplish?

Speed up rendering when there are lots of calls to `#with_collection` for the same componen, for example when rendering a collection of items, where each item contains a collection of sub-items.

### What approach did you choose and why?

I focused on reducing redundant allocation of string objects. This is because rack-mini-profiler's flamegraph showed me lots of repeats of the same string interpolation.

### Anything you want to highlight for special attention from reviewers?

The code setting the expected number of allocations will have to be updated to include values for all the relevant Ruby and Rails versions.
