### PR TITLE
Forward workflow args to main() in script/release

### DIFF
--- a/script/release
+++ b/script/release
@@ -229,4 +229,4 @@ main() {
   exit 0
 }
 
-main
+main "$@"


### PR DESCRIPTION
## Problem

Workflow run [32759347201](https://github.com/ViewComponent/view_component/actions/runs/32759347201/job/97534268267) was dispatched with `MAJOR=4 MINOR=14 PATCH=0`, but the script printed `Creating release for 4.13.0` and cut the wrong release.

## Root cause

`script/release` defines `main()` to accept positional args:

```sh
if [ $# -gt 0 ]; then
  major=$1
  minor=$2
  patch=$3
  ...
```

…but the bottom of the file just calls:

```sh
main
```

`"$@"` is not forwarded, so inside `main()` `$#` is always 0, the CI branch is skipped, and the script falls into the interactive path. On a headless runner `select` returns immediately and `major/minor/patch` retain the values read from `lib/view_component/version.rb` (`4.13.0`), which then gets released regardless of the workflow inputs.

## Fix

Forward `"$@"` to `main`.

## Verification

Reproduced locally: without `"$@"`, `main` sees `$# == 0` and version stays at 4.13.0. With `"$@"`, args `4 14 0 ""` are received and version becomes 4.14.0.