### PR TITLE
Use minitest-memory for allocation tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Repository instructions
+
+- After changing dependencies in `Gemfile`, regenerate the appraisal Gemfiles with `bundle exec appraisal generate`, then update every appraisal lockfile with `bundle exec appraisal-run gemfiles/*.gemfile -- bundle lock`.

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ ruby_version = (ENV["RUBY_VERSION"] || "~> 4.0").to_s
 ruby ruby_version
 
 group :development, :test do
-  gem "allocation_stats"
   gem "appraisal", "~> 2"
   gem "appraisal-run", "~> 1.1"
   gem "audition", require: false
@@ -27,6 +26,7 @@ group :development, :test do
   gem "m", "~> 1"
   gem "method_source", "~> 1"
   gem "minitest", "~> 6"
+  gem "minitest-memory"
   gem "minitest-mock"
   gem "nokogiri", "1.19.4"
   gem "propshaft", "~> 1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,6 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    allocation_stats (0.1.5)
     ansi (1.6.0)
     appraisal (2.5.0)
       bundler
@@ -189,7 +188,12 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    minitest-memory (1.1.0)
+      minitest (>= 5.21, < 7)
+      minitest-strict (>= 1.0)
     minitest-mock (5.27.0)
+    minitest-strict (1.0.1)
+      minitest (>= 5.21, < 7)
     net-imap (0.6.6)
       date
       net-protocol
@@ -443,7 +447,6 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  allocation_stats
   appraisal (~> 2)
   appraisal-run (~> 1.1)
   audition
@@ -459,6 +462,7 @@ DEPENDENCIES
   m (~> 1)
   method_source (~> 1)
   minitest (~> 6)
+  minitest-memory
   minitest-mock
   nokogiri (= 1.19.4)
   propshaft (~> 1)
@@ -498,7 +502,6 @@ CHECKSUMS
   activestorage (8.1.3.1) sha256=f555254f387b1cffa499d2fd3115d12635eadc5b15206a8534316a67036163ef
   activesupport (8.1.3.1) sha256=85458765f25ea48b9019c46b6bb3fa5683197bf4280d9f06710a6e8d7a831376
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  allocation_stats (0.1.5) sha256=cb9bb238c871d0d308e7f8316044be0a9bf68b194959a0c7a16adb97efa2b903
   ansi (1.6.0) sha256=ac9ea0c0ea8d32fb4e271348e609963ac78882f34b73836c2a02b3622e666658
   appraisal (2.5.0) sha256=36989221be127913b0dba8d114da2001e6b2dceea7bd4951200eaba764eed3ce
   appraisal-run (1.1.0) sha256=93179b8fe4d7a3469a703dab69deccc88432bfe43f979acdebbe514e21af9789
@@ -546,7 +549,9 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  minitest-memory (1.1.0) sha256=1251476a6e636a9b3bf4f02cd50a2edd6837db53afb81c5e78474e7144f1b747
   minitest-mock (5.27.0) sha256=7040ed7185417a966920987eaa6eaf1be4ea1fc5b25bb03ff4703f98564a55b0
+  minitest-strict (1.0.1) sha256=5bf179ed48c21013575cc00506be3fd6ceec8529636ce6897468f9574004ae06
   net-imap (0.6.6) sha256=96aa4ee50df3060203e649efc341f53480b791d49e150f2fdebf68beb141a8df
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Replace the custom memory allocation test helper with `minitest-memory`, preserving Ruby-version-specific allocation thresholds while improving failure diagnostics.
+
+    *Joel Hawksley*
+
 * Remove the `$PROGRAM_NAME` version-printing line from `version.rb` so the file no longer reads a global variable (unshareable across Ractors). The version is still available via `ViewComponent::VERSION::STRING`.
 
     *Joel Hawksley*

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -7,7 +7,6 @@ ruby "~> 3.2"
 gem "rails", "~> 7.1.0"
 
 group :development, :test do
-  gem "allocation_stats"
   gem "appraisal", "~> 2"
   gem "appraisal-run", "~> 1.1"
   gem "benchmark-ips", "~> 2"
@@ -22,6 +21,7 @@ group :development, :test do
   gem "m", "~> 1"
   gem "method_source", "~> 1"
   gem "minitest", "~> 6"
+  gem "minitest-memory"
   gem "minitest-mock"
   gem "nokogiri", "1.19.3"
   gem "propshaft", "~> 1"

--- a/gemfiles/rails_7.1.gemfile.lock
+++ b/gemfiles/rails_7.1.gemfile.lock
@@ -90,7 +90,6 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    allocation_stats (0.1.5)
     ansi (1.5.0)
     appraisal (2.5.0)
       bundler
