### PR TITLE
[3.x] Add a failing test for rendering a partial inside a collection rendering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    view_component (3.24.0)
+    view_component (3.25.0)
       activesupport (>= 5.2.0, < 8.2)
       concurrent-ruby (~> 1)
       method_source (~> 1.0)

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -23,7 +23,7 @@ module PreviewHelper
   end
 
   def find_template_data_for_preview_source(lookup_context:, template_identifier:)
-    template = lookup_context.find_template(template_identifier)
+    template = find_template_for_preview_source(lookup_context, template_identifier)
 
     if Rails.version.to_f >= 6.1 || template.source.present?
       {
@@ -60,6 +60,14 @@ module PreviewHelper
   end
 
   private
+
+  def find_template_for_preview_source(lookup_context, template_identifier)
+    if lookup_context.respond_to?(:find_template)
+      lookup_context.find_template(template_identifier)
+    else
+      lookup_context.find(template_identifier)
+    end
+  end
 
   def prism_language_name_by_template(template:)
     language = template.identifier.split(".").last

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ nav_order: 6
 
     *Justin Coyne, Joel Hawksley*
 
-* Restore compatibility with Rails main after `ActionView::Template.template_handler_extensions` was removed.
+* Restore compatibility with Rails main after `ActionView::Template.template_handler_extensions` and `ActionView::LookupContext#find_template` were removed.
 
     *Joel Hawksley*
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ nav_order: 6
 
     *Justin Coyne, Joel Hawksley*
 
+* Restore compatibility with Rails main after `ActionView::Template.template_handler_extensions` was removed.
+
+    *Joel Hawksley*
+
 ## 3.25.0
 
 * Support Rails `render_in` options signature. Rails [#50623](https://github.com/rails/rails/pull/50623) changed the `render_in` signature from `render_in(view_context, &block)` to `render_in(view_context, **options, &block)`. `ViewComponent::Base#render_in`, `ViewComponent::Collection#render_in`, and `ViewComponent::Instrumentation#render_in` now accept `**options`, restoring compatibility with Rails main and silencing the deprecation warning.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Fix rendering partials from components rendered as a collection when the original view context is explicitly stashed as `nil`.
+
+    *Justin Coyne, Joel Hawksley*
+
 ## 3.25.0
 
 * Support Rails `render_in` options signature. Rails [#50623](https://github.com/rails/rails/pull/50623) changed the `render_in` signature from `render_in(view_context, &block)` to `render_in(view_context, **options, &block)`. `ViewComponent::Base#render_in`, `ViewComponent::Collection#render_in`, and `ViewComponent::Instrumentation#render_in` now accept `**options`, restoring compatibility with Rails main and silencing the deprecation warning.

--- a/lib/view_component/base.rb
+++ b/lib/view_component/base.rb
@@ -88,7 +88,7 @@ module ViewComponent
       @view_context = view_context
       self.__vc_original_view_context =
         if instance_variable_defined?(:@__vc_pending_original_view_context)
-          remove_instance_variable(:@__vc_pending_original_view_context)
+          remove_instance_variable(:@__vc_pending_original_view_context) || view_context
         else
           view_context
         end

--- a/lib/view_component/compiler.rb
+++ b/lib/view_component/compiler.rb
@@ -170,7 +170,7 @@ module ViewComponent
       @templates ||=
         begin
           templates = @component.sidecar_files(
-            ActionView::Template.template_handler_extensions
+            template_handler_extensions
           ).map do |path|
             # Extract format and variant from template filename
             this_format, variant =
@@ -224,6 +224,14 @@ module ViewComponent
 
           templates
         end
+    end
+
+    def template_handler_extensions
+      if ActionView::Template.respond_to?(:template_handler_extensions)
+        ActionView::Template.template_handler_extensions
+      else
+        ActionView::Template::Handlers.extensions.map(&:to_s)
+      end
     end
   end
 end

--- a/test/sandbox/test/collection_test.rb
+++ b/test/sandbox/test/collection_test.rb
@@ -22,6 +22,20 @@ module ViewComponent
       end
     end
 
+    # Renders a plain partial, which routes through `ViewComponent::Base#render`
+    # and so depends on `__vc_original_view_context` being set.
+    class PartialRenderingComponent < ViewComponent::Base
+      with_collection_parameter :item
+
+      def initialize(item: nil)
+        @item = item
+      end
+
+      def call
+        render partial: "integration_examples/test_partial"
+      end
+    end
+
     def setup
       @products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
       @collection = ProductComponent.with_collection(@products, notice: "secondhand")
@@ -45,6 +59,16 @@ module ViewComponent
     def test_supports_collection_with_spacer_component
       render_inline(ProductComponent.with_collection(@products, spacer_component: SpacerComponent.new))
       assert_selector("hr", count: 1)
+    end
+
+    # A collection rendered from a plain view (rather than from inside another
+    # component) never has `set_original_view_context` called on it, so its own
+    # `__vc_original_view_context` is nil. That nil must not be forwarded to the
+    # child components, or rendering a partial from one raises NoMethodError.
+    def test_supports_components_that_render_partials
+      render_inline(PartialRenderingComponent.with_collection([1, 2]))
+
+      assert_text("hello,partial world!", count: 2)
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
This is a bug report, of a regression in 3.25 (from 3.24).  

We get this error when rendering a partial from within a rendered component:

```
NoMethodError: undefined method 'render' for nil
    lib/view_component/base.rb:228:in 'ViewComponent::Base#render'
    test/sandbox/test/collection_test.rb:35:in '...PartialRenderingComponent#call'
    lib/view_component/collection.rb:22:in 'block in ViewComponent::Collection#render_in'
    lib/view_component/test_helpers.rb:54:in 'ViewComponent::TestHelpers#render_inline'
```

I believe this was introduced by ce1c920a

on this line here: https://github.com/ViewComponent/view_component/commit/ce1c920a0894199756e6ca2297f7aed429fa081e#diff-b69c75ffd85596e0b5fca1327059ecf3b2930f3f77004c78a268fa85e8ec8d9eL83

The old `||=` silently masked a `nil`. The new code keys off `instance_variable_defined?`, so an explicitly-stashed `nil` is now honored.

I think we can fix this by adding:
```ruby
(remove_instance_variable(...) || view_context
```
 at base.rb:91.
