### PR TITLE
Grant actions: write to publish job so push_gem dispatch works

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      actions: write
     # Only run if this is a release commit created by script/release.
     # Match either the direct commit message from script/release
     # ("release X.Y.Z") or the merge-commit body containing the release


### PR DESCRIPTION
The `publish` job in `publish-release.yml` runs `gh workflow run push_gem.yml --ref "$tag"` at the end of `script/publish` to kick off the gem push. That dispatch was failing with:

```
HTTP 403: Resource not accessible by integration
```

because the job's `GITHUB_TOKEN` didn't have `actions: write`. The failure was swallowed by `|| true`, so publish-release ran green while the gem never got pushed to RubyGems — which is why `v4.15.0` shipped a GitHub release but no gem, and `push_gem.yml` had to be dispatched manually (and even then failed until dispatched with `--ref v4.15.0`).

Adding `actions: write` to the job's permissions lets the dispatch succeed on the next release.