### PR TITLE
Add rubocop-view_component to resources

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Add rubocop-view_component to resources.
+
+    *Andy Waite*
+
 * Fix bug where inheritance of components with formatless templates improperly raised a NoMethodError.
 
     *GitHub Copilot*, *Joel Hawksley*, *Cameron Dutro*

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -27,6 +27,9 @@ _Is this page missing a link? Open a PR!_
 - [ViewComponent Contrib](https://github.com/palkan/view_component-contrib)
 - [Lookbook](https://lookbook.build)
 - [ViewComponentAttributes](https://github.com/Amba-Health/view_component_attributes)
+
+## Tools
+
 - [rubocop-view_component](https://github.com/andyw8/rubocop-view_component)
 
 ## Podcasts

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -27,6 +27,7 @@ _Is this page missing a link? Open a PR!_
 - [ViewComponent Contrib](https://github.com/palkan/view_component-contrib)
 - [Lookbook](https://lookbook.build)
 - [ViewComponentAttributes](https://github.com/Amba-Health/view_component_attributes)
+- [rubocop-view_component](https://github.com/andyw8/rubocop-view_component)
 
 ## Podcasts
 


### PR DESCRIPTION
### What are you trying to accomplish?

Add [rubocop-view_component](https://github.com/andyw8/rubocop-view_component) to the resources page under ViewComponent extensions. This is a gem I wrote that provides RuboCop cops for ViewComponent, based on the Best Practices guide.

### What approach did you choose and why?

New section since it didn't fit in any existing ones.

### Anything you want to highlight for special attention from reviewers?

n/a