### PR TITLE
Yielded content gets insertet at wrong location when used with Rails' form helpers

### DIFF
--- a/test/sandbox/app/components/partial_with_yield_form_component.html.erb
+++ b/test/sandbox/app/components/partial_with_yield_form_component.html.erb
@@ -1,0 +1,5 @@
+<%= form_with url: '/' do |form| %>
+  <%= render "shared/yielding_form_partial", form: do %>
+    world
+  <% end %>
+<% end %>

--- a/test/sandbox/app/components/partial_with_yield_form_component.rb
+++ b/test/sandbox/app/components/partial_with_yield_form_component.rb
@@ -1,0 +1,2 @@
+class PartialWithYieldFormComponent < ViewComponent::Base
+end

--- a/test/sandbox/app/views/shared/_yielding_form_partial.html.erb
+++ b/test/sandbox/app/views/shared/_yielding_form_partial.html.erb
@@ -1,0 +1,3 @@
+<%= form.label :something do %>
+  <%= yield %>
+<% end %>

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1379,6 +1379,10 @@ class RenderingTest < ViewComponent::TestCase
     assert_text "hello world", exact: true, normalize_ws: true
   end
 
+  def test_render_partial_with_yield_form
+    assert_includes render_inline(PartialWithYieldFormComponent.new).css('label').to_html, 'world'
+  end
+
   def test_render_partial_with_yield_and_method_call
     render_inline(PartialWithYieldAndMethodCallComponent.new)
     assert_text "hello world", exact: true, normalize_ws: true


### PR DESCRIPTION
When passing the from helper to a shared partial which yields some content, the content gets inserted at the wrong location.

In this test it should be inside the label tag – `<label>world</label>` – but it is rendered outside: `world <label></label>`.

For now this MR just adds a failing test for you to reproduce which is the way bug reports are expected according to the issue template.

Is there somebody that can take a look at this? Thank you very much.