### PR TITLE
Add Consultport to "Who uses ViewComponent?"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Add Consultport to list of companies using ViewComponent.
+
+    *Sebastian Nepote*
+
 * Resolve deprecation warning for `ActiveSupport::Configurable`.
 
     *Simon Fish*

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,6 +126,7 @@ Hundreds of people have [contributed](https://github.com/ViewComponent/view_comp
 * [Clio](https://www.clio.com/)
 * [Cometeer](https://cometeer.com/)
 * [Consul](https://consulproject.org/en/)
+* [Consultport](https://app.consultport.com/)
 * [Content Harmony](https://www.contentharmony.com/)
 * [Cults.](https://cults3d.com/)
 * [Defacto](https://www.defacto.nl)


### PR DESCRIPTION
### What are you trying to accomplish?

Reporting a company proudly using View Component.

### What approach did you choose and why?

No trade-offs. After reading the `4.1.0` changelog and considering that I work at a company that’s a big fan of ViewComponent, I thought it should be listed.

### Anything you want to highlight for special attention from reviewers?

No code change. Only documentation update.
 