### PR TITLE
Fix: missing generators in gemfiles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,9 +10,7 @@ nav_order: 6
 
 ## main
 
-## pending
-
-* Fix missing generators
+* Fix issue where generators were not included in published gem.
 
     *Jean-Louis Giordano*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ nav_order: 6
 
 ## main
 
+## pending
+
+* Fix missing generators
+
+    *Jean-Louis Giordano*
+
 ## 4.0.0.rc3
 
 * Reformat the avatars section to arrange them in a grid.

--- a/view_component.gemspec
+++ b/view_component.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
     "README.md",
     "app/**/*",
     "docs/CHANGELOG.md",
-    "lib/rails/**/*.rb",
-    "lib/rails/**/*.tt",
+    "lib/generators/**/*.rb",
+    "lib/generators/**/*.tt",
     "lib/view_component.rb",
     "lib/view_component/**/*"
   ]


### PR DESCRIPTION
there's no `lib/rails` folder but there is a `lib/generators` folder, I believe this is a configuration bug that was introduced during a v4-related refactoring?

### What are you trying to accomplish?

Attempting to address: https://github.com/ViewComponent/view_component/issues/2394

### What approach did you choose and why?

I looked into the expected convention for rails generators, noticed that the `lib/generators` folder was missing in the install folder of the gem on my local machine.

### Anything you want to highlight for special attention from reviewers?

I'm hoping this is a simple typo / oversight, which I believe a maintainer should be able to quickly figure out from this PR! 😅 

I am not entirely sure how to write a spec for this, but perhaps that's not necessary for a gemspec typo?