### PR TITLE
Fix bug where virtual path was not reset, breaking translations outside of components

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -131,6 +131,8 @@ namespace :docs do
 end
 
 task :all_tests do
+  ENV["RAILS_ENV"] = "test"
+
   if ENV["MEASURE_COVERAGE"]
     SimpleCov.start do
       command_name "RSpec-rails#{Rails::VERSION::STRING}-ruby#{RUBY_VERSION}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ nav_order: 6
 
     *Meyric Rawlings*, *Joel Hawksley*
 
+* Fix bug where virtual path was not reset, breaking translations outside of components.
+
+    *Alex Coles*, *Joel Hawksley*
+
 ## 4.0.0.alpha7
 
 * BREAKING: Remove deprecated `use_helper(s)`. Use `include MyHelper` or `helpers.` proxy instead.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -141,6 +141,8 @@ module ViewComponent
         value = nil
 
         @output_buffer.with_buffer do
+          @view_context.instance_variable_set(:@virtual_path, virtual_path)
+
           rendered_template = render_template_for(@__vc_requested_details).to_s
 
           # Avoid allocating new string when output_preamble and output_postamble are blank

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -108,6 +108,7 @@ module ViewComponent
       self.class.__vc_compile(raise_errors: true)
 
       @view_context = view_context
+      old_virtual_path = view_context.instance_variable_get(:@virtual_path)
       self.__vc_original_view_context ||= view_context
 
       @output_buffer = view_context.output_buffer
@@ -160,6 +161,7 @@ module ViewComponent
         ""
       end
     ensure
+      view_context.instance_variable_set(:@virtual_path, old_virtual_path)
       @current_template = old_current_template
     end
 

--- a/lib/view_component/template.rb
+++ b/lib/view_component/template.rb
@@ -98,9 +98,8 @@ module ViewComponent
       @component.silence_redefinition_of_method(call_method_name)
 
       # rubocop:disable Style/EvalWithLocation
-      @component.class_eval <<~RUBY, @path, @lineno - 1
+      @component.class_eval <<~RUBY, @path, @lineno
         def #{call_method_name}
-          @view_context.instance_variable_set(:@virtual_path, virtual_path)
           #{compiled_source}
         end
       RUBY

--- a/test/sandbox/app/views/integration_examples/virtual_path_reset.html.erb
+++ b/test/sandbox/app/views/integration_examples/virtual_path_reset.html.erb
@@ -1,0 +1,7 @@
+<p>Virtual path: <%= @virtual_path %></p>
+<p id="before"><%= t('.message') %></p>
+
+<%= render MyComponent.new %>
+
+<p>Virtual path: <%= @virtual_path %></p>
+<p id="after"><%= t('.message') %></p>

--- a/test/sandbox/config/locales/en.yml
+++ b/test/sandbox/config/locales/en.yml
@@ -15,3 +15,10 @@ en:
 
   editorb_component:
     title: Editorb!
+
+  integration_examples:
+    virtual_path_reset:
+      message: "Hello world!"
+
+  my_component:
+    message: "OH NO! (you shouldn't see me)"

--- a/test/sandbox/config/routes.rb
+++ b/test/sandbox/config/routes.rb
@@ -33,6 +33,7 @@ Sandbox::Application.routes.draw do
   get :unsafe_postamble_component, to: "integration_examples#unsafe_postamble_component"
   get :multiple_formats_component, to: "integration_examples#multiple_formats_component"
   get :slotable_default_override, to: "integration_examples#slotable_default_override"
+  get :virtual_path_reset, to: "integration_examples#virtual_path_reset"
   post :create, to: "integration_examples#create"
   get :turbo_content_type, to: "integration_examples#turbo_content_type"
   post :submit, to: "integration_examples#submit"

--- a/test/sandbox/test/integration_test.rb
+++ b/test/sandbox/test/integration_test.rb
@@ -767,4 +767,11 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     get "/rails/view_components/preview_component/default"
     assert_select "h1", text: "Lorem Ipsum"
   end
+
+  def test_virtual_path_reset
+    get "/virtual_path_reset"
+
+    assert_select "#before", text: "Hello world!"
+    assert_select "#after", text: "Hello world!"
+  end
 end

--- a/test/sandbox/test/translatable_test.rb
+++ b/test/sandbox/test/translatable_test.rb
@@ -184,6 +184,9 @@ class TranslatableTest < ViewComponent::TestCase
   def translate(key, **options)
     component = TranslatableComponent.new
     render_inline(component)
+    component.
+      instance_variable_get(:@view_context).
+      instance_variable_set(:@virtual_path, component.virtual_path)
     component.translate(key, **options)
   end
 end


### PR DESCRIPTION
Closes: https://github.com/ViewComponent/view_component/issues/2359

### What approach did you choose and why?

1) I added logic to reset `virtual_path` to the original value after rendering a component.
2) I moved the logic overriding virtual path to inside `render_in`, making the execution path easier to follow and likely fixing an uncaught edge case where some translations wouldn't work in `call` methods defined by consumers.

I also fixed a small bug where running the tests locally would build the docs.