### PR TITLE
Dispatch push_gem against the tag ref, not main

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -5,11 +5,6 @@ on:
     tags:
       - v*
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to push to RubyGems (e.g. v4.14.0)'
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -35,7 +30,6 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/script/publish
+++ b/script/publish
@@ -77,7 +77,9 @@ gh release create "$tag" \
 # the tag push above will not fire push_gem.yml on its own when this
 # script runs inside the publish-release workflow. Dispatch it here so
 # 'script/publish' always results in a gem being pushed to RubyGems.
+#
+# Dispatch against the tag ref (not main) because the 'release'
+# environment restricts deployments to v* tags.
 gh workflow run push_gem.yml \
   --repo ViewComponent/view_component \
-  --ref main \
-  --field tag="$tag" || true
+  --ref "$tag" || true


### PR DESCRIPTION
Follow-up to #2702. The `workflow_dispatch --ref main` I added was rejected by the `release` environment:

> Branch "main" is not allowed to deploy to release due to environment protection rules.
> The deployment was rejected or didn't satisfy other protection rules.

## Root cause

The `release` environment restricts deployments to `v*` tag refs. Dispatching from `main` was never going to satisfy that rule.

## Fix

Dispatch `push_gem.yml` with `--ref "$tag"` instead of `--ref main`. That way the deployment runs against the tag itself, which the environment allows. As a nice consequence, `github.ref` in `push_gem.yml` now already points at the tag, so the `tag` input and `ref` override are no longer needed — dropped both to simplify the workflow.

## Caveat for v4.14.0 recovery

`workflow_dispatch` requires the trigger to exist on the target ref. The v4.14.0 tag was created **before** we added `workflow_dispatch` to `push_gem.yml`, so it does not carry the trigger. Once this PR is merged you have two options to ship the gem for 4.14.0:

**Option A — retag v4.14.0 at current main (recommended):**

```sh
git checkout main && git pull
git tag -f v4.14.0
git push origin v4.14.0 --force
```

The tag push will fire `push_gem.yml` naturally via the existing `push: tags: v*` trigger — no dispatch needed. (This also correctly points the tag at HEAD once the release fixes are in.)

**Option B — temporary env change:** Repo Settings → Environments → `release` → add `main` to allowed deployment branches, dispatch `Push Gem` manually with `--ref main`, then revert the env change. Riskier; Option A is cleaner.

Future releases don't hit this issue because the `workflow_dispatch` trigger will always be present on any newly cut tag.