### PR TITLE
Expire memoized template digests when a component registers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ nav_order: 6
 
 ## main
 
+* Invalidate Action View's memoized template digests when a component registers with `ViewComponent::CacheDigest`, so a digest computed before the component loaded isn't served for the rest of the process.
+
+    *Erik Axel Nielsen*
+
 ## 4.15.0
 
 * Add experimental caching support, opt-in per component via `include ViewComponent::ExperimentallyCacheable`.

--- a/lib/view_component/cache_digest.rb
+++ b/lib/view_component/cache_digest.rb
@@ -75,8 +75,16 @@ module ViewComponent
       # @private
       def register(component)
         return unless component.virtual_path && component.name
+        return if registry[component.virtual_path] == component.name
 
         registry[component.virtual_path] = component.name
+
+        # Components register as they load, and under lazy loading that happens
+        # after Action View has already digested and memoized some templates.
+        # Those digests were computed without this component's dependencies and
+        # would otherwise be served for the rest of the process, making the
+        # digest a function of load order rather than of source.
+        expire_digests
       end
 
       # The synthetic virtual path a component is digested under.
@@ -222,6 +230,13 @@ module ViewComponent
       end
 
       private
+
+      # Drop Action View's memoized template digests, leaving its resolver
+      # caches alone: no template changed, only the set of dependencies the
+      # Digestor can see.
+      def expire_digests
+        ActionView::LookupContext::DetailsKey.digest_caches.each(&:clear)
+      end
 
       # Resolve a constant name to a component that opted into caching.
       #

--- a/test/sandbox/test/experimentally_cacheable_integration_test.rb
+++ b/test/sandbox/test/experimentally_cacheable_integration_test.rb
@@ -75,6 +75,28 @@ class ExperimentallyCacheableIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # Components register as they're autoloaded, so under lazy loading a template
+  # can be digested before the components it renders have loaded. Action View
+  # memoizes digests for the life of the process, so that first digest sticks:
+  # without invalidation the same source digests differently depending on the
+  # order things happened to load in.
+  def test_digest_does_not_depend_on_when_the_component_registered
+    registered_first = with_registry("cacheable_component" => "CacheableComponent") do
+      clear_digest_cache
+      fragment_digest_for("integration_examples/cached_component")
+    end
+
+    registered_late = with_registry({}) do
+      clear_digest_cache
+      fragment_digest_for("integration_examples/cached_component")
+      ViewComponent::CacheDigest.register(CacheableComponent)
+
+      fragment_digest_for("integration_examples/cached_component")
+    end
+
+    assert_equal registered_first, registered_late
+  end
+
   def test_component_output_is_cached_between_requests
     get "/cached_component"
     assert_select(".cacheable", text: "cached")
@@ -96,6 +118,15 @@ class ExperimentallyCacheableIntegrationTest < ActionDispatch::IntegrationTest
       format: :html,
       finder: ActionView::LookupContext.new(ActionController::Base.view_paths)
     )
+  end
+
+  def with_registry(entries)
+    saved = ViewComponent::CacheDigest.registry.dup
+    ViewComponent::CacheDigest.registry.replace(entries)
+    yield
+  ensure
+    ViewComponent::CacheDigest.registry.replace(saved)
+    clear_digest_cache
   end
 
   def view_context

--- a/test/sandbox/test/experimentally_cacheable_test.rb
+++ b/test/sandbox/test/experimentally_cacheable_test.rb
@@ -20,6 +20,32 @@ class ExperimentallyCacheableTest < ViewComponent::TestCase
     )
   end
 
+  # Registration runs on every class load, so an unchanged component must not
+  # throw away digests other templates are still using.
+  def test_registering_an_unchanged_component_leaves_memoized_digests_alone
+    clear_digest_cache
+    CacheableComponent.cache_digest
+    memoized = digest_cache_size
+
+    assert_operator memoized, :>, 0
+
+    ViewComponent::CacheDigest.register(CacheableComponent)
+
+    assert_equal memoized, digest_cache_size
+  end
+
+  def test_registering_a_new_component_expires_memoized_digests
+    clear_digest_cache
+    CacheableComponent.cache_digest
+
+    assert_operator digest_cache_size, :>, 0
+
+    ViewComponent::CacheDigest.registry.delete("cacheable_component")
+    ViewComponent::CacheDigest.register(CacheableComponent)
+
+    assert_equal 0, digest_cache_size
+  end
+
   def test_component_is_marked_cacheable
     assert_predicate CacheableComponent, :__vc_cacheable?
     refute_respond_to ErbComponent, :__vc_cacheable?
