### PR TITLE
Fix release script: deprecation horizon sed, CI PR creation, and push auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b

--- a/script/release
+++ b/script/release
@@ -49,7 +49,7 @@ update_ruby_version() {
   # Update deprecation horizon version
   major=$1
   sed -i \
-      -e "s/DEPRECATION_HORIZON = [0-9]*/DEPRECATION_HORIZON = $((major + 1))/g" \
+      -e "s/DEPRECATION_HORIZON = \"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"/DEPRECATION_HORIZON = \"$((major + 1)).0.0\"/g" \
       lib/view_component/deprecation.rb
 }
 
@@ -91,10 +91,10 @@ push() {
   # Open PR
   pr_url=$(gh pr create \
     --title "Release $1.$2.$3" \
+    --body "Automated release PR for version $1.$2.$3." \
     --base main \
     --head release-$1-$2-$3 \
-    --repo ViewComponent/view_component \
-    --web)
+    --repo ViewComponent/view_component)
 
   echo "####################################################"
   echo "PR opened: $pr_url"


### PR DESCRIPTION
Fixes three issues surfaced by the failed Release 4.13.0 workflow run.

## 1. `DEPRECATION_HORIZON` sed pattern produced invalid Ruby
`script/release`'s `update_ruby_version` had:

```sh
sed -e "s/DEPRECATION_HORIZON = [0-9]*/DEPRECATION_HORIZON = $((major + 1))/g" \
    lib/view_component/deprecation.rb
```

But `DEPRECATION_HORIZON` is a quoted string (`"5.0.0"`), not a bare number. `[0-9]*` matched zero digits before the opening `"`, so the replacement produced:

```ruby
DEPRECATION_HORIZON = 5"5.0.0"
```

…which crashed `rake docs:build` with `unexpected string literal, expecting end-of-input`.

Fixed by matching the full quoted `X.Y.Z` and replacing with `"<major+1>.0.0"`.

## 2. `gh pr create --web` fails on headless runners
The workflow log showed:

```
/usr/bin/xdg-open: 882: www-browser: not found
...
xdg-open: no method available for opening 'https://github.com/...'
exit status 3
```

`--web` tries to open a browser, which does not exist on `ubuntu-latest`. Removed `--web` and added an explicit `--body` so the PR is created via the API.

## 3. `git push` prompted for a username in CI
```
fatal: could not read Username for 'https://github.com': No such device or address
```

The release job's `actions/checkout` was configured with `persist-credentials: false`, so the `GITHUB_TOKEN` passed to checkout was not written into the git config for later steps. Set `persist-credentials: true` on the release job's checkout so the automated `git push` in `script/release` can authenticate.

## Verification
Simulated the sed fix locally against a copy of `lib/view_component/deprecation.rb`:

- `major=4` → `DEPRECATION_HORIZON = "5.0.0"` ✅
- `major=5` → `DEPRECATION_HORIZON = "6.0.0"` ✅
- `ruby -c` on the result: `Syntax OK`