### PR TITLE
release 3.26.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    view_component (3.25.0)
+    view_component (3.26.0)
       activesupport (>= 5.2.0, < 8.2)
       concurrent-ruby (~> 1)
       method_source (~> 1.0)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ nav_order: 6
 
 ## main
 
+## 3.26.0
+
 * Fix rendering partials from components rendered as a collection when the original view context is explicitly stashed as `nil`.
 
     *Justin Coyne, Joel Hawksley*

--- a/docs/_data/library.yml
+++ b/docs/_data/library.yml
@@ -1,1 +1,1 @@
-version: 3.25.0
+version: 3.26.0

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,6 +14,10 @@ nav_order: 3
 
 Returns the current config.
 
+### `.identifier` → [String]
+
+The file path of the component Ruby file.
+
 ### `.sidecar_files(extensions)`
 
 Find sidecar files for the given extensions.
@@ -37,7 +41,7 @@ end
 
 Whether trailing whitespace will be stripped before compilation.
 
-### `.with_collection(collection, **args)`
+### `.with_collection(collection, spacer_component: nil, **args)`
 
 Render a component for each element in a collection ([documentation](/guide/collections)):
 
@@ -78,23 +82,24 @@ that inhibits encapsulation & reuse, often making testing difficult.
 A proxy through which to access helpers. Use sparingly as doing so introduces
 coupling that inhibits encapsulation & reuse, often making testing difficult.
 
-### `#output_preamble` → [String]
-
-Optional content to be returned before the rendered template.
-
 ### `#output_postamble` → [String]
 
 Optional content to be returned after the rendered template.
+
+### `#output_preamble` → [String]
+
+Optional content to be returned before the rendered template.
 
 ### `#render?` → [Boolean]
 
 Override to determine whether the ViewComponent should render.
 
-### `#render_in(view_context, &block)` → [String]
+### `#render_in(view_context, **options, &block)` → [String]
 
 Entrypoint for rendering components.
 
 - `view_context`: ActionView context from calling view
+- `options`: optional render options (e.g., locals)
 - `block`: optional block to be captured within the view context
 
 Returns HTML that has been escaped by the respective template handler.
@@ -191,6 +196,12 @@ Always generate a Stimulus controller alongside the component:
 
     config.view_component.generate.stimulus_controller = true
 
+#### `#typescript`
+
+Generate TypeScript files instead of JavaScript files:
+
+    config.view_component.generate.typescript = true
+
 #### `#locale`
 
 Always generate translations file alongside the component:
@@ -222,6 +233,19 @@ Required when there is more than one path defined in preview_paths.
 Defaults to `""`. If this is blank, the generator will use
 `ViewComponent.config.preview_paths` if defined,
 `"test/components/previews"` otherwise
+
+#### `#use_component_path_for_rspec_tests`
+
+Whether to use the `config.view_component_path` when generating new
+RSpec component tests:
+
+    config.view_component.generate.use_component_path_for_rspec_tests = true
+
+When set to `true`, the generator will use the `view_component_path` to
+decide where to generate the new RSpec component test.
+For example, if the `view_component_path` is
+`app/views/components`, then the generator will create a new spec file
+in `spec/views/components/` rather than the default `spec/components/`.
 
 ### `.instrumentation_enabled`
 
@@ -325,6 +349,15 @@ In RSpec, `Preview` is appended to `described_class`.
 
 Returns the result of a render_inline call.
 
+### `#rendered_json`
+
+`JSON.parse`-d component output.
+
+```ruby
+render_inline(MyJsonComponent.new)
+assert_equal(rendered_json["hello"], "world")
+```
+
 ### `#vc_test_controller` → [ActionController::Base]
 
 Access the controller used by `render_inline`:
@@ -343,7 +376,7 @@ Access the request used by `render_inline`:
 
 ```ruby
 test "component does not render in Firefox" do
-  vc_test_request.env["HTTP_USER_AGENT"] = "Mozilla/5.0"
+  request.env["HTTP_USER_AGENT"] = "Mozilla/5.0"
   render_inline(NoFirefoxComponent.new)
   refute_component_rendered
 end
@@ -360,7 +393,17 @@ with_controller_class(UsersController) do
 end
 ```
 
-### `#with_request_url(full_path, host: nil, method: nil)`
+### `#with_format(format)`
+
+Set format of the current request
+
+```ruby
+with_format(:json) do
+  render_inline(MyComponent.new)
+end
+```
+
+### `#with_request_url(full_path, host: nil, method: nil, format: ViewComponent::Base::VC_INTERNAL_DEFAULT_FORMAT)`
 
 Set the URL of the current request (such as when using request-dependent path helpers):
 
@@ -418,7 +461,7 @@ To fix this issue, either use the `content` accessor directly or choose a differ
 
 ### `ControllerCalledBeforeRenderError`
 
-`#controller` can't be used during initialization, as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
+`#controller` can't be used before rendering, as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
 
 It's sometimes possible to fix this issue by moving code dependent on `#controller` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void).
 
@@ -444,7 +487,7 @@ See [the collections docs](https://viewcomponent.org/guide/collections.html) for
 
 ### `HelpersCalledBeforeRenderError`
 
-`#helpers` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
+`#helpers` can't be used before rendering as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
 
 It's sometimes possible to fix this issue by moving code dependent on `#helpers` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void).
 
@@ -528,7 +571,7 @@ ViewComponent SystemTest controller must only be called in a test environment fo
 
 ### `TranslateCalledBeforeRenderError`
 
-`#translate` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
+`#translate` can't be used before rendering as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
 
 It's sometimes possible to fix this issue by moving code dependent on `#translate` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void).
 

--- a/lib/view_component/version.rb
+++ b/lib/view_component/version.rb
@@ -3,7 +3,7 @@
 module ViewComponent
   module VERSION
     MAJOR = 3
-    MINOR = 25
+    MINOR = 26
     PATCH = 0
     PRE = nil
 


### PR DESCRIPTION
Release 3.26.0.

## Changes

* Fix rendering partials from components rendered as a collection when the original view context is explicitly stashed as `nil`. (#2674)

    *Justin Coyne, Joel Hawksley*

* Restore compatibility with Rails main after `ActionView::Template.template_handler_extensions` and `ActionView::LookupContext#find_template` were removed.

    *Joel Hawksley*

After merge: run `script/publish` on `3.x` to push the gem, then create a GitHub release for `v3.26.0`.