### PR TITLE
Stabilize allocation test thresholds

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Stabilize rendering allocation tests with explicit warmups and exact expectations by Rails and Ruby.
+
+    *Joel Hawksley*
+
 * Replace the custom memory allocation test helper with `minitest-memory`, preserving Ruby-version-specific allocation thresholds while improving failure diagnostics.
 
     *Joel Hawksley*

--- a/test/sandbox/test/rendering_allocations_test.rb
+++ b/test/sandbox/test/rendering_allocations_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RenderingAllocationsTest < ViewComponent::TestCase
+  INLINE_ALLOCATIONS = {
+    ["7.1", "3.2"] => 54,
+    ["7.2", "3.3"] => 49,
+    ["8.0", "3.4"] => 43,
+    ["8.1", "4.0"] => 41,
+    ["8.1", "4.1"] => 41,
+    ["8.2", "4.0"] => 128,
+    ["8.2", "4.1"] => 128
+  }.freeze
+
+  COLLECTION_ALLOCATIONS = {
+    ["7.1", "3.2"] => 101,
+    ["7.2", "3.3"] => 97,
+    ["8.0", "3.4"] => 89,
+    ["8.1", "4.0"] => 74,
+    ["8.1", "4.1"] => 74,
+    ["8.2", "4.0"] => 161,
+    ["8.2", "4.1"] => 161
+  }.freeze
+
+  def vc_test_controller_class
+    IntegrationExamplesController
+  end
+
+  def test_render_inline_allocations
+    # Stabilize compilation status ahead of testing allocations to simulate rendering
+    # performance with compiled component
+    ViewComponent::CompileCache.cache.delete(MyComponent)
+    MyComponent.__vc_ensure_compiled
+
+    # Ensure any one-time render allocations are done.
+    render_inline(MyComponent.new)
+
+    with_instrumentation_enabled_option(false) do
+      assert_versioned_allocations(INLINE_ALLOCATIONS) do
+        render_inline(MyComponent.new)
+      end
+    end
+
+    assert_selector("div", text: "hello,world!")
+  end
+
+  def test_render_collection_inline_allocations
+    # Stabilize compilation status ahead of testing allocations to simulate rendering
+    # performance with compiled component
+    ViewComponent::CompileCache.cache.delete(ProductComponent)
+    ProductComponent.__vc_ensure_compiled
+
+    products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
+    notice = "On sale"
+    # Ensure any one-time render allocations are done.
+    render_inline(ProductComponent.with_collection(products, notice: notice))
+
+    with_instrumentation_enabled_option(false) do
+      assert_versioned_allocations(COLLECTION_ALLOCATIONS) do
+        render_inline(ProductComponent.with_collection(products, notice: notice))
+      end
+    end
+
+    assert_selector("h1", text: "Product", count: 2)
+  end
+end

--- a/test/sandbox/test/rendering_allocations_test.rb
+++ b/test/sandbox/test/rendering_allocations_test.rb
@@ -4,27 +4,44 @@ require "test_helper"
 
 class RenderingAllocationsTest < ViewComponent::TestCase
   INLINE_ALLOCATIONS = {
-    ["7.1", "3.2"] => 54,
-    ["7.2", "3.3"] => 49,
-    ["8.0", "3.4"] => 43,
-    ["8.1", "4.0"] => 41,
-    ["8.1", "4.1"] => 41,
-    ["8.2", "4.0"] => 128,
-    ["8.2", "4.1"] => 128
+    ["7.1", "3.2"] => 47,
+    ["7.2", "3.3"] => 47,
+    ["8.0", "3.4"] => 41,
+    ["8.1", "4.0"] => 39,
+    ["8.1", "4.1"] => 39,
+    ["8.2", "4.0"] => 57,
+    ["8.2", "4.1"] => 57
   }.freeze
 
   COLLECTION_ALLOCATIONS = {
-    ["7.1", "3.2"] => 101,
-    ["7.2", "3.3"] => 97,
-    ["8.0", "3.4"] => 89,
-    ["8.1", "4.0"] => 74,
-    ["8.1", "4.1"] => 74,
-    ["8.2", "4.0"] => 161,
-    ["8.2", "4.1"] => 161
+    ["7.1", "3.2"] => 94,
+    ["7.2", "3.3"] => 95,
+    ["8.0", "3.4"] => 87,
+    ["8.1", "4.0"] => 72,
+    ["8.1", "4.1"] => 72,
+    ["8.2", "4.0"] => 90,
+    ["8.2", "4.1"] => 90
   }.freeze
 
