### PR TITLE
Fix double rendering issue for partials that yield

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,10 @@ nav_order: 6
 
     *Cameron Dutro*
 
+* Fix double rendering issue for partials that yield.
+
+    *Cameron Dutro*
+
 ## 4.0.0
 
 Two years after releasing [3.0.0](https://github.com/ViewComponent/view_component/releases/tag/v3.0.0) and almost six years since [1.0.0](https://github.com/ViewComponent/view_component/releases/tag/v1.0.0), we're proud to ship ViewComponent 4. This release marks a shift towards a Long Term Support model for the project, having reached significant feature maturity. While contributions are always welcome, we're unlikely to accept further breaking changes or major feature additions.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Fix double rendering issue for partials that yield.
+
+    *Cameron Dutro*
+
 ## 4.0.1
 
 * Setup Trusted Publishing to RubyGems to improve software supply chain safety.
@@ -19,10 +23,6 @@ nav_order: 6
 * Conditionally add the `ViewComponent::Base#format` method back for Rails 7.1 only.
 * Compute and check lockfiles into source control.
 * Constrain Rails versions in gemfiles to only allow the patch version to vary, eg. `~> 7.1.0` instead of `~> 7.1`.
-
-    *Cameron Dutro*
-
-* Fix double rendering issue for partials that yield.
 
     *Cameron Dutro*
 

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -259,7 +259,7 @@ module ViewComponent
         # We assume options is a component, so there's no need to evaluate the
         # block in the view context as we do below.
         @view_context.render(options, args, &block)
-      else
+      elsif block
         __vc_original_view_context.render(options, args) do
           # Partials are rendered to their own buffer and do not append to the
           # original @output_buffer we retain a reference to in #render_in. This
@@ -270,6 +270,8 @@ module ViewComponent
           # created for the partial.
           __vc_original_view_context.instance_exec(&block)
         end
+      else
+        __vc_original_view_context.render(options, args)
       end
     end
 

--- a/test/sandbox/app/components/partial_with_yield_component.html.erb
+++ b/test/sandbox/app/components/partial_with_yield_component.html.erb
@@ -1,0 +1,3 @@
+<%= render "shared/yielding_partial" do %>
+  world
+<% end %>

--- a/test/sandbox/app/components/partial_with_yield_component.rb
+++ b/test/sandbox/app/components/partial_with_yield_component.rb
@@ -1,0 +1,2 @@
+class PartialWithYieldComponent < ViewComponent::Base
+end

--- a/test/sandbox/app/views/shared/_yielding_partial.html.erb
+++ b/test/sandbox/app/views/shared/_yielding_partial.html.erb
@@ -1,0 +1,1 @@
+hello <%= yield %>

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1317,4 +1317,9 @@ class RenderingTest < ViewComponent::TestCase
 
     assert_text("Hi!")
   end
+
+  def test_render_partial_with_yield
+    render_inline(PartialWithYieldComponent.new)
+    assert_text "hello world", exact: true, normalize_ws: true
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide a description of the changes. Link to any related issues or projects. -->

Fixes https://github.com/ViewComponent/view_component/issues/2423

### What approach did you choose and why?

<!-- Describe your thought process in making these changes. List any tradeoffs you made. Describe any alternative approaches you considered and why you discarded them. -->

`ViewComponent::Base` retains a reference to the view context's output buffer. When component templates are evaluated, they do so inside the context of `ViewComponent::Base`, and thus append to the retained `@output_buffer` instance. However, Rails creates a new output buffer when rendering partials, and temporarily reassigns its own `@output_buffer` instance variable. When rendering partials inside a view component, `ViewComponent::Base` forwards the block on to `view_context.render`, but since the block was created inside `ViewComponent::Base`, that's where it will be evaluated when called. This means the block will append to the original `@output_buffer` and not to the new one Rails creates for the partial. To mitigate the issue, this PR evaluates the block inside the view context with `instance_exec`, which causes the block to append to the correct buffer.