### PR TITLE
Setup Trusted Publishing

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -1,0 +1,38 @@
+name: Push Gem
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    if: github.repository == 'ViewComponent/view_component'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    # GitHub environment configured on RubyGems
+    environment: release
+
+    steps:
+      # Set up
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ nav_order: 6
 
 ## main
 
-* Setup Trusted Publishing to RubyGems, to improve software supply chain safety.
+* Setup Trusted Publishing to RubyGems to improve software supply chain safety.
 
     *Hans Lemuet*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Setup Trusted Publishing to RubyGems, to improve software supply chain safety.
+
+    *Hans Lemuet*
+
 ## 4.0.0.rc5
 
 * Revert change setting `#format`. In GitHub's codebase, the change led to hard-to-detect failures. For example, components rendered from controllers included layouts when they didn't before. In other cases, the response `content_type` changed, breaking downstream consumers. For cases where a specific content type is needed, use:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -98,6 +98,8 @@ To run the Vale prose linter locally, `brew install vale` and `vale docs/`.
 
 `./script/release`
 
+To improve software supply chain safety, new gem versions are automatically pushed to RubyGems by Github Actions, thanks to [Trusted Publishing](https://guides.rubygems.org/trusted-publishing/).
+
 ## Governance
 
 ViewComponent is built by over a hundred members of the community. Project membership has several levels:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -98,8 +98,6 @@ To run the Vale prose linter locally, `brew install vale` and `vale docs/`.
 
 `./script/release`
 
-To improve software supply chain safety, new gem versions are automatically pushed to RubyGems by Github Actions, thanks to [Trusted Publishing](https://guides.rubygems.org/trusted-publishing/).
-
 ## Governance
 
 ViewComponent is built by over a hundred members of the community. Project membership has several levels:

--- a/script/publish
+++ b/script/publish
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Publish gem
-bundle exec rake release
+# this step has been replaced by .github/workflows/push_gem.yml
 
 # Publish updated docs
 git branch -D gh-pages

--- a/script/release
+++ b/script/release
@@ -82,7 +82,9 @@ push() {
 
   echo "####################################################"
   echo "Now, open a PR with this branch and merge it to main"
-  echo "Then, run script/publish on main to release the gem"
+  echo "Then, run script/publish on main to publish the docs"
+  echo "The gem will be pushed to RubyGems automatically by"
+  echo "Github Actions, using Trusted Publishing."
   echo "Finally, create a GitHub release https://github.com/viewcomponent/view_component/releases/new with the changes from docs/CHANGELOG"
   echo "####################################################"
 }


### PR DESCRIPTION
Close #2224

### What are you trying to accomplish?

Setting up Trusted Publishing, to improve software supply chain safety.

- [RubyGems' blog](https://blog.rubygems.org/2023/12/14/trusted-publishing.html)
- [RubyGems' guide](https://guides.rubygems.org/trusted-publishing/)

### What approach did you choose and why?

I added a Trusted Publisher on RubyGems: https://rubygems.org/gems/view_component/trusted_publishers (access to this link is limited to maintainers).

Whenever we push a new tag starting with `v`, a specific workflow (`push_gem`) runs in Github Actions and takes care of publishing the gem to RubyGems.

### Anything you want to highlight for special attention from reviewers?

As advised by RubyGems, this new workflow runs in a [dedicated `release` environment](https://github.com/ViewComponent/view_component/settings/environments/7795049317/edit), limited to maintainers.