### PR TITLE
Skip GITHUB_TOKEN-incompatible push-perm probe in script/publish under Actions

### DIFF
--- a/script/publish
+++ b/script/publish
@@ -15,6 +15,17 @@ check_github_permissions() {
     exit 1
   fi
 
+  # Skip the push-permission probe when running in GitHub Actions.
+  # GET /repos/:owner/:repo only returns `.permissions` for user/OAuth
+  # tokens — for the workflow's GITHUB_TOKEN the field is absent, so
+  # the probe would incorrectly report no push access even when the
+  # workflow has `contents: write`. In CI we rely on the job's declared
+  # permissions; failures will surface from the actual git push / gh
+  # release create calls below with clear messages.
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    return 0
+  fi
+
   # Check if user can create releases (requires write access)
   # Attempt a dry-run by checking repo permissions
   local perms=$(gh api repos/ViewComponent/view_component -q '.permissions.push // false')


### PR DESCRIPTION
Follow-up. After #2700 landed and Publish Release was re-triggered manually, `script/publish` still aborted:

```
Error: insufficient permissions to create releases in ViewComponent/view_component
You need at least 'push' (write) access to the repository
Error: Process completed with exit code 1.
```

## Root cause

`check_github_permissions` probes push access with:

```sh
gh api repos/ViewComponent/view_component -q '.permissions.push // false'
```

But `GET /repos/:owner/:repo` only includes the `.permissions` object when queried by a user/OAuth token. For the workflow's `GITHUB_TOKEN`, the field is absent, so `.permissions.push // false` resolves to `"false"` and the script bails — even though the `publish-release` job declares `contents: write` and can actually push and create releases.

## Fix

Skip the probe when running in GitHub Actions (`$GITHUB_ACTIONS`). In CI we already rely on the job's declared permissions; any real permission problem will surface with a clear message from the subsequent `git push origin $tag`, `git push origin gh-pages --force`, or `gh release create` calls. Local runs still get the probe.

## Recovery

Once this merges, re-run **Publish Release** (workflow_dispatch on `main`) to publish 4.14.0. `script/publish` is idempotent for the tag creation, so a partial prior run doesn't block a retry.