### PR TITLE
Fix release: bundler frozen mode and silent rake docs:build failure

### DIFF
--- a/script/release
+++ b/script/release
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# bundler-cache: true in setup-ruby enables frozen mode, which blocks
+# updating Gemfile.lock after the gemspec version bump. Disable it for
+# every bundler invocation in this script so the lockfile can be
+# regenerated to match the new version.
+export BUNDLE_FROZEN=false
+export BUNDLE_DEPLOYMENT=false
+
 fetch() {
   git fetch --all
 }
@@ -54,8 +61,10 @@ update_ruby_version() {
 }
 
 update_gemfiles() {
-  # Update Gemfile.lock
-  bundle
+  # Update Gemfile.lock. Use `bundle lock` (not `bundle install`) so we
+  # only rewrite the lockfile with the new version — no gem installs
+  # needed, and it avoids re-triggering the bundler-cache frozen check.
+  bundle lock
 
   # Update appraisal gemfile locks.
   # BUNDLE_IGNORE_RUBY_VERSION is needed because the gemfiles declare ruby
@@ -66,8 +75,8 @@ update_gemfiles() {
 }
 
 build_docs() {
-  ruby script/sync_contributors.rb
-  bundle exec rake docs:build
+  ruby script/sync_contributors.rb || { echo "Error: sync_contributors.rb failed"; exit 1; }
+  bundle exec rake docs:build || { echo "Error: rake docs:build failed"; exit 1; }
 }
 
 add_changed_files() {


### PR DESCRIPTION
Follow-up to #2694. The last release workflow run [32759987499](https://github.com/ViewComponent/view_component/actions/runs/32759987499/job/97536374050) reported success, but the resulting release PR ([#2695](https://github.com/ViewComponent/view_component/pull/2695)) has stale docs because `rake docs:build` silently failed:

```
bundler: failed to load command: rake
The gemspecs for path gems changed, but the lockfile can't be updated
because frozen mode is set (Bundler::ProductionError)
```

## Root cause

`ruby/setup-ruby` with `bundler-cache: true` enables Bundler's frozen mode. After `script/release` bumps the gemspec version, `bundle` (install) refuses to rewrite `Gemfile.lock`, leaving the lockfile pointing at the old version. `bundle exec rake docs:build` then aborts on the gemspec/lockfile mismatch. The script had no exit-code check on that step, so the release continued and pushed a PR with un-rebuilt docs.

## Fix

- `export BUNDLE_FROZEN=false` and `export BUNDLE_DEPLOYMENT=false` at the top of the script so every bundler invocation can rewrite the lockfile after the version bump.
- Switch `update_gemfiles` from `bundle` (install) to `bundle lock`, matching what the appraisal loop already does — gems are already installed by `setup-ruby`; we only need to refresh the lockfile.
- Fail hard if `script/sync_contributors.rb` or `rake docs:build` returns non-zero, so a broken release can never be pushed again.

I skipped `set -euo pipefail` because the existing script relies on pipelines that intentionally return non-zero (e.g. `grep "PRE = " ... | grep -o "\"[^\"]*\""` when `PRE = nil`); explicit checks on the failing step are safer than blanket strict mode here.