### PR TITLE
Add zizmor security analysis to CI

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,7 +16,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
       - name: Run zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions security analysis
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Add zizmor security analysis for GitHub Actions workflows to CI.
+
+    *Joel Hawksley*
+
 * Remove the `$PROGRAM_NAME` version-printing line from `version.rb` so the file no longer reads a global variable (unshareable across Ractors). The version is still available via `ViewComponent::VERSION::STRING`.
 
     *Joel Hawksley*


### PR DESCRIPTION
### What are you trying to accomplish?

Continuously scan the repository's GitHub Actions configuration for security issues with [zizmor](https://github.com/zizmorcore/zizmor).

### What approach did you choose and why?

Add the upstream-recommended zizmor action as a dedicated workflow on pull requests and pushes to `main`. The workflow uploads SARIF results to code scanning, uses only the required `security-events: write` permission, disables persisted checkout credentials, and pins actions to commit SHAs.

SARIF reporting is intentionally non-blocking because the repository currently has pre-existing findings that should be triaged separately rather than blocking every pull request immediately.

### Anything you want to highlight for special attention from reviewers?

The new workflow was scanned locally with zizmor 1.29.0 and reports no findings of its own.