### PR TITLE
Add support for slot arguments

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ nav_order: 6
 
     *Joel Hawksley*
 
+* Support slot arguments.
+
+    *Stanislav Lashmanov*
+
 ## 4.2.0
 
 * Fix translation scope resolution in deeply nested component blocks (3+ levels). Translations called inside deeply nested slot blocks using `renders_many`/`renders_one` were incorrectly resolving to an intermediate component's scope instead of the partial's scope where the block was defined. The fix captures the virtual path at block definition time and restores it during block execution, ensuring translations always resolve relative to where the block was created regardless of nesting depth.

--- a/docs/guide/slots.md
+++ b/docs/guide/slots.md
@@ -219,6 +219,92 @@ end
 
 _Note: While a lambda is called when the `with_*` method is called, a returned component isn't rendered until first use._
 
+## Passing arguments to slots
+
+Slots can receive arguments during rendering. This is useful when the component template has data that the slot content needs access to.
+
+```ruby
+# greeting_component.rb
+class GreetingComponent < ViewComponent::Base
+  renders_one :message
+end
+```
+
+```erb
+<%# greeting_component.html.erb %>
+<div class="greeting">
+  <%= message("Hello", "World") %>
+</div>
+```
+
+```erb
+<%# index.html.erb %>
+<%= render GreetingComponent.new do |component| %>
+  <% component.with_message do |greeting, name| %>
+    <%= greeting %>, <%= name %>!
+  <% end %>
+<% end %>
+```
+
+Returning:
+
+```erb
+<div class="greeting">
+  Hello, World!
+</div>
+```
+
+For `renders_many` slots, call `.call()` on each slot item:
+
+```ruby
+# list_component.rb
+class ListComponent < ViewComponent::Base
+  renders_many :items
+end
+```
+
+```erb
+<%# list_component.html.erb %>
+<ul>
+  <% items.each_with_index do |item, index| %>
+    <li><%= item.call(index) %></li>
+  <% end %>
+</ul>
+```
+
+```erb
+<%# index.html.erb %>
+<%= render ListComponent.new do |component| %>
+  <% component.with_item do |index| %>
+    Item <%= index + 1 %>
+  <% end %>
+  <% component.with_item do |index| %>
+    Item <%= index + 1 %>
+  <% end %>
+<% end %>
+```
+
+Returning:
+
+```erb
+<ul>
+  <li>Item 1</li>
+  <li>Item 2</li>
+</ul>
+```
+
+Keyword arguments are also supported:
+
+```erb
+<%# In the component template %>
+<%= my_slot(name: "Alice", role: "Admin") %>
+
+<%# When setting the slot %>
+<% component.with_my_slot do |name:, role:| %>
+  <%= name %> (<%= role %>)
+<% end %>
+```
+
 ## Rendering collections
 
 Since 2.23.0

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -86,8 +86,13 @@ module ViewComponent
             __vc_set_slot(slot_name, nil, *args, **kwargs, &block)
           end
 
-          self::GeneratedSlotMethods.define_method slot_name do
-            __vc_get_slot(slot_name)
+          self::GeneratedSlotMethods.define_method slot_name do |*args, **kwargs, &block|
+            slot = __vc_get_slot(slot_name)
+            if (args.any? || kwargs.any? || block) && slot
+              slot.call(*args, **kwargs, &block)
+            else
+              slot
+            end
           end
 
           self::GeneratedSlotMethods.define_method :"#{slot_name}?" do
@@ -229,8 +234,13 @@ module ViewComponent
       end
 
       def __vc_register_polymorphic_slot(slot_name, types, collection:)
-        self::GeneratedSlotMethods.define_method(slot_name) do
-          __vc_get_slot(slot_name)
+        self::GeneratedSlotMethods.define_method(slot_name) do |*args, **kwargs, &block|
+          slot = __vc_get_slot(slot_name)
+          if (args.any? || kwargs.any? || block) && slot && !slot.is_a?(Array)
+            slot.call(*args, **kwargs, &block)
+          else
+            slot
+          end
         end
 
         self::GeneratedSlotMethods.define_method(:"#{slot_name}?") do

--- a/test/sandbox/app/components/slot_args_component.html.erb
+++ b/test/sandbox/app/components/slot_args_component.html.erb
@@ -1,0 +1,14 @@
+<div class="slot-args">
+  <% if greeting? %>
+    <div class="greeting"><%= greeting("Hello", "World") %></div>
+  <% end %>
+  <% items.each_with_index do |item, index| %>
+    <div class="item"><%= item.call(index, "extra") %></div>
+  <% end %>
+  <% if kwargs_slot? %>
+    <div class="kwargs"><%= kwargs_slot(name: "test", value: 42) %></div>
+  <% end %>
+  <% if mixed_slot? %>
+    <div class="mixed"><%= mixed_slot("positional", key: "keyword") %></div>
+  <% end %>
+</div>

