### PR TITLE
fix outdated settings related to default layout preview

### DIFF
--- a/docs/guide/previews.md
+++ b/docs/guide/previews.md
@@ -110,7 +110,7 @@ To set a custom layout for individual previews and the previews index page, set:
 ```ruby
 # config/application.rb
 # Set the default layout to app/views/layouts/component_preview.html.erb
-config.view_component.default_preview_layout = "component_preview"
+config.view_component.previews.default_layout = "component_preview"
 ```
 
 ## Preview paths


### PR DESCRIPTION
### What are you trying to accomplish?

- Fix wrong docs related to setting up a default layout for preview components.

### What approach did you choose and why?

- Explore the configuration structure with `Rails.application.config.view_component` and notice that the documentation configuration is not working properly. 

Before:
```rb
# with config.view_component.default_preview_layout = "component_preview"
{:generate=>{...},
 :previews=>
  {:controller=>"ViewComponentsController",
   :route=>"/rails/view_components",
   :enabled=>true,
   :default_layout=>nil, # value as nil
   :paths=>[...]},
 :instrumentation_enabled=>false,
 :default_preview_layout=>"component_preview"}
 ```
 
 After:
 ```rb
 # with config.view_component.previews.default_layout = "Component_preview"
{:generate=>{...},
 :previews=>
  {:controller=>"ViewComponentsController",
   :route=>"/rails/view_components",
   :enabled=>true,
   :default_layout=>"component_preview", # correct value
   :paths=>[...]},
 :instrumentation_enabled=>false,
 :default_preview_layout=>"component_preview"}
 ```

### Anything you want to highlight for special attention from reviewers?

- Is required to review if the current `config.view_component.default_preview_layout` is still in use or should it be removed.