@@ -193,7 +192,12 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    minitest-memory (1.1.0)
+      minitest (>= 5.21, < 7)
+      minitest-strict (>= 1.0)
     minitest-mock (5.27.0)
+    minitest-strict (1.0.1)
+      minitest (>= 5.21, < 7)
     mutex_m (0.3.0)
     net-imap (0.5.12)
       date
@@ -435,7 +439,6 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  allocation_stats
   appraisal (~> 2)
   appraisal-run (~> 1.1)
   benchmark-ips (~> 2)
@@ -450,6 +453,7 @@ DEPENDENCIES
   m (~> 1)
   method_source (~> 1)
   minitest (~> 6)
+  minitest-memory
   minitest-mock
   nokogiri (= 1.19.3)
   propshaft (~> 1)

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -7,7 +7,6 @@ ruby "~> 3.3"
 gem "rails", "~> 7.2.0"
 
 group :development, :test do
-  gem "allocation_stats"
   gem "appraisal", "~> 2"
   gem "appraisal-run", "~> 1.1"
   gem "benchmark-ips", "~> 2"
@@ -22,6 +21,7 @@ group :development, :test do
   gem "m", "~> 1"
   gem "method_source", "~> 1"
   gem "minitest", "~> 6"
+  gem "minitest-memory"
   gem "minitest-mock"
   gem "nokogiri", "1.19.3"
   gem "propshaft", "~> 1"

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -84,7 +84,6 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    allocation_stats (0.1.5)
     ansi (1.5.0)
     appraisal (2.5.0)
       bundler
@@ -187,7 +186,12 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    minitest-memory (1.1.0)
+      minitest (>= 5.21, < 7)
+      minitest-strict (>= 1.0)
     minitest-mock (5.27.0)
+    minitest-strict (1.0.1)
+      minitest (>= 5.21, < 7)
     net-imap (0.5.12)
       date
       net-protocol
@@ -428,7 +432,6 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  allocation_stats
   appraisal (~> 2)
   appraisal-run (~> 1.1)
   benchmark-ips (~> 2)
@@ -443,6 +446,7 @@ DEPENDENCIES
   m (~> 1)
   method_source (~> 1)
   minitest (~> 6)
+  minitest-memory
   minitest-mock
   nokogiri (= 1.19.3)
   propshaft (~> 1)

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -7,7 +7,6 @@ ruby "~> 3.4"
 gem "rails", "~> 8.0.0"
 
 group :development, :test do
-  gem "allocation_stats"
   gem "appraisal", "~> 2"
   gem "appraisal-run", "~> 1.1"
   gem "benchmark-ips", "~> 2"
@@ -22,6 +21,7 @@ group :development, :test do
   gem "m", "~> 1"
   gem "method_source", "~> 1"
   gem "minitest", "~> 6"
+  gem "minitest-memory"
   gem "minitest-mock"
   gem "nokogiri", "1.19.3"
   gem "propshaft", "~> 1"

--- a/gemfiles/rails_8.0.gemfile.lock
+++ b/gemfiles/rails_8.0.gemfile.lock
@@ -82,7 +82,6 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    allocation_stats (0.1.5)
     ansi (1.5.0)
     appraisal (2.5.0)
       bundler
@@ -184,7 +183,12 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    minitest-memory (1.1.0)
+      minitest (>= 5.21, < 7)
+      minitest-strict (>= 1.0)
     minitest-mock (5.27.0)
+    minitest-strict (1.0.1)
+      minitest (>= 5.21, < 7)
     net-imap (0.5.12)
       date
       net-protocol
@@ -425,7 +429,6 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  allocation_stats
   appraisal (~> 2)
   appraisal-run (~> 1.1)
   benchmark-ips (~> 2)
@@ -440,6 +443,7 @@ DEPENDENCIES
   m (~> 1)
   method_source (~> 1)
   minitest (~> 6)
+  minitest-memory
   minitest-mock
   nokogiri (= 1.19.3)
   propshaft (~> 1)

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -7,7 +7,6 @@ ruby "~> 4.0"
 gem "rails", "~> 8.1.0"
 
 group :development, :test do
-  gem "allocation_stats"
   gem "appraisal", "~> 2"
   gem "appraisal-run", "~> 1.1"
   gem "benchmark-ips", "~> 2"
@@ -22,6 +21,7 @@ group :development, :test do
   gem "m", "~> 1"
   gem "method_source", "~> 1"
   gem "minitest", "~> 6"
+  gem "minitest-memory"
   gem "minitest-mock"
   gem "nokogiri", "1.19.3"
   gem "propshaft", "~> 1"

--- a/gemfiles/rails_8.1.gemfile.lock
+++ b/gemfiles/rails_8.1.gemfile.lock
@@ -85,7 +85,6 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
-    allocation_stats (0.1.5)
     ansi (1.5.0)
     appraisal (2.5.0)
       bundler
