### PR TITLE
Update govuk-components resources link to new x-govuk.org domain

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Update link to GOV.UK Components library in resources list to govuk-components.x-govuk.org
+
+    *Peter Yates*
+
 ## 4.12.0
 
 * Fix stale render context on reused component instances. A `ViewComponent::Base` instance memoized its controller, helpers, request, view context, lookup context, view flow, and requested format details on first render via `||=`. Rendering the same instance a second time (intentionally or via aliasing) reused that stale context, which could leak data across requests, sessions, or users. `#render_in` now resets these ivars on every call so each render derives its context from the current view.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -11,7 +11,7 @@ _Is this page missing a link? Open a PR!_
 ## ViewComponent libraries
 
 - [Primer ViewComponents](https://primer.style/view-components/)
-- [GOV.UK Rails Components](https://govuk-components.netlify.app/)
+- [GOV.UK Rails Components](https://govuk-components.x-govuk.org/)
 - [Polaris ViewComponents](https://github.com/baoagency/polaris_view_components)
 - [Rails Designer](https://railsdesigner.com/)
 


### PR DESCRIPTION
We've moved all x-govuk projects under the [x-govuk.org](https://x-govuk.org/) umbrella now and won't be using the netlify.app subdomains any more.

This follows govuk-components.netlify.app being flagged for 'social engineering'. We've verified x-govuk.org with Netcraft so this shouldn't happen again :crossed_fingers: 