+  class TestController < IntegrationExamplesController
+    def view_assigns
+      {}
+    end
+  end
+
   def vc_test_controller_class
-    IntegrationExamplesController
+    TestController
+  end
+
+  def without_debug_event_reporting
+    reporter = ActiveSupport.event_reporter if ActiveSupport.respond_to?(:event_reporter)
+    return yield unless reporter
+
+    debug_mode = reporter.debug_mode?
+    reporter.debug_mode = false
+    yield
+  ensure
+    reporter.debug_mode = debug_mode if reporter
   end
 
   def test_render_inline_allocations
@@ -36,9 +53,11 @@ class RenderingAllocationsTest < ViewComponent::TestCase
     # Ensure any one-time render allocations are done.
     render_inline(MyComponent.new)
 
-    with_instrumentation_enabled_option(false) do
-      assert_versioned_allocations(INLINE_ALLOCATIONS) do
-        render_inline(MyComponent.new)
+    without_debug_event_reporting do
+      with_instrumentation_enabled_option(false) do
+        assert_versioned_allocations(INLINE_ALLOCATIONS) do
+          render_inline(MyComponent.new)
+        end
       end
     end
 
@@ -56,9 +75,11 @@ class RenderingAllocationsTest < ViewComponent::TestCase
     # Ensure any one-time render allocations are done.
     render_inline(ProductComponent.with_collection(products, notice: notice))
 
-    with_instrumentation_enabled_option(false) do
-      assert_versioned_allocations(COLLECTION_ALLOCATIONS) do
-        render_inline(ProductComponent.with_collection(products, notice: notice))
+    without_debug_event_reporting do
+      with_instrumentation_enabled_option(false) do
+        assert_versioned_allocations(COLLECTION_ALLOCATIONS) do
+          render_inline(ProductComponent.with_collection(products, notice: notice))
+        end
       end
     end
 

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -3,26 +3,6 @@
 require "test_helper"
 
 class RenderingTest < ViewComponent::TestCase
-  INLINE_ALLOCATIONS = {
-    ["7.1", "3.2"] => 54,
-    ["7.2", "3.3"] => 49,
-    ["8.0", "3.4"] => 43,
-    ["8.1", "4.0"] => 41,
-    ["8.1", "4.1"] => 41,
-    ["8.2", "4.0"] => 128,
-    ["8.2", "4.1"] => 128
-  }.freeze
-
-  COLLECTION_ALLOCATIONS = {
-    ["7.1", "3.2"] => 101,
-    ["7.2", "3.3"] => 97,
-    ["8.0", "3.4"] => 89,
-    ["8.1", "4.0"] => 74,
-    ["8.1", "4.1"] => 74,
-    ["8.2", "4.0"] => 161,
-    ["8.2", "4.1"] => 161
-  }.freeze
-
   def vc_test_controller_class
     IntegrationExamplesController
   end
@@ -31,44 +11,6 @@ class RenderingTest < ViewComponent::TestCase
     render_inline(MyComponent.new)
 
     assert_selector("div", text: "hello,world!")
