### PR TITLE
Add link to Scoped CSS in Ruby blog post

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -67,6 +67,7 @@ _Is this page missing a link? Open a PR!_
 - [ViewComponent in the Wild I: building modern Rails frontends](https://evilmartians.com/chronicles/viewcomponent-in-the-wild-building-modern-rails-frontends)
 - [ViewComponent in the Wild II: supercharging your components](https://evilmartians.com/chronicles/viewcomponent-in-the-wild-supercharging-your-components)
 - [Quicktips for ViewComponent with Tailwind CSS/Hotwire](https://railsdesigner.com/viewcomponents-and-tailwindcss/)
+- [Scoped CSS in Ruby](https://blog.mrloop.com/ruby/rails/css/viewcomponent/2025/06/07/scoped-css-in-ruby)
 
 ## Etcetera
 


### PR DESCRIPTION
### What are you trying to accomplish?

Add a blog to the docs showing a technique to scoped CSS within view components

### What approach did you choose and why?

I added a link to `docs/resources.md` file, under the heading 'Articles' that contain links to blogs and articles. The link added to the bottom of list maintaining the order.

### Anything you want to highlight for special attention from reviewers?

Interesting blog on scoping CSS :) 
