### PR TITLE
Pin `ruby-version` in release workflows

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b
         with:
+          ruby-version: 4.0
           bundler-cache: true
 
       - name: Harden runner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b
         with:
+          ruby-version: 4.0
           bundler-cache: true
 
       - name: Configure git


### PR DESCRIPTION
The release workflow fails with:

> Error: Unknown version 4.1-dev for ruby on ubuntu-24.04

`ruby/setup-ruby` in `release.yml` and `publish-release.yml` doesn't specify a `ruby-version`, so it falls back to `.tool-versions`, which is pinned to `ruby 4.1-dev` — not a version available on the runner.

Rather than changing `.tool-versions`, pin `ruby-version: 4.0` directly in both workflows, matching the version used across `ci.yml`, `lint.yml`, and `push_gem.yml`.