### PR TITLE
Add Carwow to "Who uses ViewComponent?"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Add Carwow to list of companies using ViewComponent.
+
+    *Tom Lord*
+
 ## 4.0.2
 
 * Share the view context in tests to prevent out-of-order rendering issues for certain advanced use-cases, eg. testing instances of Rails' `FormBuilder`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,6 +119,7 @@ Hundreds of people have [contributed](https://github.com/ViewComponent/view_comp
 * [Brightline](https://hellobrightline.com)
 * [Buildkite](https://buildkite.com)
 * [Bump.sh](https://bump.sh)
+* [Carwow](https://www.carwow.com/) (300+ components)
 * [Causey](https://www.causey.app/) (100+ components)
 * [CharlieHR](https://www.charliehr.com/)
 * [City of Paris](https://www.paris.fr/)


### PR DESCRIPTION
_Most_ of Carwow's code is not open source, so I'm not sure I can link to code examples of the usage.

However, the Carwow styleguide - used throughout the website - is publically accessible, and gives some clues about how View Components are used! e.g. https://styleguide.carwow.co.uk/inspect/award_badge/default