### PR TITLE
Update gemfile locks via sed instead of bundle lock

### DIFF
--- a/script/release
+++ b/script/release
@@ -61,16 +61,22 @@ update_ruby_version() {
 }
 
 update_gemfiles() {
-  # Update Gemfile.lock. Use `bundle lock` (not `bundle install`) so we
-  # only rewrite the lockfile with the new version — no gem installs
-  # needed, and it avoids re-triggering the bundler-cache frozen check.
-  bundle lock
+  major=$1
+  minor=$2
+  patch=$3
+  new_version="$major.$minor.$patch"
 
-  # Update appraisal gemfile locks.
-  # BUNDLE_IGNORE_RUBY_VERSION is needed because the gemfiles declare ruby
-  # versions that don't match the local Ruby (e.g. 3.2, 3.3, 4.1.0.dev).
-  for gemfile in gemfiles/*.gemfile; do
-    BUNDLE_GEMFILE="$gemfile" BUNDLE_IGNORE_RUBY_VERSION=1 bundle lock
+  # The only lockfile change during a release is the view_component
+  # version pinned by the path gemspec. Update it in place across every
+  # lockfile. Running `bundle lock` from a mismatched Ruby (e.g. ruby-head
+  # appraisals from Ruby 4.0) produces lockfiles CI cannot consume in
+  # frozen mode, so we edit them directly instead.
+  for lockfile in Gemfile.lock gemfiles/*.gemfile.lock; do
+    [ -f "$lockfile" ] || continue
+    sed -i \
+      -e "s/^\(    view_component \)([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*)/\1($new_version)/" \
+      -e "s/^\(  view_component \)([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*)/\1($new_version)/" \
+      "$lockfile"
   done
 }
 


### PR DESCRIPTION
Follow-up. On the 4.14.0 release PR, CI failed on the `rails_main_head` appraisal with:

```
Cannot write a changed lockfile while frozen.
...
The running version of Bundler (4.0.16) does not match the version of
the specification installed for it (4.1.0.dev).
```

## Root cause

`script/release`'s `update_gemfiles` ran `bundle lock` against every appraisal — including `rails_main_head` (ruby-head) and `rails_main` (future Ruby) — from the release job's Ruby 4.0. Even with `BUNDLE_IGNORE_RUBY_VERSION=1`, the resulting `rails_main_head.gemfile.lock` is not consistent with what ruby-head's Bundler produces, so CI on ruby-head wants to rewrite it and fails in frozen mode.

## Fix

The only lockfile change during a release is the `view_component` version stamped by the path gemspec (e.g. `4.13.0` → `4.14.0`). Replace the `bundle lock` loop with a targeted `sed` that rewrites that version in every `Gemfile.lock` / `gemfiles/*.gemfile.lock`:

- Robust across mismatched Ruby versions — we no longer need any Ruby installed to update the appraisals.
- No Bundler frozen-mode conflicts.
- Precisely matches release intent (only the version pin changes).

## Verification

Ran the new sed locally against the current lockfiles:

- `Gemfile.lock`: PATH section (line 4) and DEPENDENCIES pin (line 647) both rewritten from `4.13.0` → `4.14.0`.
- `gemfiles/rails_main_head.gemfile.lock`: same, at lines 113 and 588.
- Both anchored patterns (`^    view_component ` and `^  view_component `) match only the intended lines — no false hits on lines like `  view_component!` or unrelated gems.