### PR TITLE
Generate API docs for release PRs

### DIFF
--- a/script/release
+++ b/script/release
@@ -74,6 +74,7 @@ add_changed_files() {
   git add \
     docs/api.md \
     docs/CHANGELOG.md \
+    docs/_data/contributors.yml \
     docs/_data/library.yml \
     Gemfile.lock \
     gemfiles/*.gemfile.lock \
@@ -221,6 +222,7 @@ main() {
   update_ruby_version $major $minor $patch
   update_gemfiles $major $minor $patch
   echo "version: $major.$minor.$patch" > docs/_data/library.yml
+  build_docs
   add_changed_files $major $minor $patch
   commit $major $minor $patch
   push $major $minor $patch


### PR DESCRIPTION
### What are you trying to accomplish?

Keep `docs/api.md` current by regenerating it as part of every release PR.

### What approach did you choose and why?

Call the existing `build_docs` function before staging the release commit. Also stage `docs/_data/contributors.yml`, since `build_docs` refreshes contributor data through `script/sync_contributors.rb`.

### Anything you want to highlight for special attention from reviewers?

The release workflow already installs the bundle before invoking `script/release`, so the existing documentation task has the dependencies it needs.