-  end
-
-  def test_render_inline_allocations
-    # Stabilize compilation status ahead of testing allocations to simulate rendering
-    # performance with compiled component
-    ViewComponent::CompileCache.cache.delete(MyComponent)
-    MyComponent.__vc_ensure_compiled
-
-    # Ensure any one-time render allocations are done.
-    render_inline(MyComponent.new)
-
-    with_instrumentation_enabled_option(false) do
-      assert_versioned_allocations(INLINE_ALLOCATIONS) do
-        render_inline(MyComponent.new)
-      end
-    end
-
-    assert_selector("div", text: "hello,world!")
-  end
-
-  def test_render_collection_inline_allocations
-    # Stabilize compilation status ahead of testing allocations to simulate rendering
-    # performance with compiled component
-    ViewComponent::CompileCache.cache.delete(ProductComponent)
-    ProductComponent.__vc_ensure_compiled
-
-    products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
-    notice = "On sale"
-    # Ensure any one-time render allocations are done.
-    render_inline(ProductComponent.with_collection(products, notice: notice))
-
-    with_instrumentation_enabled_option(false) do
-      assert_versioned_allocations(COLLECTION_ALLOCATIONS) do
-        render_inline(ProductComponent.with_collection(products, notice: notice))
-      end
-    end
-
-    assert_selector("h1", text: "Product", count: 2)
   end
 
   def test_initialize_super

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -3,6 +3,26 @@
 require "test_helper"
 
 class RenderingTest < ViewComponent::TestCase
+  INLINE_ALLOCATIONS = {
+    ["7.1", "3.2"] => 54,
+    ["7.2", "3.3"] => 49,
+    ["8.0", "3.4"] => 43,
+    ["8.1", "4.0"] => 41,
+    ["8.1", "4.1"] => 41,
+    ["8.2", "4.0"] => 128,
+    ["8.2", "4.1"] => 128
+  }.freeze
+
+  COLLECTION_ALLOCATIONS = {
+    ["7.1", "3.2"] => 101,
+    ["7.2", "3.3"] => 97,
+    ["8.0", "3.4"] => 89,
+    ["8.1", "4.0"] => 74,
+    ["8.1", "4.1"] => 74,
+    ["8.2", "4.0"] => 161,
+    ["8.2", "4.1"] => 161
+  }.freeze
+
   def vc_test_controller_class
     IntegrationExamplesController
   end
@@ -19,8 +39,11 @@ class RenderingTest < ViewComponent::TestCase
     ViewComponent::CompileCache.cache.delete(MyComponent)
     MyComponent.__vc_ensure_compiled
 
+    # Ensure any one-time render allocations are done.
+    render_inline(MyComponent.new)
+
     with_instrumentation_enabled_option(false) do
-      assert_versioned_allocations({"4.1" => 69..160, "4.0" => 69..161, "3.4" => 75..76, "3.3" => 77..79, "3.2" => 80..82}) do
+      assert_versioned_allocations(INLINE_ALLOCATIONS) do
         render_inline(MyComponent.new)
       end
     end
@@ -34,15 +57,13 @@ class RenderingTest < ViewComponent::TestCase
     ViewComponent::CompileCache.cache.delete(ProductComponent)
     ProductComponent.__vc_ensure_compiled
 
-    allocations = {"4.1" => 71..170, "4.0" => 71..170, "3.4" => 86..89, "3.3" => 92..97, "3.2" => 97..101}
-
     products = [Product.new(name: "Radio clock"), Product.new(name: "Mints")]
     notice = "On sale"
-    # Ensure any one-time allocations are done
+    # Ensure any one-time render allocations are done.
     render_inline(ProductComponent.with_collection(products, notice: notice))
 
     with_instrumentation_enabled_option(false) do
-      assert_versioned_allocations(allocations) do
+      assert_versioned_allocations(COLLECTION_ALLOCATIONS) do
         render_inline(ProductComponent.with_collection(products, notice: notice))
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -188,7 +188,8 @@ def capture_warnings(&block)
   end
 end
 
-def assert_versioned_allocations(count_map, &block)
+def assert_versioned_allocations(counts, &block)
+  rails_version = Rails.gem_version.segments.first(2).join(".")
   ruby_version = RUBY_VERSION.split(".").first(2).join(".")
-  assert_allocations(count: count_map.fetch(ruby_version), &block)
+  assert_allocations(count: counts.fetch([rails_version, ruby_version]), &block)
 end


### PR DESCRIPTION
The allocation tests used broad Ruby-only ranges that combined materially different Rails behavior, and the single-component test did not explicitly warm its render path before tracing.

This change warms both render paths before measuring and keys exact allocation counts by both Rails and Ruby versions. Repeated measurements across every supported appraisal produced stable counts, including Rails main and Ruby head.