--- a/test/sandbox/app/components/slot_args_component.rb
+++ b/test/sandbox/app/components/slot_args_component.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SlotArgsComponent < ViewComponent::Base
+  renders_one :greeting
+  renders_many :items
+  renders_one :kwargs_slot
+  renders_one :mixed_slot
+end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -831,4 +831,58 @@ class SlotableTest < ViewComponent::TestCase
 
     assert_selector(".breadcrumb.active")
   end
+
+  def test_slot_with_args_renders_one
+    render_inline(SlotArgsComponent.new) do |component|
+      component.with_greeting do |arg1, arg2|
+        "#{arg1} #{arg2}!"
+      end
+    end
+
+    assert_selector(".greeting", text: "Hello World!")
+  end
+
+  def test_slot_with_args_renders_many
+    render_inline(SlotArgsComponent.new) do |component|
+      component.with_item do |index, extra|
+        "Item #{index}: #{extra}"
+      end
+      component.with_item do |index, extra|
+        "Item #{index}: #{extra}"
+      end
+    end
+
+    assert_selector(".item", text: "Item 0: extra")
+    assert_selector(".item", text: "Item 1: extra")
+  end
+
+  def test_slot_call_with_kwargs
+    render_inline(SlotArgsComponent.new) do |component|
+      component.with_kwargs_slot do |name:, value:|
+        "Name: #{name}, Value: #{value}"
+      end
+    end
+
+    assert_selector(".kwargs", text: "Name: test, Value: 42")
+  end
+
+  def test_slot_call_with_mixed_args_and_kwargs
+    render_inline(SlotArgsComponent.new) do |component|
+      component.with_mixed_slot do |pos, key:|
+        "#{pos} and #{key}"
+      end
+    end
+
+    assert_selector(".mixed", text: "positional and keyword")
+  end
+
+  def test_slot_call_method_directly
+    render_inline(SlotArgsComponent.new) do |component|
+      component.with_greeting do |arg1, arg2|
+        "Direct: #{arg1}-#{arg2}"
+      end
+    end
+
+    assert_selector(".greeting", text: "Direct: Hello-World")
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR adds support for slot arguments.

```ruby
# greeting_component.rb
class GreetingComponent < ViewComponent::Base
  renders_one :message
end
```

```erb
<%# greeting_component.html.erb %>
<div class="greeting">
  <%= message("Hello", "World") %>
</div>
```

```erb
<%# index.html.erb %>
<%= render GreetingComponent.new do |component| %>
  <% component.with_message do |greeting, name| %>
    <%= greeting %>, <%= name %>!
  <% end %>
<% end %>
```

Returning:

```erb
<div class="greeting">
  Hello, World!
</div>
```

### What approach did you choose and why?

Slot arguments provide 2 major benefits to a component approach:

1. Isolation – parent components no longer need to access private component instance to grab necessary data for rendering
2. Configuration – slots could be used in more sophisticated ways previously not possible

Right now ViewComponent only supports basic slots without arguments. This means you have to follow patterns like this in order to get the data you need for rendering:

```erb
<%# index.html.erb %>
<%= render GreetingComponent.new do |component| %>
  <% component.with_message %>
    <%= component.greeting %>, <%= component.name %>!
  <% end %>
<% end %>
```

This breaks one of the key component principles: Encapsulation. If the parent component knows about internal state of the child component they become coupled. That leads to unreliable refactorings and degraded component's reusability.

A common pattern of customizing a slot would be to use lambda slots:

```ruby
class BlogComponent < ViewComponent::Base
  renders_one :header, ->(classes:, &block) do
    content_tag :h1, class: classes, &block
  end
end
```

Unfortunately this approach does not allow us to pass data to the block directly, meaning it's actually the inverse of what we want: it passes data to a child component, not the child component passing data to the parent.

Another problem with this approach is that we can't customize what exactly we render inside the lambda.

Slot arguments allow us to solve these problems with elegance. Instead of component instance we access slot arguments passed to the block:

```erb
<%# index.html.erb %>
<%= render GreetingComponent.new do |component| %>
  <% component.with_message do |greeting, name| %>
    <%= greeting %>, <%= name %>!
  <% end %>
<% end %>
```

This means we are in full control of what's rendered inside the slot and also never touch component internals, allowing for safer refactorings.

With slot arguments we can now support more advanced cases of using slots:

```erb
<%# greeting_component.html.erb %>
<div class="greetings">
  <% greetings.each_with_index do |greeting, index| %>
    <%= message(greeting, index) %>
  <% end %>
</div>
```

```erb
<%# index.html.erb %>
<%= render GreetingComponent.new do |component| %>
  <% component.with_message do |greeting, index| %>
    <%= index % 2 == 0 ? greeting : '' %>!
  <% end %>
<% end %>
```

### Anything you want to highlight for special attention from reviewers?

This feature has been [previously discussed](https://github.com/ViewComponent/view_component/issues/1810) but there still is no working alternative to it.

This approach is not new and is inspired by [Scoped Slots in Vue](https://vuejs.org/guide/components/slots.html#scoped-slots) and [Child Component as Function pattern in React](https://reactpatterns.js.org/docs/function-as-child-component/).
