### PR TITLE
Fix stale content cache when slots are accessed before render_in

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Fix stale content cache when slots are accessed before `render_in`.
+
+    *Jared Armstrong*
+
 * Add rubocop-view_component to resources.
 
     *Andy Waite*

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -131,6 +131,7 @@ module ViewComponent
       end
 
       @__vc_content_evaluated = false
+      remove_instance_variable(:@__vc_content) if defined?(@__vc_content)
       @__vc_render_in_block = block
       @view_context.instance_variable_set(:@virtual_path, virtual_path)
 

--- a/test/sandbox/app/components/slot_with_content_block_component.rb
+++ b/test/sandbox/app/components/slot_with_content_block_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SlotWithContentBlockComponent < ViewComponent::Base
+  renders_one :header
+
+  def call
+    out = +""
+    out << content_tag(:div, header, class: "header") if header?
+    out << content_tag(:div, content, class: "body") if content?
+    out.html_safe
+  end
+end

--- a/test/sandbox/test/slotable_test.rb
+++ b/test/sandbox/test/slotable_test.rb
@@ -822,6 +822,23 @@ class SlotableTest < ViewComponent::TestCase
     assert_not_equal SlotsComponent.instance_method(:title).owner, SlotNameOverrideComponent::OtherComponent.instance_method(:title).owner
   end
 
+  def test_slot_predicate_before_render_does_not_poison_content_cache
+    component = SlotWithContentBlockComponent.new
+    component.with_header { "My Header" }
+
+    # Accessing a slot predicate before render_in triggers content evaluation
+    # via __vc_get_slot. Without the fix, this caches a nil @__vc_content that
+    # persists through render_in, causing the content block to be silently ignored.
+    assert component.header?
+
+    render_inline(component) do
+      "Body content from block"
+    end
+
+    assert_selector(".header", text: "My Header")
+    assert_selector(".body", text: "Body content from block")
+  end
+
   def test_allows_marking_slot_as_last
     render_inline(LastItemComponent.new) do |component|
       component.with_item("animal")


### PR DESCRIPTION
# Problem

`content` caches its result in `@__vc_content` after first evaluation. `render_in` resets `@__vc_content_evaluated` to `false`, but doesn't clear the cached `@__vc_content` value. This means if `content` was evaluated before `render_in`, the stale cached result is returned on every subsequent call — the render block passed when rendering the component is never evaluated.

This is easy to trigger in practice because `__vc_get_slot` eagerly calls `content` to ensure content-defined slots are loaded:

```ruby 
# slotable.rb
def __vc_get_slot(slot_name)
  content unless defined?(@__vc_content_evaluated) && @__vc_content_evaluated
  ...
end
```

So any slot predicate (e.g. `column?`, `header?`) called before `render_in` poisons the cache. This comes up when building a component's structure first (configuring slots in a helper or setup block) and rendering it later with a content block:

```ruby
# helper.rb
def my_table
  Ui::Table.new.tap do |table|
    table.with_column "Name" %>
    table.with_column :options unless table.column?(:options) # triggers content evaluation
  end
end
```
```erb
<%# template.html.erb %>
<%= render my_table do %>
  <%= render partial: "row" %>  <%# silently ignored %>
<% end %>
```

# Fix

Clear `@__vc_content` in `render_in` alongside the existing `@__vc_content_evaluated` reset, so the cache is fully invalidated on each render.

Adds a regression test that accesses a slot predicate before `render_in` and asserts the content block is rendered.