### PR TITLE
Add support for Turbo-streaming ViewComponents via proxy object

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Add support for Turbo-streaming ViewComponents.
+
+    *Ben Sheldon*, *Joel Hawksley*
+
 * Reduce allocations and avoid redundant compiler work when rendering components and collections.
 
     *Joel Hawksley*

--- a/docs/guide/turbo_streams.md
+++ b/docs/guide/turbo_streams.md
@@ -1,0 +1,102 @@
+---
+layout: default
+title: Turbo Streams
+parent: How-to guide
+---
+
+# Turbo Streams
+
+ViewComponents can be used with [Turbo Streams](https://turbo.hotwired.dev/handbook/streams) to broadcast updates over WebSockets.
+
+## Rendering in controllers
+
+In a controller action, render a component inside a Turbo Stream response using `render_to_string` or `view_context.render`:
+
+```ruby
+class MessagesController < ApplicationController
+  def create
+    @message = Message.create!(message_params)
+
+    Turbo::StreamsChannel.broadcast_append_to(
+      "messages",
+      target: "messages",
+      html: render_to_string(MessageComponent.new(message: @message))
+    )
+  end
+end
+```
+
+## Broadcasting later with ActiveJob
+
+To broadcast asynchronously via ActiveJob (using `broadcast_action_later_to`), components must be serializable so they can be passed to the background job.
+
+Include `ViewComponent::Serializable` in the component and use `.render_later` instead of `.new` when broadcasting:
+
+```ruby
+class MessageComponent < ViewComponent::Base
+  include ViewComponent::Serializable
+
+  def initialize(message:)
+    @message = message
+  end
+end
+
+class Message < ApplicationRecord
+  after_create_commit :broadcast_append
+
+  private
+
+  def broadcast_append
+    Turbo::StreamsChannel.broadcast_action_later_to(
+      "messages",
+      action: :append,
+      target: "messages",
+      renderable: MessageComponent.render_later(message: self),
+      layout: false
+    )
+  end
+end
+```
+
+The component is serialized when the job is enqueued and deserialized when the job runs. The job renders the component via `ApplicationController.render` and broadcasts the resulting HTML over ActionCable.
+
+### Slots
+
+Slot calls made on the proxy are captured and replayed at render time. Slots that accept blocks aren't supported because blocks can't be serialized.
+
+```ruby
+class CardComponent < ViewComponent::Base
+  class BodyComponent < ViewComponent::Base
+    def initialize(text:)
+      @text = text
+    end
+  end
+
+  renders_many :bodies, BodyComponent
+end
+
+proxy = CardComponent.render_later(title: "Updates")
+proxy.with_body(text: "First item")
+proxy.with_body(text: "Second item")
+
+Turbo::StreamsChannel.broadcast_action_later_to(
+  "cards",
+  renderable: proxy,
+  action: :append,
+  target: "cards",
+  layout: false
+)
+```
+
+Passing a block to a slot call raises `ViewComponent::Serializable::UnserializableError` immediately.
+
+### How it works
+
+- `.render_later(*args, **kwargs)` returns a `ViewComponent::Serializable::Proxy` that stores the component class and initialization arguments without instantiating the component.
+- `ViewComponent::ActiveJobSerializer` handles converting the proxy to and from a JSON-safe format. It's automatically registered when ActiveJob is loaded.
+- ActiveRecord objects passed as arguments are serialized via GlobalID, just like any other ActiveJob argument.
+
+### Limitations
+
+- Blocks passed to `render_later`, `render_in`, or slot calls raise `ViewComponent::Serializable::UnserializableError`. Use component-based slots instead.
+- The component class must be named and loadable so it can be resolved via `safe_constantize` at deserialization time. `render_later` on an anonymous class raises `ViewComponent::Serializable::UnserializableError`.

--- a/lib/view_component.rb
+++ b/lib/view_component.rb
@@ -15,6 +15,7 @@ module ViewComponent
   autoload :InlineTemplate
   autoload :Instrumentation
   autoload :Preview
+  autoload :Serializable
   autoload :Translatable
 
   if defined?(Rails.env) && Rails.env.test?

--- a/lib/view_component/active_job_serializer.rb
+++ b/lib/view_component/active_job_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "active_job/serializers"
+
+module ViewComponent
+  class ActiveJobSerializer < ActiveJob::Serializers::ObjectSerializer
+    def klass
+      ViewComponent::Serializable::Proxy
+    end
+
+    def serialize?(argument)
+      argument.is_a?(ViewComponent::Serializable::Proxy)
+    end
+
+    def serialize(proxy)
+      super(proxy.serialize)
+    end
+
+    def deserialize(hash)
+      ViewComponent::Serializable::Proxy.deserialize(hash)
+    end
+  end
+end

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -77,6 +77,13 @@ module ViewComponent
       end
     end
 
+    initializer "view_component.serializable" do
+      ActiveSupport.on_load(:active_job) do
+        require "view_component/active_job_serializer"
+        ActiveJob::Serializers.add_serializers(ViewComponent::ActiveJobSerializer)
+      end
+    end
+
     initializer "view_component.eager_load_actions" do
       ActiveSupport.on_load(:after_initialize) do
         if Rails.application.config.eager_load

--- a/lib/view_component/serializable.rb
+++ b/lib/view_component/serializable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+require "view_component/serializable/proxy"
+
+module ViewComponent
+  module Serializable
+    extend ActiveSupport::Concern
+
+    class UnserializableError < ArgumentError; end
+
+    class_methods do
+      # Returns a Proxy that captures this class and its initialization arguments,
+      # deferring instantiation until render time. The proxy is renderable and
+      # serializable for ActiveJob (e.g. Turbo Streams). Slot calls made on the
+      # proxy are captured and replayed at render time. Blocks are not supported.
+      #
+      #   MyComponent.render_later("title", size: :large).with_item(label: "One")
+      def render_later(*args, &block)
+        raise UnserializableError, "Cannot serialize render_later with a block" if block
+
+        ViewComponent::Serializable::Proxy.new(self, *args)
+      end
+      ruby2_keywords :render_later
+    end
+  end
+end

--- a/lib/view_component/serializable/proxy.rb
+++ b/lib/view_component/serializable/proxy.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Serializable
+    # A proxy that wraps a component class and its initialization arguments, deferring
+    # component instantiation until render time. This allows slot calls and other
+    # post-initialize configuration to be captured and replayed, and enables the
+    # proxy itself (rather than a live component instance) to be serialized for
+    # background jobs (e.g. ActiveJob / Turbo Streams).
+    class Proxy
+      # Rebuilds a Proxy from a serialized hash produced by +serialize+
+      def self.deserialize(hash)
+        klass = hash["component_class"].safe_constantize
+        raise ArgumentError, "Cannot deserialize unknown component: #{hash["component_class"]}" unless klass
+
+        args = ActiveJob::Arguments.deserialize(hash["initialize_args"] || [])
+        proxy = new(klass, *args)
+
+        Array(hash["slot_calls"]).each do |call|
+          method_name = call["method"].to_sym
+          slot_args = ActiveJob::Arguments.deserialize(call["args"])
+          proxy.public_send(method_name, *slot_args)
+        end
+
+        proxy
+      end
+
+      attr_reader :component_class, :initialize_args, :slot_calls
+
+      def initialize(component_class, *args)
+        if component_class.name.nil?
+          raise UnserializableError, "Cannot serialize anonymous component class #{component_class.inspect}"
+        end
+
+        @component_class = component_class
+        @initialize_args = args
+        @slot_calls = []
+      end
+      ruby2_keywords :initialize
+
+      # Implements the Rails renderable interface
+      def render_in(view_context, &block)
+        if block
+          raise UnserializableError, "Cannot serialize render_in with a block"
+        end
+        build_component.render_in(view_context)
+      end
+
+      def method_missing(method_name, *args, &block)
+        if slot_method?(method_name)
+          capture_slot_call(method_name, args, &block)
+        else
+          super
+        end
+      end
+      ruby2_keywords :method_missing
+
+      def respond_to_missing?(method_name, include_private = false)
+        slot_method?(method_name) || super
+      end
+
+      # Returns a hash that can be rebuilt into a Proxy instance using +deserialize+
+      def serialize
+        serialized_slot_calls = @slot_calls.map do |call|
+          {
+            "method" => call[:method].to_s,
+            "args" => ActiveJob::Arguments.serialize(call[:args])
+          }
+        end
+
+        {
+          "component_class" => @component_class.name,
+          "initialize_args" => ActiveJob::Arguments.serialize(@initialize_args),
+          "slot_calls" => serialized_slot_calls
+        }
+      end
+
+      if defined?(Rails::VERSION) && Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR == 1
+        # Rails expects us to define `format` on all renderables,
+        # but we do not know the `format` of a ViewComponent until runtime.
+        def format
+          nil
+        end
+      end
+
+      private
+
+      def slot_method?(method_name)
+        method_name.to_s.start_with?("with_") && @component_class.method_defined?(method_name)
+      end
+
+      def capture_slot_call(method_name, args, &block)
+        if block
+          raise UnserializableError, "Cannot serialize slot call '#{method_name}' with a block"
+        end
+
+        @slot_calls << {method: method_name, args: args}
+        self
+      end
+
+      def build_component
+        @component_class.new(*@initialize_args).tap do |instance|
+          @slot_calls.each do |call|
+            instance.public_send(call[:method], *call[:args])
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/sandbox/app/components/serializable_component.rb
+++ b/test/sandbox/app/components/serializable_component.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class SerializableComponent < ViewComponent::Base
+  include ViewComponent::Serializable
+
+  class HeaderComponent < ViewComponent::Base
+    def initialize(text:)
+      @text = text
+    end
+
+    erb_template "<span class=\"header\"><%= @text %></span>"
+  end
+
+  class ItemComponent < ViewComponent::Base
+    def initialize(label, highlighted: false)
+      @label = label
+      @highlighted = highlighted
+    end
+
+    erb_template "<span class=\"item<%= ' highlighted' if @highlighted %>\"><%= @label %></span>"
+  end
+
+  renders_one :header, HeaderComponent
+  renders_many :items, ItemComponent
+
+  def initialize(title, count: 0)
+    @title = title
+    @count = count
+  end
+
+  erb_template <<~ERB
+    <div class="serializable-component">
+      <h1><%= @title %></h1>
+      <span><%= @count %></span>
+      <%= header %>
+      <% items.each do |item| %>
+        <div class="item"><%= item %></div>
+      <% end %>
+    </div>
+  ERB
+end

--- a/test/sandbox/test/serializable_test.rb
+++ b/test/sandbox/test/serializable_test.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SerializableProxyTest < ViewComponent::TestCase
+  def test_render_later_returns_proxy
+    proxy = SerializableComponent.render_later("Hello", count: 5)
+    assert_kind_of ViewComponent::Serializable::Proxy, proxy
+  end
+
+  def test_proxy_stores_component_class
+    proxy = SerializableComponent.render_later("Hello")
+    assert_equal SerializableComponent, proxy.component_class
+  end
+
+  def test_proxy_stores_initialize_args_positional_only
+    proxy = SerializableComponent.render_later("Hello")
+    assert_equal ["Hello"], proxy.initialize_args
+  end
+
+  def test_proxy_stores_initialize_args_mixed
+    proxy = SerializableComponent.render_later("Hello", count: 5)
+    assert_equal ["Hello", {count: 5}], proxy.initialize_args
+  end
+
+  def test_proxy_renders
+    proxy = SerializableComponent.render_later("Rendered", count: 3)
+    result = render_inline(proxy)
+    assert_includes result.to_html, "Rendered"
+    assert_includes result.to_html, "3"
+  end
+
+  def test_proxy_with_default_kwargs
+    proxy = SerializableComponent.render_later("Defaults Only")
+    result = render_inline(proxy)
+    assert_includes result.to_html, "Defaults Only"
+    assert_includes result.to_html, "0"
+  end
+
+  def test_proxy_with_positional_args_renders
+    proxy = SerializableComponent.render_later("Positional", count: 7)
+    result = render_inline(proxy)
+    assert_includes result.to_html, "Positional"
+    assert_includes result.to_html, "7"
+  end
+
+  def test_proxy_captures_slot_calls
+    proxy = SerializableComponent.render_later("Slots")
+    proxy.with_header(text: "My Header")
+    assert_equal 1, proxy.slot_calls.length
+    assert_equal :with_header, proxy.slot_calls.first[:method]
+  end
+
+  def test_proxy_slot_calls_are_replayed_at_render
+    proxy = SerializableComponent.render_later("Slotted")
+    proxy.with_header(text: "Header Content")
+    proxy.with_item("Item One")
+    proxy.with_item("Item Two")
+    result = render_inline(proxy)
+    assert_includes result.to_html, "Slotted"
+    assert_includes result.to_html, "Header Content"
+    assert_includes result.to_html, "Item One"
+    assert_includes result.to_html, "Item Two"
+  end
+
+  def test_proxy_slot_call_with_kwargs
+    proxy = SerializableComponent.render_later("Kwarg Slots")
+    proxy.with_item("Label", highlighted: true)
+    assert_equal ["Label", {highlighted: true}], proxy.slot_calls.first[:args]
+  end
+
+  def test_proxy_is_not_a_component_instance
+    proxy = SerializableComponent.render_later("Proxy")
+    refute_kind_of ViewComponent::Base, proxy
+  end
+
+  def test_proxy_only_captures_real_slot_methods
+    proxy = SerializableComponent.render_later("Real Slots")
+    refute_respond_to proxy, :with_indifferent_access
+    assert_raises(NoMethodError) { proxy.with_nonexistent_slot }
+    assert_empty proxy.slot_calls
+  end
+
+  def test_render_later_with_block_raises
+    error = assert_raises(ViewComponent::Serializable::UnserializableError) do
+      SerializableComponent.render_later("Blocky") { "content" }
+    end
+    assert_includes error.message, "block"
+  end
+
+  def test_render_later_on_anonymous_component_raises
+    anonymous_component = Class.new(ViewComponent::Base) do
+      include ViewComponent::Serializable
+    end
+
+    error = assert_raises(ViewComponent::Serializable::UnserializableError) do
+      anonymous_component.render_later
+    end
+    assert_includes error.message, "anonymous"
+  end
+
+  def test_render_in_with_block_raises
+    proxy = SerializableComponent.render_later("Block Render")
+    assert_raises(ViewComponent::Serializable::UnserializableError) do
+      render_inline(proxy) { "content" }
+    end
+  end
+
+  def test_block_slot_calls_raise_immediately
+    proxy = SerializableComponent.render_later("Blocks")
+    error = assert_raises(ViewComponent::Serializable::UnserializableError) do
+      proxy.with_header { "Header" }
+    end
+    assert_includes error.message, "with_header"
+    assert_includes error.message, "block"
+    assert_empty proxy.slot_calls
+  end
+
+  def test_unserializable_error_is_argument_error
+    assert ViewComponent::Serializable::UnserializableError < ArgumentError
+  end
+
+  def test_render_later_requires_include
+    assert_respond_to SerializableComponent, :render_later
+    refute_respond_to MyComponent, :render_later
+  end
+end
+
+class ActiveJobSerializerTest < ActiveSupport::TestCase
+  def setup
+    @serializer = ViewComponent::ActiveJobSerializer.instance
+  end
+
+  def test_serializes_proxy
+    proxy = SerializableComponent.render_later("Hi", count: 1)
+    assert @serializer.serialize?(proxy)
+  end
+
+  def test_does_not_serialize_plain_objects
+    refute @serializer.serialize?("not a proxy")
+    refute @serializer.serialize?(SerializableComponent.new("direct"))
+  end
+
+  def test_round_trip_positional_args
+    original = SerializableComponent.render_later("Round Trip", count: 42)
+    serialized = @serializer.serialize(original)
+    deserialized = @serializer.deserialize(serialized)
+
+    assert_kind_of ViewComponent::Serializable::Proxy, deserialized
+    assert_equal SerializableComponent, deserialized.component_class
+    assert_equal ["Round Trip", {count: 42}], deserialized.initialize_args
+  end
+
+  def test_round_trip_with_slot_kwargs
+    original = SerializableComponent.render_later("With Slots")
+    original.with_item("Label", highlighted: true)
+
+    serialized = @serializer.serialize(original)
+    deserialized = @serializer.deserialize(serialized)
+
+    assert_equal 1, deserialized.slot_calls.length
+    assert_equal :with_item, deserialized.slot_calls.first[:method]
+    assert_equal ["Label", {highlighted: true}], deserialized.slot_calls.first[:args]
+  end
+
+  def test_round_trip_with_slot_positional_args
+    original = SerializableComponent.render_later("Positional")
+    original.with_item("some string")
+
+    serialized = @serializer.serialize(original)
+    deserialized = @serializer.deserialize(serialized)
+
+    assert_equal 1, deserialized.slot_calls.length
+    assert_equal ["some string"], deserialized.slot_calls.first[:args]
+  end
+
+  def test_serialized_format_keys
+    proxy = SerializableComponent.render_later("Format", count: 9)
+    serialized = @serializer.serialize(proxy)
+
+    assert_equal "SerializableComponent", serialized["component_class"]
+    assert serialized.key?("initialize_args")
+    assert serialized.key?("slot_calls")
+    assert_equal [], serialized["slot_calls"]
+  end
+
+  def test_deserialize_unknown_component_raises
+    assert_raises(ArgumentError) do
+      @serializer.deserialize({"component_class" => "NonExistentComponent", "initialize_args" => [], "slot_calls" => []})
+    end
+  end
+end
+
+class RenderLaterTurboStreamTest < ActiveJob::TestCase
+  include Turbo::Broadcastable::TestHelper
+
+  def test_broadcast_action_later_with_render_later_proxy
+    proxy = SerializableComponent.render_later("Broadcast Test", count: 7)
+
+    assert_turbo_stream_broadcasts("render_later_test_stream") do
+      Turbo::StreamsChannel.broadcast_action_later_to(
+        "render_later_test_stream",
+        action: :replace,
+        target: "my-target",
+        renderable: proxy,
+        layout: false
+      )
+      perform_enqueued_jobs
+    end
+
+    broadcasts = capture_turbo_stream_broadcasts("render_later_test_stream")
+    assert_equal "replace", broadcasts.first["action"]
+    assert_equal "my-target", broadcasts.first["target"]
+    assert_includes broadcasts.first.to_html, "Broadcast Test"
+    assert_includes broadcasts.first.to_html, "7"
+  end
+end


### PR DESCRIPTION
Replaces #2645 as a freestanding PR. Alternative to #2595. Closes #1106.