### PR TITLE
BREAKING: Allow slots to be redefined, removing RedefinedSlotError

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,11 +22,12 @@ nav_order: 6
 
     class SpecialButtonComponent < ButtonComponent
       renders_many :leading_items, types: {
-        svg: SvgComponent,
         checkbox: CheckboxComponent
       }
     end
     ```
+
+    Where `SpecialButtonComponent` will accept `with_leading_item_icon`, `with_leading_item_svg`, and `with_leading_item_checkbox`.
 
 ## 4.0.0.rc1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,24 @@ nav_order: 6
 
 ## main
 
+* BREAKING: Allow slots to be redefined, removing `RedefinedSlotError`. The following is now possible:
+
+    ```ruby
+    class ButtonComponent < ViewComponent::Base
+      renders_many :leading_items, types: {
+        icon: IconComponent,
+        svg: SvgComponent
+      }
+    end
+
+    class SpecialButtonComponent < ButtonComponent
+      renders_many :leading_items, types: {
+        svg: SvgComponent,
+        checkbox: CheckboxComponent
+      }
+    end
+    ```
+
 ## 4.0.0.rc1
 
 Almost six years after releasing [v1.0.0](https://github.com/ViewComponent/view_component/releases/tag/v1.0.0), we're proud to ship the first release candidate of ViewComponent 4. This release marks a shift towards a Long Term Support model for the project, having reached significant feature maturity. While contributions are always welcome, we're unlikely to accept further breaking changes or major feature additions.

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -125,16 +125,6 @@ module ViewComponent
     end
   end
 
-  class RedefinedSlotError < StandardError
-    MESSAGE =
-      "COMPONENT declares the SLOT_NAME slot multiple times.\n\n" \
-      "To fix this issue, choose a different slot name."
-
-    def initialize(klass_name, slot_name)
-      super(MESSAGE.gsub("COMPONENT", klass_name.to_s).gsub("SLOT_NAME", slot_name.to_s))
-    end
-  end
-
   class ReservedSingularSlotNameError < InvalidSlotNameError
     MESSAGE =
       "COMPONENT declares a slot named SLOT_NAME, which is a reserved word in the ViewComponent framework.\n\n" \

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -311,7 +311,6 @@ module ViewComponent
         __vc_raise_if_slot_name_uncountable(slot_name)
         __vc_raise_if_slot_conflicts_with_call(slot_name)
         __vc_raise_if_slot_ends_with_question_mark(slot_name)
-        __vc_raise_if_slot_registered(slot_name)
       end
 
       def __vc_validate_singular_slot_name(slot_name)
@@ -325,13 +324,6 @@ module ViewComponent
 
         __vc_raise_if_slot_conflicts_with_call(slot_name)
         __vc_raise_if_slot_ends_with_question_mark(slot_name)
-        __vc_raise_if_slot_registered(slot_name)
-      end
-
-      def __vc_raise_if_slot_registered(slot_name)
-        if registered_slots.key?(slot_name)
-          raise RedefinedSlotError.new(name, slot_name)
-        end
       end
 
       def __vc_raise_if_slot_ends_with_question_mark(slot_name)

--- a/test/sandbox/app/components/polymorphic_slot_subclass_component.rb
+++ b/test/sandbox/app/components/polymorphic_slot_subclass_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PolymorphicSlotSubclassComponent < PolymorphicSlotComponent
+  renders_one :header, types: {
+    my: lambda { |&block| content_tag(:div, class: "my", &block) },
+  }
+end

--- a/test/sandbox/app/components/slots_subclass_component.rb
+++ b/test/sandbox/app/components/slots_subclass_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SlotsSubclassComponent < SlotsComponent
+  renders_one :title, ->(&block) do
+    content_tag :h1 do
+      block.call
+    end
+  end
+end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -638,9 +638,12 @@ class SlotableTest < ViewComponent::TestCase
 
   def test_subclass_can_redefine_slot
     render_inline(SlotsSubclassComponent.new(classes: "mt-4")) do |component|
+      # overridden in subclass
       component.with_title do
         "This is my title!"
       end
+
+      # defined in parent class
       component.with_subtitle do
         "This is my subtitle!"
       end
@@ -648,6 +651,21 @@ class SlotableTest < ViewComponent::TestCase
 
     assert_selector("h1", text: "This is my title!")
     assert_selector(".subtitle", text: "This is my subtitle!")
+  end
+
+  def test_subclass_can_redefine_polymorphic_slot_entirely
+    render_inline(PolymorphicSlotSubclassComponent.new) do |component|
+      # Overridden in subclass
+      component.with_header_my { "mine" }
+
+      # defined in parent class
+      component.with_foo_field(class_names: "custom-foo1")
+      component.with_item_bar(class_names: "custom-bar2")
+    end
+
+    assert_selector("div .my", text: "mine")
+    assert_selector("div .foo.custom-foo1")
+    assert_selector("div .bar.custom-bar2")
   end
 
   def test_lambda_slot_content_can_be_provided_via_a_block

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -38,8 +38,6 @@ class SlotableTest < ViewComponent::TestCase
 
     assert_selector(".title", text: "This is my title!")
 
-    assert_selector(".subtitle", text: "This is my subtitle!")
-
     assert_selector(".tab", text: "Tab A")
     assert_selector(".tab", text: "Tab B")
 
@@ -135,15 +133,6 @@ class SlotableTest < ViewComponent::TestCase
         component.with_foo { "Hello!" }
       end
     end
-  end
-
-  def test_sub_component_raise_with_duplicate_slot_name
-    exception =
-      assert_raises ViewComponent::RedefinedSlotError do
-        SlotsComponent.renders_one :title
-      end
-
-    assert_includes exception.message, "declares the title slot multiple times"
   end
 
   def test_sub_component_with_positional_args
@@ -647,6 +636,20 @@ class SlotableTest < ViewComponent::TestCase
     assert_equal 1, PartialHelper::State.calls
   end
 
+  def test_subclass_can_redefine_slot
+    render_inline(SlotsSubclassComponent.new(classes: "mt-4")) do |component|
+      component.with_title do
+        "This is my title!"
+      end
+      component.with_subtitle do
+        "This is my subtitle!"
+      end
+    end
+
+    assert_selector("h1", text: "This is my title!")
+    assert_selector(".subtitle", text: "This is my subtitle!")
+  end
+
   def test_lambda_slot_content_can_be_provided_via_a_block
     render_inline LambdaSlotComponent.new do |component|
       component.with_header(classes: "some-class") do
@@ -655,28 +658,6 @@ class SlotableTest < ViewComponent::TestCase
     end
 
     assert_selector("h1.some-class", text: "This is a header!")
-  end
-
-  def test_raises_error_on_conflicting_slot_names
-    error = assert_raises ViewComponent::RedefinedSlotError do
-      Class.new(ViewComponent::Base) do
-        renders_one :conflicting_item
-        renders_many :conflicting_items
-      end
-    end
-
-    assert_includes error.message, "conflicting_item slot multiple times"
-  end
-
-  def test_raises_error_on_conflicting_slot_names_in_reverse_order
-    error = assert_raises ViewComponent::RedefinedSlotError do
-      Class.new(ViewComponent::Base) do
-        renders_many :conflicting_items
-        renders_one :conflicting_item
-      end
-    end
-
-    assert_includes error.message, "conflicting_items slot multiple times"
   end
 
   def test_slots_dont_interfere_with_content


### PR DESCRIPTION
The following is now possible:

```ruby
class ButtonComponent < ViewComponent::Base
  renders_many :leading_items, types: {
    icon: IconComponent,
    svg: SvgComponent
  }
end

class SpecialButtonComponent < ButtonComponent
  renders_many :leading_items, types: {
    svg: SvgComponent,
    checkbox: CheckboxComponent
  }
end
```

Closes https://github.com/ViewComponent/view_component/issues/2311.