### PR TITLE
Fix DEPRECATION_HORIZON sed pattern in script/release

### DIFF
--- a/script/release
+++ b/script/release
@@ -47,10 +47,13 @@ update_ruby_version() {
       -e "s/PATCH = [0-9]+/PATCH = $3/g" \
       lib/view_component/version.rb
 
-  # Update deprecation horizon version
+  # Update deprecation horizon version. deprecation.rb stores the value
+  # as a quoted string (e.g. "4.0.0"), so match/replace the full quoted
+  # X.Y.Z — the previous [0-9]+ pattern matched no digits before the
+  # opening quote and silently no-oped on every release.
   major=$1
   sed -E -i '' \
-      -e "s/DEPRECATION_HORIZON = [0-9]+/DEPRECATION_HORIZON = $((major + 1))/g" \
+      -e "s/DEPRECATION_HORIZON = \"[0-9]+\.[0-9]+\.[0-9]+\"/DEPRECATION_HORIZON = \"$((major + 1)).0.0\"/g" \
       lib/view_component/deprecation.rb
 }
 


### PR DESCRIPTION
Backport of the DEPRECATION_HORIZON sed fix from main (companion to #2691 on main).

## Root cause

`lib/view_component/deprecation.rb` stores the value as a quoted string:

```ruby
DEPRECATION_HORIZON = "4.0.0"
```

But `script/release`'s sed was:

```sh
sed -E -i '' -e "s/DEPRECATION_HORIZON = [0-9]+/DEPRECATION_HORIZON = \$((major + 1))/g"
```

`[0-9]+` requires ≥1 digit immediately after `= `, but the next character is the opening quote. So the substitution matched nothing and silently no-oped on every 3.x release — the horizon has never actually been bumped by the script.

## Fix

Match the full quoted `X.Y.Z` and replace with `"<major+1>.0.0"`, mirroring the fix I made on main.

## Applicability of other main-branch release fixes

For reference, most of the recent main-branch release fixes do not apply to 3.x:
- 3.x has no `release.yml`, `publish-release.yml`, or `push_gem.yml` workflows — releases are done locally.
- `script/release` on 3.x is interactive-only (no CI-args branch) and doesn't call `build_docs`.
- `script/publish` on 3.x is just `bundle exec rake release` + gh-pages push — no `gh release create`, no `check_github_permissions`.

Only this sed bug is relevant. Verified locally on macOS with BSD sed: starting value `"5.0.0"` + major=3 → `"4.0.0"`; `ruby -c` reports `Syntax OK`.