### PR TITLE
BREAKING: Allow with_content to override content passed as a block.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,21 @@ nav_order: 6
 
     *Joel Hawksley*
 
+* BREAKING: Allow `with_content` to override content passed as a block. `DuplicateSlotContentError` will no longer be raised.
+
+    For example, slots can now have their content set with `with_content`:
+
+        ```ruby
+        render(ParentSlotComponent.new) do |parent|
+          parent.with_child do |child|
+            child.with_title { "Child Title" }
+            child.with_content("Child Content")
+          end
+        end
+        ```
+
+    *Joel Hawksley*
+
 ## 4.0.0.alpha6
 
 * BREAKING: Remove `config.test_controller` in favor of `vc_test_controller_class` test helper method.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -318,15 +318,16 @@ module ViewComponent
     # The content passed to the component instance as a block.
     #
     # @return [String]
-    def content
+    def content(always_evaluate: true)
       @__vc_content_evaluated = true
-      return @__vc_content if defined?(@__vc_content)
+
+      return @__vc_content if defined?(@__vc_content) && !always_evaluate
 
       @__vc_content =
-        if __vc_render_in_block_provided?
-          view_context.capture(self, &@__vc_render_in_block)
-        elsif __vc_content_set_by_with_content_defined?
+        if __vc_content_set_by_with_content_defined?
           @__vc_content_set_by_with_content
+        elsif __vc_render_in_block_provided?
+          view_context.capture(self, &@__vc_render_in_block)
         end
     end
 

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -5,17 +5,6 @@ module ViewComponent
     end
   end
 
-  class DuplicateSlotContentError < StandardError
-    MESSAGE =
-      "It looks like a block was provided after calling `with_content` on COMPONENT, " \
-      "which means that ViewComponent doesn't know which content to use.\n\n" \
-      "To fix this issue, use either `with_content` or a block."
-
-    def initialize(klass_name)
-      super(MESSAGE.gsub("COMPONENT", klass_name.to_s))
-    end
-  end
-
   class TemplateError < StandardError
     def initialize(errors, templates = nil)
       message = errors.join("\n")

--- a/lib/view_component/slot.rb
+++ b/lib/view_component/slot.rb
@@ -47,10 +47,6 @@ module ViewComponent
 
       view_context = @parent.send(:view_context)
 
-      if defined?(@__vc_content_block) && defined?(@__vc_content_set_by_with_content)
-        raise DuplicateSlotContentError.new(self.class.name)
-      end
-
       @content =
         if __vc_component_instance?
           @__vc_component_instance.__vc_original_view_context = @parent.__vc_original_view_context

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -353,7 +353,7 @@ module ViewComponent
 
     def get_slot(slot_name)
       @__vc_set_slots ||= {}
-      content unless content_evaluated? # ensure content is loaded so slots will be defined
+      content(always_evaluate: false) unless content_evaluated? # ensure content is loaded so slots will be defined
 
       # If the slot is set, return it
       return @__vc_set_slots[slot_name] if @__vc_set_slots[slot_name]


### PR DESCRIPTION
For example, slots can now have their content set with `with_content`:

        ```ruby
        render(ParentSlotComponent.new) do |parent|
          parent.with_child do |child|
            child.with_title { "Child Title" }
            child.with_content("Child Content")
          end
        end
        ```