### PR TITLE
Fix CI regressions from GHSA-8qw7-6phv-7q6p remediation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Freeze `ReusedInstanceError::MESSAGE` and update `test_renders_component_with_asset_url` to build a fresh `AssetComponent` per render, fixing CI regressions introduced by the GHSA-8qw7-6phv-7q6p remediation.
+
+    *Joel Hawksley*
+
 * [Security] Fix incomplete remediation for CVE-2026-54497 (GHSA-8qw7-6phv-7q6p): reused ViewComponent instances could still leak `with_content` and `renders_one`/`renders_many` slot content from an earlier render into a later render because slot state and content set via `with_content` are populated by the caller before `render_in` runs and were not cleared by the previous per-render reset. Reinstate the `ViewComponent::ReusedInstanceError` guard that raises when a component instance is rendered more than once. Rebuild collection child components per render and dup collection spacer components before each render so that legitimate re-rendering of `Collection`/spacer objects continues to work.
 
     *Yazan Balawneh, Cystack.ps*

--- a/lib/view_component/errors.rb
+++ b/lib/view_component/errors.rb
@@ -185,7 +185,7 @@ module ViewComponent
       "Reusing a component instance across renders can leak request-scoped state " \
       "(controller, helpers, request, view_flow, slot content, `with_content`) from an earlier render " \
       "into a later one, which has security and correctness implications (GHSA-8qw7-6phv-7q6p).\n\n" \
-      "To fix this issue, create a new component instance per render."
+      "To fix this issue, create a new component instance per render.".freeze
 
     def initialize(klass_name)
       super(MESSAGE.gsub("COMPONENT", klass_name.to_s))

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -341,17 +341,19 @@ class RenderingTest < ViewComponent::TestCase
   end
 
   def test_renders_component_with_asset_url
-    component = AssetComponent.new
-    assert_match(%r{http://assets\.example\.com/assets/application-\w+\.css}, render_inline(component).text)
+    assert_match(%r{http://assets\.example\.com/assets/application-\w+\.css}, render_inline(AssetComponent.new).text)
 
     if Rails.version.to_f < 8.0
       # Propshaft doesn't allow setting custom hosts so this only works in Rails < 8
+      component = AssetComponent.new
       component.config.asset_host = nil
       assert_match(%r{/assets/application-\w+\.css}, render_inline(component).text)
 
+      component = AssetComponent.new
       component.config.asset_host = "http://assets.example.com"
       assert_match(%r{http://assets\.example\.com/assets/application-\w+\.css}, render_inline(component).text)
 
+      component = AssetComponent.new
       component.config.asset_host = "assets.example.com"
       assert_match(%r{http://assets\.example\.com/assets/application-\w+\.css}, render_inline(component).text)
     end

--- a/test/sandbox/test/rendering_test.rb
+++ b/test/sandbox/test/rendering_test.rb
@@ -345,17 +345,19 @@ class RenderingTest < ViewComponent::TestCase
 
     if Rails.version.to_f < 8.0
       # Propshaft doesn't allow setting custom hosts so this only works in Rails < 8
-      component = AssetComponent.new
-      component.config.asset_host = nil
-      assert_match(%r{/assets/application-\w+\.css}, render_inline(component).text)
+      original_asset_host = ActionController::Base.asset_host
+      begin
+        ActionController::Base.asset_host = nil
+        assert_match(%r{/assets/application-\w+\.css}, render_inline(AssetComponent.new).text)
 
-      component = AssetComponent.new
-      component.config.asset_host = "http://assets.example.com"
-      assert_match(%r{http://assets\.example\.com/assets/application-\w+\.css}, render_inline(component).text)
+        ActionController::Base.asset_host = "http://assets.example.com"
+        assert_match(%r{http://assets\.example\.com/assets/application-\w+\.css}, render_inline(AssetComponent.new).text)
 
-      component = AssetComponent.new
-      component.config.asset_host = "assets.example.com"
-      assert_match(%r{http://assets\.example\.com/assets/application-\w+\.css}, render_inline(component).text)
+        ActionController::Base.asset_host = "assets.example.com"
+        assert_match(%r{http://assets\.example\.com/assets/application-\w+\.css}, render_inline(AssetComponent.new).text)
+      ensure
+        ActionController::Base.asset_host = original_asset_host
+      end
     end
   end
 


### PR DESCRIPTION
The GHSA-8qw7-6phv-7q6p fix (81f501d) landed on `main` and broke CI in two ways:

1. **`test (Rails 7.1/7.2)`** — `RenderingTest#test_renders_component_with_asset_url` renders the same `AssetComponent` instance up to four times. Under the new single-use invariant, the second render raises `ViewComponent::ReusedInstanceError`. Updated the test to build a fresh `AssetComponent.new` per render.

2. **`audition`** — `ReusedInstanceError::MESSAGE` was missing `.freeze`, tripping the Ractor-readiness `mutable-constants` check. Added `.freeze` to match the surrounding error constants.

Full local suite: 546 runs, 0 failures. `audition --static-only` reports no new errors.