@@ -185,7 +184,12 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    minitest-memory (1.1.0)
+      minitest (>= 5.21, < 7)
+      minitest-strict (>= 1.0)
     minitest-mock (5.27.0)
+    minitest-strict (1.0.1)
+      minitest (>= 5.21, < 7)
     net-imap (0.6.2)
       date
       net-protocol
@@ -423,7 +427,6 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  allocation_stats
   appraisal (~> 2)
   appraisal-run (~> 1.1)
   benchmark-ips (~> 2)
@@ -438,6 +441,7 @@ DEPENDENCIES
   m (~> 1)
   method_source (~> 1)
   minitest (~> 6)
+  minitest-memory
   minitest-mock
   nokogiri (= 1.19.3)
   propshaft (~> 1)

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -8,7 +8,6 @@ gem "rails", github: "rails/rails", branch: "main"
 gem "rack", git: "https://github.com/rack/rack", ref: "8a4475a9f416a72e5b02bd7817e4a8ed684f29b0"
 
 group :development, :test do
-  gem "allocation_stats"
   gem "appraisal", "~> 2"
   gem "appraisal-run", "~> 1.1"
   gem "benchmark-ips", "~> 2"
@@ -23,6 +22,7 @@ group :development, :test do
   gem "m", "~> 1"
   gem "method_source", "~> 1"
   gem "minitest", "~> 6"
+  gem "minitest-memory"
   gem "minitest-mock"
   gem "nokogiri", "1.19.3"
   gem "propshaft", "~> 1"

--- a/gemfiles/rails_main.gemfile.lock
+++ b/gemfiles/rails_main.gemfile.lock
@@ -122,7 +122,6 @@ GEM
       railties
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    allocation_stats (0.1.5)
     ansi (1.6.0)
     appraisal (2.5.0)
       bundler
@@ -223,7 +222,12 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    minitest-memory (1.1.0)
+      minitest (>= 5.21, < 7)
+      minitest-strict (>= 1.0)
     minitest-mock (5.27.0)
+    minitest-strict (1.0.1)
+      minitest (>= 5.21, < 7)
     net-imap (0.6.4)
       date
       net-protocol
@@ -437,7 +441,6 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  allocation_stats
   appraisal (~> 2)
   appraisal-run (~> 1.1)
   benchmark-ips (~> 2)
@@ -452,6 +455,7 @@ DEPENDENCIES
   m (~> 1)
   method_source (~> 1)
   minitest (~> 6)
+  minitest-memory
   minitest-mock
   nokogiri (= 1.19.3)
   propshaft (~> 1)
@@ -492,7 +496,6 @@ CHECKSUMS
   activestorage (8.2.0.alpha)
   activesupport (8.2.0.alpha)
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  allocation_stats (0.1.5) sha256=cb9bb238c871d0d308e7f8316044be0a9bf68b194959a0c7a16adb97efa2b903
   ansi (1.6.0) sha256=ac9ea0c0ea8d32fb4e271348e609963ac78882f34b73836c2a02b3622e666658
   appraisal (2.5.0) sha256=36989221be127913b0dba8d114da2001e6b2dceea7bd4951200eaba764eed3ce
   appraisal-run (1.1.0) sha256=93179b8fe4d7a3469a703dab69deccc88432bfe43f979acdebbe514e21af9789
@@ -542,7 +545,9 @@ CHECKSUMS
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  minitest-memory (1.1.0) sha256=1251476a6e636a9b3bf4f02cd50a2edd6837db53afb81c5e78474e7144f1b747
   minitest-mock (5.27.0) sha256=7040ed7185417a966920987eaa6eaf1be4ea1fc5b25bb03ff4703f98564a55b0
+  minitest-strict (1.0.1) sha256=5bf179ed48c21013575cc00506be3fd6ceec8529636ce6897468f9574004ae06
   net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/gemfiles/rails_main_head.gemfile
+++ b/gemfiles/rails_main_head.gemfile
@@ -8,7 +8,6 @@ gem "rails", github: "rails/rails", branch: "main"
 gem "rack", git: "https://github.com/rack/rack", ref: "8a4475a9f416a72e5b02bd7817e4a8ed684f29b0"
 
 group :development, :test do
-  gem "allocation_stats"
   gem "appraisal", "~> 2"
   gem "appraisal-run", "~> 1.1"
   gem "benchmark-ips", "~> 2"
@@ -23,6 +22,7 @@ group :development, :test do
   gem "m", "~> 1"
   gem "method_source", "~> 1"
   gem "minitest", "~> 6"
+  gem "minitest-memory"
   gem "minitest-mock"
   gem "nokogiri", "1.19.3"
   gem "propshaft", "~> 1"

