### PR TITLE
Fix compiler crash on Rails main after template_handler_extensions removal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ nav_order: 6
 
     *Peter Yates*
 
+* Fix `NoMethodError: undefined method 'template_handler_extensions'` when gathering sidecar templates on Rails main. Action View removed the `ActionView::Template.template_handler_extensions` method in newer versions; the compiler now reads the registered extensions through `ActionView::Template::Handlers.extensions`, which is the supported read-path API across all supported Rails versions (7.1+).
+
+    *Luiz Kowalski*
+
 ## 4.12.0
 
 * Fix stale render context on reused component instances. A `ViewComponent::Base` instance memoized its controller, helpers, request, view context, lookup context, view flow, and requested format details on first render via `||=`. Rendering the same instance a second time (intentionally or via aliasing) reused that stale context, which could leak data across requests, sessions, or users. `#render_in` now resets these ivars on every call so each render derives its context from the current view.

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -177,7 +177,7 @@ module ViewComponent
         else
           path_parser = ActionView::Resolver::PathParser.new
           templates = @component.sidecar_files(
-            ActionView::Template.template_handler_extensions
+            ActionView::Template::Handlers.extensions
           ).map do |path|
             details = path_parser.parse(path).details
             Template::File.new(component: @component, path: path, details: details)


### PR DESCRIPTION
Rails removed `ActionView::Template.template_handler_extensions` in [rails/rails#57874](https://github.com/rails/rails/pull/57874), so the compiler crashes with `NoMethodError` when gathering sidecar templates on Rails main.

This reads the registered extensions through `ActionView::Template::Handlers.extensions` instead. That method is the supported read-path API and exists on every supported Rails version (7.1+), so no version check is needed.

Tested: full sandbox suite green on Rails 8.1; confirmed the old call raises and the new one works against the actual PR commit.