### PR TITLE
Fix i18n scope for nested lambda-backed slots

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Fix translation scope resolution in nested lambda-backed slots. Relative `t(".key")` calls inside lambda-backed slots were resolving against an intermediate component's scope instead of the original partial's scope where the block was defined.
+
+    *Artin Boghosian*
+
 ## 4.10.0
 
 * Fix `NameError: uninitialized constant ViewComponent::SystemTestControllerNefariousPathError` when booting in the test environment with `eager_load = true`.

--- a/lib/view_component/slotable.rb
+++ b/lib/view_component/slotable.rb
@@ -380,6 +380,7 @@ module ViewComponent
     def __vc_set_slot(slot_name, slot_definition = nil, *args, **kwargs, &block)
       slot_definition ||= self.class.registered_slots[slot_name]
       slot = Slot.new(self)
+      captured_block_virtual_path = nil
 
       # Passing the block to the sub-component wrapper like this has two
       # benefits:
@@ -394,7 +395,8 @@ module ViewComponent
         slot.__vc_content_block = block
         # Capture the virtual path at the time the block is defined, so that
         # translations resolve relative to where the block was created, not where it's rendered
-        slot.__vc_content_block_virtual_path = view_context.instance_variable_get(:@virtual_path)
+        captured_block_virtual_path = view_context.instance_variable_get(:@virtual_path)
+        slot.__vc_content_block_virtual_path = captured_block_virtual_path
       end
 
       # If class
@@ -413,7 +415,7 @@ module ViewComponent
         renderable_value =
           if block
             renderable_function.call(*args, **kwargs) do |*rargs|
-              with_captured_virtual_path(@old_virtual_path) do
+              with_captured_virtual_path(captured_block_virtual_path) do
                 view_context.capture(*rargs, &block)
               end
             end

--- a/test/sandbox/app/components/lambda_slot_inner_component.rb
+++ b/test/sandbox/app/components/lambda_slot_inner_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class LambdaSlotInnerComponent < ViewComponent::Base
+  renders_one :aside, ->(&block) do
+    content_tag :div, class: "lambda-slot-aside", &block
+  end
+
+  erb_template <<~ERB
+    <div class="lambda-slot-inner">
+      <%= aside %>
+    </div>
+  ERB
+end

--- a/test/sandbox/app/components/lambda_slot_outer_component.rb
+++ b/test/sandbox/app/components/lambda_slot_outer_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class LambdaSlotOuterComponent < ViewComponent::Base
+  renders_one :inner, LambdaSlotInnerComponent
+
+  erb_template <<~ERB
+    <div class="lambda-slot-outer">
+      <%= inner %>
+    </div>
+  ERB
+end

--- a/test/sandbox/app/components/lambda_slot_translation_wrapper_component.rb
+++ b/test/sandbox/app/components/lambda_slot_translation_wrapper_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class LambdaSlotTranslationWrapperComponent < ViewComponent::Base
+  def call
+    render "shared/lambda_slot_translation"
+  end
+end

--- a/test/sandbox/app/views/shared/_lambda_slot_translation.html.erb
+++ b/test/sandbox/app/views/shared/_lambda_slot_translation.html.erb
@@ -1,0 +1,7 @@
+<%= render LambdaSlotOuterComponent.new do |outer| %>
+  <% outer.with_inner do |inner| %>
+    <% inner.with_aside do %>
+      <%= t(".lambda_action") %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/test/sandbox/config/locales/en.yml
+++ b/test/sandbox/config/locales/en.yml
@@ -32,6 +32,8 @@ en:
       menu_action: Menu Action from Partial
     deep_navigation:
       deep_action: Deep Action from Partial (5 levels!)
+    lambda_slot_translation:
+      lambda_action: Lambda Action from Partial
 
   rendering_test:
     i18n_test_component:

--- a/test/sandbox/test/components/deeply_nested_translation_test.rb
+++ b/test/sandbox/test/components/deeply_nested_translation_test.rb
@@ -28,6 +28,23 @@ class DeeplyNestedTranslationTest < ViewComponent::TestCase
     assert_includes result.to_html, "Menu Action from Partial"
   end
 
+  # Tests a nested lambda-backed slot, where the translation is defined in a partial
+  # but rendered inside a lambda slot on a nested child component.
+  #
+  # Structure:
+  #   Partial (_lambda_slot_translation.html.erb)
+  #     └─> LambdaSlotOuterComponent (Level 1)
+  #         └─> outer.with_inner → LambdaSlotInnerComponent (Level 2)
+  #             └─> inner.with_aside → lambda-backed slot (Level 3)
+  #                 └─> t(".lambda_action") ← Translation should resolve to partial's scope
+  #
+  # This exercises the lambda-backed slot path in Slotable#__vc_set_slot.
+  def test_translation_in_nested_lambda_backed_slot
+    result = render_inline(LambdaSlotTranslationWrapperComponent.new)
+
+    assert_includes result.to_html, "Lambda Action from Partial"
+  end
+
   # Tests 5 levels of nesting to prove the fix works for arbitrary depth
   #
   # Structure:


### PR DESCRIPTION
### What are you trying to accomplish?

Fix relative t(".key") translations inside nested lambda-backed slots resolving against the wrong scope. Instead of resolving to the partial where the block was defined, they resolved to an intermediate component's virtual path.
Fixes the bug reported in #2513 which persisted after #2520.

### What approach did you choose and why?

PR #2520 introduced `__vc_content_block_virtual_path` — capturing the virtual path at block-definition time and restoring it at block-evaluation time. This correctly fixed non-lambda slots via Slot#to_s.

However, lambda-backed slots are evaluated immediately inside `__vc_set_slot` rather than deferred to `Slot#to_s`. The lambda branch was updated in #2520 to wrap the block evaluation with `with_captured_virtual_path`, but used `@old_virtual_path` (the intermediate parent component's path) instead of the already-captured `slot.__vc_content_block_virtual_path` (the original partial's path).

The existing `slot.__vc_content_block_virtual_path` is defined via `attr_writer`, making it write-only. Rather than exposing it through an `attr_reader`, the captured path is stored in a local variable within __vc_set_slot and passed directly to the lambda branch. Happy to use a different approach if the project prefers exposing the reader instead.
