### PR TITLE
Remove $PROGRAM_NAME version-print line (audition round 3)

### DIFF
--- a/.audition-baseline.json
+++ b/.audition-baseline.json
@@ -2,7 +2,6 @@
   "class-level-state|lib/view_component/base.rb": 9,
   "class-level-state|lib/view_component/preview.rb": 2,
   "class-variables|lib/view_component/base.rb": 2,
-  "global-variables|lib/view_component/version.rb": 1,
   "runtime-class-state|/Users/joelhawksley/.local/share/mise/installs/ruby/4.0.5/lib/ruby/4.0.0/delegate.rb": 1,
   "runtime-class-state|/Users/joelhawksley/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/actionpack-8.1.3/lib/action_dispatch/http/mime_type.rb": 3,
   "runtime-class-state|/Users/joelhawksley/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/actionview-8.1.3/lib/action_view/gem_version.rb": 1,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,6 +339,10 @@ GEM
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
     rubydex (0.3.0)
+    rubydex (0.3.0-aarch64-linux)
+    rubydex (0.3.0-arm64-darwin)
+    rubydex (0.3.0-x86_64-darwin)
+    rubydex (0.3.0-x86_64-linux)
     rubyzip (3.3.0)
     securerandom (0.4.1)
     selenium-webdriver (4.44.0)
@@ -604,6 +608,10 @@ CHECKSUMS
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   rubydex (0.3.0) sha256=902ba4546c548de6a1908acee54cf3f5b998f01c87e2ad6fbd708011774df4e5
+  rubydex (0.3.0-aarch64-linux) sha256=a7221b71b21c5a1cdda1fbac0946ee0411a2efd94c8115cf37e4e69461d88e73
+  rubydex (0.3.0-arm64-darwin) sha256=19f685610216e4e7f488722ac90dfbc33113a384dd16db309cf939606f4c32dd
+  rubydex (0.3.0-x86_64-darwin) sha256=59d20c98b0bf2226f5db5bee14cf57075aa93aa0c3fa0176f496a217691ff7b6
+  rubydex (0.3.0-x86_64-linux) sha256=dfe4026591f226b4a1b53f82f86dc14fad2e7c221ee8a5be99a0a46bf2d58b04
   rubyzip (3.3.0) sha256=a372fc67892a4f8c0bc8ec906b720353d8e48807a64b2e63adf99b1e3583a034
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.44.0) sha256=6f1df072529af369589c46f0e01132952aabb250cfd683c274d74dc1eb5d8477

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Remove the `$PROGRAM_NAME` version-printing line from `version.rb` so the file no longer reads a global variable (unshareable across Ractors). The version is still available via `ViewComponent::VERSION::STRING`.
+
+    *Joel Hawksley*
+
 * Freeze `ViewComponent::VERSION::STRING` so the version constant is immutable and Ractor-shareable.
 
     *Joel Hawksley*

--- a/lib/view_component/version.rb
+++ b/lib/view_component/version.rb
@@ -10,4 +10,3 @@ module ViewComponent
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join(".").freeze
   end
 end
-

--- a/lib/view_component/version.rb
+++ b/lib/view_component/version.rb
@@ -11,4 +11,3 @@ module ViewComponent
   end
 end
 
-puts ViewComponent::VERSION::STRING if __FILE__ == $PROGRAM_NAME


### PR DESCRIPTION
Round 3 of audition Ractor-readiness work. Small by design: fixes the one remaining finding resolvable without breaking public APIs or the test suite; leaves the rest.

Changes:
- version.rb: removed trailing puts VERSION::STRING if __FILE__ == $PROGRAM_NAME (reads the $PROGRAM_NAME global, unshareable in non-main Ractors; only ran when executed directly, which nothing does). Clears the global-variables finding.
- .audition-baseline.json: removed the resolved version.rb entry.
- Gemfile.lock: pinned rubydex precompiled platform variants so bundle install works without Cargo.

Left for later (would risk API/tests/load-order): @@default_output_preamble/postamble (frozen-constant fix drops test_render_inline_allocations below its per-version floor); class_attribute/mattr_accessor (public config API); define_method blocks; class-level memoization (allocation-sensitive); autoload/lazy requires (deliberate load-order/optional-dep).

Verified: full suite green on Ruby 4.0 (517 runs, 0 failures); audition --static-only passes.