### PR TITLE
Fix publish-release trigger and push auth

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,14 +17,21 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    # Only run if this is a release commit (created by script/release)
-    if: startsWith(github.event.head_commit.message, 'release ')
+    # Only run if this is a release commit created by script/release.
+    # Match either the direct commit message from script/release
+    # ("release X.Y.Z") or the merge-commit body containing the release
+    # PR title ("Release X.Y.Z"), so a normal PR merge still triggers.
+    # Also always run on manual workflow_dispatch.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'release ') ||
+      contains(github.event.head_commit.message, 'Release ')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b


### PR DESCRIPTION
Follow-up. After #2697 (Release 4.14.0) merged to main, `.github/workflows/publish-release.yml` did not run, so 4.14.0 was never tagged, gh-pages was not updated, and no GitHub Release was created.

## Root cause

The workflow gate was:

```yaml
if: startsWith(github.event.head_commit.message, 'release ')
```

But the merge commit created by GitHub's PR merge is:

```
Merge pull request #2697 from ViewComponent/release-4-14-0

Release 4.14.0
```

That starts with `Merge pull request…` (and the PR title's `Release` is capitalized), so the gate never matched. It would only match if someone pushed a raw `release X.Y.Z` commit directly to main — which is not how the release flow works today.

Additionally, the checkout used `persist-credentials: false`, so `script/publish`'s `git push origin $tag` and `git push origin gh-pages --force` would fail to authenticate — same class of bug as the release workflow.

## Fix

- Broaden the gate to also match the merge-commit body containing `Release `, so a normal PR merge triggers publish.
- Add `workflow_dispatch:` so publish can be re-triggered manually when a release lands but was missed (needed right now to publish 4.14.0).
- Set `persist-credentials: true` so tag and gh-pages pushes authenticate.

## Recovery for 4.14.0

Once this merges, go to Actions → **Publish Release** → **Run workflow** on `main` to tag `v4.14.0`, push gh-pages, and create the GitHub Release. `script/publish` is already idempotent for the tag creation (`git rev-parse --quiet --verify` check + `|| true` on the tag push), so a re-run is safe.