### PR TITLE
Potential fix for code scanning alert no. 14: Incomplete regular expression for hostnames

### DIFF
--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -377,13 +377,13 @@ class RenderingTest < ViewComponent::TestCase
     if Rails.version.to_f < 8.0
       # Propshaft doesn't allow setting custom hosts so this only works in Rails < 8
       component.config.asset_host = nil
-      assert_match(%r{/assets/application-\w+.css}, render_inline(component).text)
+      assert_match(%r{/assets/application-\w+\.css}, render_inline(component).text)
 
       component.config.asset_host = "http://assets.example.com"
-      assert_match(%r{http://assets.example.com/assets/application-\w+.css}, render_inline(component).text)
+      assert_match(%r{http://assets\.example\.com/assets/application-\w+\.css}, render_inline(component).text)
 
       component.config.asset_host = "assets.example.com"
-      assert_match(%r{http://assets.example.com/assets/application-\w+.css}, render_inline(component).text)
+      assert_match(%r{http://assets\.example\.com/assets/application-\w+\.css}, render_inline(component).text)
     end
   end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -372,7 +372,7 @@ class RenderingTest < ViewComponent::TestCase
 
   def test_renders_component_with_asset_url
     component = AssetComponent.new
-    assert_match(%r{http://assets.example.com/assets/application-\w+.css}, render_inline(component).text)
+    assert_match(%r{http://assets\.example\.com/assets/application-\w+\.css}, render_inline(component).text)
 
     if Rails.version.to_f < 8.0
       # Propshaft doesn't allow setting custom hosts so this only works in Rails < 8


### PR DESCRIPTION
Potential fix for [https://github.com/ViewComponent/view_component/security/code-scanning/14](https://github.com/ViewComponent/view_component/security/code-scanning/14)

To fix the issue, the `.` in the regular expression should be escaped to ensure it matches a literal dot rather than any character. Specifically, the pattern `%r{http://assets.example.com/assets/application-\w+.css}` should be updated to `%r{http://assets\.example\.com/assets/application-\w+\.css}`. This change ensures that the regular expression matches only the intended domain and path.

The fix will be applied to line 375 in the file `test/sandbox/test/rendering_test.rb`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
