### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   trailing-whitespace:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ViewComponent/view_component/security/code-scanning/7](https://github.com/ViewComponent/view_component/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the `contents: read` permission is sufficient for most jobs, as they primarily involve reading repository contents. For jobs that require additional permissions, such as `pull-requests: write`, we will define those permissions explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
