### PR TITLE
Make script/release push and PR creation idempotent on retry

### DIFF
--- a/script/release
+++ b/script/release
@@ -95,15 +95,25 @@ commit() {
 }
 
 push() {
-  git push origin release-$1-$2-$3
+  # Force-push: the release-X-Y-Z branch is auto-generated and is safe
+  # to overwrite. A previous failed run may have left the branch on the
+  # remote, which would otherwise reject a non-fast-forward push.
+  git push --force origin release-$1-$2-$3
 
-  # Open PR
-  pr_url=$(gh pr create \
-    --title "Release $1.$2.$3" \
-    --body "Automated release PR for version $1.$2.$3." \
-    --base main \
-    --head release-$1-$2-$3 \
-    --repo ViewComponent/view_component)
+  # Open PR (or reuse an existing one from a previous failed run).
+  pr_url=$(gh pr view "release-$1-$2-$3" \
+    --repo ViewComponent/view_component \
+    --json url --jq .url 2>/dev/null || true)
+  if [ -z "$pr_url" ]; then
+    pr_url=$(gh pr create \
+      --title "Release $1.$2.$3" \
+      --body "Automated release PR for version $1.$2.$3." \
+      --base main \
+      --head release-$1-$2-$3 \
+      --repo ViewComponent/view_component)
+  else
+    echo "Reusing existing PR: $pr_url"
+  fi
 
   echo "####################################################"
   echo "PR opened: $pr_url"


### PR DESCRIPTION
Follow-up to #2696. Retrying the release workflow after the previous broken run left the `release-4-14-0` branch on the remote, and the retry's `git push` was rejected:

```
! [rejected] release-4-14-0 -> release-4-14-0 (non-fast-forward)
error: failed to push some refs to 'https://github.com/ViewComponent/view_component'
```

Even after fixing the push, the next step (`gh pr create`) would fail because a PR for `release-4-14-0` (#2695) already exists.

## Fix

- **Force-push the release branch.** `release-X-Y-Z` is an auto-generated, throwaway branch. Overwriting a stale copy left behind by a previous failed run is the intended behavior for a retry.
- **Reuse an existing PR if one is already open** for the release branch, so a retried run can continue past the push step without hitting `gh: a pull request for branch already exists`.

## Cleanup

To retry the 4.14.0 release cleanly you'll still want to close stale PR #2695 (or let it auto-close when the branch is force-pushed and a new PR opens — GitHub keeps the same PR when the branch is updated, so #2695 will just get the new commits).