### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ViewComponent/view_component/security/code-scanning/12](https://github.com/ViewComponent/view_component/security/code-scanning/12)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimum required permissions for the workflow. Based on the provided workflow, it appears that the jobs primarily perform read operations (e.g., checking out code, running tests, and uploading artifacts). Therefore, we will set `contents: read` as the default permission. If any job requires additional permissions, we will define them explicitly within that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
