### PR TITLE
Correct documentation regarding previews.paths option

### DIFF
--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -115,7 +115,7 @@ config.view_component.default_preview_layout = "component_preview"
 
 ## Preview paths
 
-Preview classes live in `test/components/previews`, which can be configured using the `preview_paths` option:
+Preview classes live in `test/components/previews`, which can be configured using the `previews.paths` option:
 
 ```ruby
 # config/application.rb
@@ -210,9 +210,9 @@ config.view_component.previews.enabled = false
 
 ## Use with RSpec
 
-When using previews with RSpec,  replace `test/components` with `spec/components` and update `preview_paths`:
+When using previews with RSpec,  replace `test/components` with `spec/components` and update `previews.paths`:
 
 ```ruby
 # config/application.rb
-config.view_component.preview_paths << "#{Rails.root}/spec/components/previews"
+config.view_component.previews.paths << "#{Rails.root}/spec/components/previews"
 ```


### PR DESCRIPTION
Hi all, first time contributing so hope I'm doing this right. Noticed in the documentation under `docs/guides/preview.md` that the old `previews_path` option was still being used in a few examples while migrating to 4.0. After changing my application to use the new `previews.paths` syntax previews worked again so assuming this is an oversight. If not sorry and feel free to close!
