### PR TITLE
Trigger push_gem from script/publish and allow manual dispatch

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to push to RubyGems (e.g. v4.14.0)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -29,6 +35,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/script/publish
+++ b/script/publish
@@ -71,3 +71,13 @@ gh release create "$tag" \
   --title "$version" \
   --notes "$changelog" \
   --repo ViewComponent/view_component
+
+# Kick off the Push Gem workflow explicitly. GitHub Actions does not
+# trigger downstream workflows for events driven by GITHUB_TOKEN — so
+# the tag push above will not fire push_gem.yml on its own when this
+# script runs inside the publish-release workflow. Dispatch it here so
+# 'script/publish' always results in a gem being pushed to RubyGems.
+gh workflow run push_gem.yml \
+  --repo ViewComponent/view_component \
+  --ref main \
+  --field tag="$tag" || true


### PR DESCRIPTION
Diagnosis of the "push_gem published v4.13.0, not v4.14.0" confusion:

- The push_gem run for v4.13.0 was queued back on 2026-08-20 waiting on the `release` environment approval; it finally completed today (99h50m). That's the run you saw.
- The v4.14.0 tag we pushed today did **not** trigger push_gem at all. RubyGems has no v4.14.0.

## Root cause

GitHub Actions does not trigger downstream workflows for events driven by `GITHUB_TOKEN`. `script/publish` now runs inside the `publish-release` job, which uses `GITHUB_TOKEN` for its checkout, so `git push origin v4.14.0` from that job does not fire the `push: tags: v*` event on `push_gem.yml`. Previous releases were tagged by a maintainer running `script/publish` locally with a PAT — that's why `push_gem` always fired historically.

## Fix

Two changes:

1. **Add `workflow_dispatch` to `push_gem.yml`** with a required `tag` input, and check that tag out (`ref: inputs.tag`). Lets a maintainer manually push the gem for a specific tag — needed right now to publish v4.14.0 to RubyGems.
2. **Dispatch `push_gem.yml` from `script/publish`** after `gh release create`, passing the freshly created tag. `|| true` so any dispatch failure never masks a successful release. Future releases will push the gem automatically even when `script/publish` runs from Actions.

## Recovery for v4.14.0

Once this merges: Actions → **Push Gem** → **Run workflow** → tag: `v4.14.0`. That will check out the v4.14.0 tag and push the gem to RubyGems via Trusted Publishing (still gated on the `release` environment approval).