@@ -485,6 +511,11 @@ class ExperimentallyCacheableTest < ViewComponent::TestCase
   def recompile(component)
     ViewComponent::CompileCache.cache.delete(component)
     component.__vc_compile(force: true)
+  end
+
+  # Every digest Action View has memoized, across all details keys.
+  def digest_cache_size
+    ActionView::LookupContext::DetailsKey.digest_caches.sum(&:size)
   end
 
   def build_template(source)


### PR DESCRIPTION
## Problem

`ViewComponent::CacheDigest.enabled?` is `!registry.empty?`, and `dependencies_in` returns `[]` while it's false. The registry only fills as components are *autoloaded*. Under lazy loading — development, and any test environment without `eager_load` — a digest computed before the first component loads silently omits every component dependency, and `ActionView::Digestor` memoizes it in `DetailsKey.digest_cache`, so the wrong value sticks for the life of the process.

The digest is therefore not a pure function of the source: same files, same code, different answer depending on load order.

### Reproduction

An `app/views` partial with a `cache` block around `render SomeComponent.new`, where `SomeComponent` includes `ExperimentallyCacheable`:

```ruby
finder = -> { ActionView::LookupContext.new(ActionController::Base.view_paths) }
digest = ->(p) { ActionView::Digestor.digest(name: p, format: :html, finder: finder.call) }

digest.call("vc_cache_probe/_host")
# => "5d2c78aeba543f6517a00d9f27a4d790"   registry empty

SomeComponent                                 # referencing it registers the component
ActionView::LookupContext::DetailsKey.clear
digest.call("vc_cache_probe/_host")
# => "0190488ed202a6ee3b0a6227a1b6f9cc"   registry size 1
```

No files changed between those two calls.

### Impact

Production is mostly safe, because `eager_load = true` loads every component at boot. Development and test are not: the same fragment cache block can key differently between two boots, and a fragment digested early in a process silently loses its component dependencies. It also makes the feature confusing to evaluate — this is what made our first attempt to verify the advertised behaviour look like the feature simply did not work.

The sandbox suite doesn't catch it because `test/sandbox/config/environments/test.rb` sets `config.eager_load = true`.

## Fix

`CacheDigest.register` now expires Action View's memoized digests when it adds a **new** entry, so a digest computed before a component registered is recomputed rather than served from memory. Re-registering an unchanged component returns early, so reloads and repeated registrations don't churn.

The reset is deliberately narrow: `DetailsKey.digest_caches.each(&:clear)` drops memoized digests only and leaves resolver caches alone, since no template changed — only the set of dependencies the Digestor can see. `DetailsKey.digest_caches` is public API in every supported Action View (7.1 through `main`). `DetailsKey.clear` also works but throws away resolver caches for no reason.

Registration only happens on class load, so the churn is bounded and stops once everything has loaded.

### Alternative considered

Eagerly registering every component at boot instead. That is harder to do correctly under lazy loading, since it means discovering components independently of the autoloader, which is why invalidating on register looks like the better trade.

## Tests

- `test_digest_does_not_depend_on_when_the_component_registered` (integration) — a fragment digest is identical whether the component registered before or after the template was first digested. Fails on `main`.
- `test_registering_an_unchanged_component_leaves_memoized_digests_alone` and `test_registering_a_new_component_expires_memoized_digests` (unit) — cover both branches of the new guard.

`bundle exec rake` passes on Rails 7.1, 7.2, 8.0 and 8.1. The only failures seen were pre-existing and unrelated: allocation-count assertions in `RenderingAllocationsTest` on 8.0, and the Ruby/Rails version-matrix fixture on 7.1 when run under a Ruby other than the pinned one.
