### PR TITLE
Freeze ViewComponent::VERSION::STRING (audition round 2)

### DIFF
--- a/.audition-baseline.json
+++ b/.audition-baseline.json
@@ -124,7 +124,6 @@
   "runtime-unshareable-constant|/Users/joelhawksley/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/i18n-1.14.8/lib/i18n/interpolate/ruby.rb": 1,
   "runtime-unshareable-constant|/Users/joelhawksley/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/logger-1.7.0/lib/logger.rb": 1,
   "runtime-unshareable-constant|/Users/joelhawksley/github/view_component/lib/view_component/deprecation.rb": 1,
-  "runtime-unshareable-constant|/Users/joelhawksley/github/view_component/lib/view_component/version.rb": 1,
   "unsafe-calls|lib/view_component/base.rb": 1,
   "unsafe-calls|lib/view_component/compile_cache.rb": 1,
   "unsafe-calls|lib/view_component/compiler.rb": 3,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Freeze `ViewComponent::VERSION::STRING` so the version constant is immutable and Ractor-shareable.
+
+    *Joel Hawksley*
+
 * Add [audition](https://github.com/yaroslav/audition) Ractor-readiness checks to CI. Applied safe `.freeze` auto-fixes to string constants in `ViewComponent::Errors` and baselined existing findings so the gate fails only on new Ractor-isolation violations.
 
     *Joel Hawksley*

--- a/lib/view_component/version.rb
+++ b/lib/view_component/version.rb
@@ -7,7 +7,7 @@ module ViewComponent
     PATCH = 0
     PRE = nil
 
-    STRING = [MAJOR, MINOR, PATCH, PRE].compact.join(".")
+    STRING = [MAJOR, MINOR, PATCH, PRE].compact.join(".").freeze
   end
 end
 


### PR DESCRIPTION
Follow-up to the audition CI integration.

Fixes one non-controversial, low-hanging finding from the audition baseline:

- `ViewComponent::VERSION::STRING` is built with `[...].compact.join(".")`. Because `frozen_string_literal` only freezes string *literals* (not the result of `#join`), the constant held a mutable, non-Ractor-shareable String. Freezing it makes the version constant immutable and shareable.
- Regenerated `.audition-baseline.json` (201 → 200 findings); the `runtime-unshareable-constant` entry for `version.rb` is removed.

Left for later (not low-hanging / would change behavior or public API): the class variables and `class_attribute`/`mattr_accessor` state, class-level ivars, `define_method` blocks, and the `$PROGRAM_NAME` script-run line.