--- a/gemfiles/rails_main_head.gemfile.lock
+++ b/gemfiles/rails_main_head.gemfile.lock
@@ -122,7 +122,6 @@ GEM
       railties
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    allocation_stats (0.1.5)
     ansi (1.6.0)
     appraisal (2.5.0)
       bundler
@@ -217,7 +216,12 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    minitest-memory (1.1.0)
+      minitest (>= 5.21, < 7)
+      minitest-strict (>= 1.0)
     minitest-mock (5.27.0)
+    minitest-strict (1.0.1)
+      minitest (>= 5.21, < 7)
     net-imap (0.6.4)
       date
       net-protocol
@@ -407,7 +411,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  allocation_stats
   appraisal (~> 2)
   appraisal-run (~> 1.1)
   benchmark-ips (~> 2)
@@ -422,6 +425,7 @@ DEPENDENCIES
   m (~> 1)
   method_source (~> 1)
   minitest (~> 6)
+  minitest-memory
   minitest-mock
   nokogiri (= 1.19.3)
   propshaft (~> 1)
@@ -462,7 +466,6 @@ CHECKSUMS
   activestorage (8.2.0.alpha)
   activesupport (8.2.0.alpha)
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  allocation_stats (0.1.5) sha256=cb9bb238c871d0d308e7f8316044be0a9bf68b194959a0c7a16adb97efa2b903
   ansi (1.6.0) sha256=ac9ea0c0ea8d32fb4e271348e609963ac78882f34b73836c2a02b3622e666658
   appraisal (2.5.0) sha256=36989221be127913b0dba8d114da2001e6b2dceea7bd4951200eaba764eed3ce
   appraisal-run (1.1.0) sha256=93179b8fe4d7a3469a703dab69deccc88432bfe43f979acdebbe514e21af9789
@@ -506,7 +509,9 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  minitest-memory (1.1.0) sha256=1251476a6e636a9b3bf4f02cd50a2edd6837db53afb81c5e78474e7144f1b747
   minitest-mock (5.27.0) sha256=7040ed7185417a966920987eaa6eaf1be4ea1fc5b25bb03ff4703f98564a55b0
+  minitest-strict (1.0.1) sha256=5bf179ed48c21013575cc00506be3fd6ceec8529636ce6897468f9574004ae06
   net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -20,7 +20,7 @@ class RenderingTest < ViewComponent::TestCase
     MyComponent.__vc_ensure_compiled
 
     with_instrumentation_enabled_option(false) do
-      assert_allocations({"4.1" => 69..160, "4.0" => 69..161, "3.4" => 75..76, "3.3" => 77..79, "3.2" => 80..82}) do
+      assert_versioned_allocations({"4.1" => 69..160, "4.0" => 69..161, "3.4" => 75..76, "3.3" => 77..79, "3.2" => 80..82}) do
         render_inline(MyComponent.new)
       end
     end
@@ -42,7 +42,7 @@ class RenderingTest < ViewComponent::TestCase
     render_inline(ProductComponent.with_collection(products, notice: notice))
 
     with_instrumentation_enabled_option(false) do
-      assert_allocations(**allocations) do
+      assert_versioned_allocations(allocations) do
         render_inline(ProductComponent.with_collection(products, notice: notice))
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-require "allocation_stats"
 require "rails/version"
 require "bundler/setup"
 require "pathname"
 require "minitest/autorun"
+require "minitest/memory"
 require "minitest/mock"
+
+Minitest::Test.include(Minitest::Memory)
 
 module Warning
   PROJECT_ROOT = File.expand_path("..", __dir__).freeze
@@ -186,10 +188,7 @@ def capture_warnings(&block)
   end
 end
 
-def assert_allocations(count_map, &block)
-  trace = AllocationStats.trace(&block)
-  total = trace.allocations.all.size
-  count = count_map[RUBY_VERSION.split(".").first(2).join(".")]
-
-  assert count === total, "Expected #{count} allocations, got #{total} allocations for Ruby #{RUBY_VERSION}"
+def assert_versioned_allocations(count_map, &block)
+  ruby_version = RUBY_VERSION.split(".").first(2).join(".")
+  assert_allocations(count: count_map.fetch(ruby_version), &block)
 end


### PR DESCRIPTION
Replace the custom `allocation_stats` integration with `minitest-memory` so allocation failures provide richer diagnostics and the test suite can use its broader memory assertions in the future.

The version-aware wrapper continues selecting allocation ranges by Ruby minor version, then delegates the global count assertion to `minitest-memory`. The existing render and collection allocation thresholds remain unchanged.

## Testing

- `bundle exec ruby -Itest test/sandbox/test/rendering_test.rb --name '/allocations/'`
- `bundle exec standardrb test/test_helper.rb test/sandbox/test/rendering_test.rb`