### PR TITLE
ignore failed head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
   test:
     name: test (Rails ${{ matrix.rails_version }}, Ruby ${{ matrix.ruby_version }})
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.ruby_version == 'head' }}
     strategy:
       fail-fast: false
       matrix:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Allow ruby-head CI job to fail without failing workflow.
+
+    *Hakan Ensari*
+
 * Fix bug where error line numbers were incorrect in Rails 8.1.
 
     *Joel Hawksley*


### PR DESCRIPTION
Just cleaning up CI. Ruby head failures are informative and, in a way, expected.