### PR TITLE
Fix yielded content rendered at wrong location with Rails form helpers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Fix yielded content rendered at wrong location when using form helpers.
+
+    *Joel Hawksley*, *Markus*
+
 ## 4.8.0
 
 * Add `compile.view_component` ActiveSupport::Notifications event for eager compilation at boot time.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,7 +28,6 @@ nav_order: 6
 
     *Joel Hawksley*
 
-
 ## 4.8.0
 
 * Add `compile.view_component` ActiveSupport::Notifications event for eager compilation at boot time.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -278,6 +278,22 @@ module ViewComponent
       end
     end
 
+    # Sync @output_buffer with the view context's current output buffer before
+    # capturing. Form helpers create builders with @template_object pointing to
+    # the component. When those builders later call capture inside a partial
+    # (whose _run allocated a fresh OutputBuffer on the view context), the
+    # component's stale @output_buffer would capture from the wrong buffer.
+    # Temporarily switching to the view context's buffer keeps both in sync.
+    #
+    # @private
+    def capture(*, **, &block)
+      old_output_buffer = @output_buffer
+      @output_buffer = view_context.output_buffer if view_context
+      super
+    ensure
+      @output_buffer = old_output_buffer
+    end
+
     # The current controller. Use sparingly as doing so introduces coupling
     # that inhibits encapsulation & reuse, often making testing difficult.
     #

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -286,10 +286,10 @@ module ViewComponent
     # Temporarily switching to the view context's buffer keeps both in sync.
     #
     # @private
-    def capture(*, **, &block)
+    def capture(...)
       old_output_buffer = @output_buffer
       @output_buffer = view_context.output_buffer if view_context
-      super
+      super(...)
     ensure
       @output_buffer = old_output_buffer
     end

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -289,7 +289,7 @@ module ViewComponent
     def capture(...)
       old_output_buffer = @output_buffer
       @output_buffer = view_context.output_buffer if view_context
-      super(...)
+      super
     ensure
       @output_buffer = old_output_buffer
     end

--- a/test/sandbox/app/components/partial_with_yield_form_component.html.erb
+++ b/test/sandbox/app/components/partial_with_yield_form_component.html.erb
@@ -1,0 +1,5 @@
+<%= form_with url: '/' do |form| %>
+  <%= render "shared/yielding_form_partial", form: do %>
+    world
+  <% end %>
+<% end %>

--- a/test/sandbox/app/components/partial_with_yield_form_component.html.erb
+++ b/test/sandbox/app/components/partial_with_yield_form_component.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: '/' do |form| %>
+<%= form_with url: "/" do |form| %>
   <%= render "shared/yielding_form_partial", form: do %>
     world
   <% end %>

--- a/test/sandbox/app/components/partial_with_yield_form_component.rb
+++ b/test/sandbox/app/components/partial_with_yield_form_component.rb
@@ -1,0 +1,2 @@
+class PartialWithYieldFormComponent < ViewComponent::Base
+end

--- a/test/sandbox/app/views/shared/_yielding_form_partial.html.erb
+++ b/test/sandbox/app/views/shared/_yielding_form_partial.html.erb
@@ -1,0 +1,3 @@
+<%= form.label :something do %>
+  <%= yield %>
+<% end %>

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1379,6 +1379,10 @@ class RenderingTest < ViewComponent::TestCase
     assert_text "hello world", exact: true, normalize_ws: true
   end
 
+  def test_render_partial_with_yield_form
+    assert_includes render_inline(PartialWithYieldFormComponent.new).css('label').to_html, 'world'
+  end
+
   def test_render_partial_with_yield_and_method_call
     render_inline(PartialWithYieldAndMethodCallComponent.new)
     assert_text "hello world", exact: true, normalize_ws: true

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -1380,7 +1380,7 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_render_partial_with_yield_form
-    assert_includes render_inline(PartialWithYieldFormComponent.new).css('label').to_html, 'world'
+    assert_includes render_inline(PartialWithYieldFormComponent.new).css("label").to_html, "world"
   end
 
   def test_render_partial_with_yield_and_method_call


### PR DESCRIPTION
## Problem

When a ViewComponent renders a partial that uses a Rails form helper (like `form.label`) with a yielding block, the yielded content is rendered **outside** the helper's tag instead of inside it.

**Expected:** `<label>world</label>`
**Actual:** `world <label></label>`

Reported in #2617 — this PR provides the fix.

## Root Cause

`form_with` creates form builders with `@template_object` pointing to the **component**. When the form builder is later used inside a partial (e.g. `form.label :something do ... end`), it calls `@template_object.capture(builder, &block)` — capturing on the **component's** `@output_buffer`.

However, Rails' `Template#render` → `_run` has already replaced `view_context.@output_buffer` with a **fresh `OutputBuffer`** for the partial. The compiled partial template code writes to this new buffer, while the component's `@output_buffer` still references the original one set during `render_in`.

This mismatch means `form.label`'s capture reads from an empty (stale) buffer, and the block's output leaks into the partial's main output stream instead of being wrapped by the label tag.

## Fix

Override `capture` in `ViewComponent::Base` to synchronize `@output_buffer` with `view_context.output_buffer` before delegating to `super`. This ensures form helpers that capture through the component use the same buffer that the block's template code writes to.

```ruby
def capture(*, **, &block)
  old_output_buffer = @output_buffer
  @output_buffer = view_context.output_buffer if view_context
  super
ensure
  @output_buffer = old_output_buffer
end
```

## Test

Adds a test case with a component that renders a partial using `form.label` with `yield`, verifying the yielded content appears inside the label tag.