### PR TITLE
Fix display of contributor avatars.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -103,9 +103,11 @@ ViewComponents are Ruby objects, making it easy to follow (and enforce) code qua
 
 Hundreds of people have [contributed](https://github.com/ViewComponent/view_component/graphs/contributors) to ViewComponent, including:
 
+<div>
 {% for contributor in site.data.contributors.usernames %}
 <img src="https://avatars.githubusercontent.com/{{ contributor }}?s=64" alt="{{ contributor }}" width="32" />
 {% endfor %}
+</div>
 
 ## Who uses ViewComponent?
 


### PR DESCRIPTION
This prevents Jekyll from wrapping each image in `<p>` tags. It now wraps around so that the avatars look nicer.

### What are you trying to accomplish?

Before:

<img width="1184" height="978" alt="before@2x" src="https://github.com/user-attachments/assets/00b4808e-9902-4bb2-bd86-a1804064da8b" />

After:

<img width="1564" height="1286" alt="after@2x" src="https://github.com/user-attachments/assets/abf9f856-2c76-40f9-b2f6-3ad4beb5f6b7" />

### What approach did you choose and why?

I wrapped the avatars in `<div>` tags to prevent Jekyll from wrapping `<p>`s around each avatar. There might be a better way, but I thought it might help to suggest a quick fix.